### PR TITLE
Handling member LiveDataTip of casted object

### DIFF
--- a/External/Plugins/FlashDebugger/Controls/LiveDataTip.cs
+++ b/External/Plugins/FlashDebugger/Controls/LiveDataTip.cs
@@ -106,12 +106,21 @@ namespace FlashDebugger
 
 		private String GetWordAtPosition(ScintillaControl sci, Int32 position)
 		{
+			int insideBrackets = 0;
 			Char c;
 			System.Text.StringBuilder sb = new System.Text.StringBuilder();
 			for (Int32 startPosition = position - 1; startPosition >= 0; startPosition--)
 			{
 				c = (Char)sci.CharAt(startPosition);
-				if (!(Char.IsLetterOrDigit(c) || c == '_' || c == '$' || c == '.'))
+				if (c == ')')
+				{
+					insideBrackets++;
+				}
+				else if (c == '(' && insideBrackets > 0)
+				{
+					insideBrackets--;
+				}
+				else if (!(Char.IsLetterOrDigit(c) || c == '_' || c == '$' || c == '.') && insideBrackets == 0)
 				{
 					break;
 				}


### PR DESCRIPTION
Modified GetWordAtPosition function in LiveDataTip to be able to handle (obj as MyClass).value when hovering with mouse over value member of obj object.

I started working on project that is big and alot of times there is casting like (obj as ClassName).stringValue and I have to put mouse on obj and navigate over alot of class members just to see value of stringValue. So I decided to fix this... :)

I'm not 100% if I covered all cases or if I implemented some bugs. So can someone please think abit if this is OK solution.

Previous code was not handling brackets so it would pass to java debugger ".stringValue" but now its sending (obj as ClassName).stringValue and everything works cool. I tested abit with calling method which ofcourse does not work. Any other corner cases suggestions are very welcome I can test myself...

If someone want to test code below put breakpoint in traceObject function and hover over testString.
Thank you,
David

I'm also pasting sample program that I used to test few cases...

``` as3
package 
{
    import flash.display.Sprite;    
    public class Main extends Sprite 
    {

        public function Main():void 
        {
            var test1:TestClass = new TestClass();
            test1.testString = "Should!!!NOT!!!BeSeen";
            var test2:TestClass = new TestClass();
            test2.testString = "ShouldBeSeen";
            test1.traceObject(test2);
        }
    }   
}
```

``` as3
package  
{
    public class TestClass 
    {       
        public var testString:String;

        public function traceObject(obj:Object)
        {
            trace((obj as TestClass).testString);
            trace(TestClass(obj).testString);
            trace((obj).testString);
            trace(obj.testString);
            trace((createTestClass() as TestClass).testString);
            trace(createTestClass().testString);
        }

        private function createTestClass():TestClass {
            var testObj:TestClass = new TestClass();
            testObj.testString = "newTestClass";
            return testObj;
        }
    }
}
```
