### PR TITLE
Calling Context.GetFileModel instead of FileModel constructor

### DIFF
--- a/External/Plugins/AS3Context/Context.cs
+++ b/External/Plugins/AS3Context/Context.cs
@@ -486,11 +486,11 @@ namespace AS3Context
         }
 
         /// <summary>
-        /// Create a new file model using the default file parser
+        /// Create a new file model without parsing file
         /// </summary>
-        /// <param name="filename">Full path</param>
+        /// <param name="fileName">Full path</param>
         /// <returns>File model</returns>
-        public override FileModel GetFileModel(string fileName)
+        public override FileModel CreateFileModel(string fileName)
         {
             if (fileName == null || fileName.Length == 0 || !File.Exists(fileName))
                 return new FileModel(fileName);
@@ -501,10 +501,9 @@ namespace AS3Context
                 FileModel nFile = new FileModel(fileName);
                 nFile.Context = this;
                 nFile.HasFiltering = true;
-                ASFileParser.ParseFile(nFile);
                 return nFile;
             }
-            else return base.GetFileModel(fileName);
+            else return base.CreateFileModel(fileName);
         }
 
         private void GuessPackage(string fileName, FileModel nFile)

--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -1678,7 +1678,7 @@ namespace ASCompletion.Completion
             ClassModel aType = ASContext.Context.ResolveType(interf, ASContext.Context.CurrentModel);
             if (aType.IsVoid()) return;
 
-            FileModel fileModel = ASFileParser.ParseFile(aType.InFile.FileName, ASContext.Context);
+            FileModel fileModel = ASFileParser.ParseFile(ASContext.Context.CreateFileModel(aType.InFile.FileName));
             foreach (ClassModel cm in fileModel.Classes)
             {
                 if (cm.QualifiedName.Equals(aType.QualifiedName))

--- a/External/Plugins/ASCompletion/Context/ASContext.cs
+++ b/External/Plugins/ASCompletion/Context/ASContext.cs
@@ -831,7 +831,7 @@ namespace ASCompletion.Context
             }
 
             // parse and add to cache
-            nFile = ASFileParser.ParseFile(fileName, this);
+            nFile = ASFileParser.ParseFile(CreateFileModel(fileName));
             string upName = fileName.ToUpper();
             foreach (PathModel aPath in classPath)
             {
@@ -898,10 +898,21 @@ namespace ASCompletion.Context
         {
             if (fileName == null || fileName.Length == 0 || !File.Exists(fileName))
                 return new FileModel(fileName);
-            
-            fileName = PathHelper.GetLongPathName(fileName);
-            FileModel nFile = ASFileParser.ParseFile(fileName, this);
-            return nFile;
+            return ASFileParser.ParseFile(CreateFileModel(fileName));
+        }
+
+        /// <summary>
+        /// Create a new file model without parsing file
+        /// </summary>
+        /// <param name="fileName">Full path</param>
+        /// <returns>File model</returns>
+        public virtual FileModel CreateFileModel(string fileName)
+        {
+            if (fileName == null || fileName.Length == 0 || !File.Exists(fileName))
+                return new FileModel(fileName);
+            var fileModel = new FileModel(PathHelper.GetLongPathName(fileName));
+            fileModel.Context = this;
+            return fileModel;
         }
 
         /// <summary>
@@ -1451,8 +1462,8 @@ namespace ASCompletion.Context
 				}
 			}
 			FileModel aFile;
-			if (src == null) aFile = cFile;
-			else aFile = ASFileParser.ParseFile(src, this);
+            if (src == null) aFile = cFile;
+            else aFile = ASFileParser.ParseFile(CreateFileModel(src));
 			if (aFile.Version == 0) return;
 			//
 			string code = aFile.GenerateIntrinsic(false);

--- a/External/Plugins/ASCompletion/Context/IASContext.cs
+++ b/External/Plugins/ASCompletion/Context/IASContext.cs
@@ -90,6 +90,13 @@ namespace ASCompletion.Context
 		FileModel GetFileModel(string fileName);
 
         /// <summary>
+        /// Create a new file model without parsing file
+        /// </summary>
+        /// <param name="fileName">Full path</param>
+        /// <returns>File model</returns>
+        FileModel CreateFileModel(string fileName);
+
+        /// <summary>
         /// Parse a raw source code
         /// </summary>
         /// <param name="src"></param>

--- a/External/Plugins/ASCompletion/Model/ASFileParser.cs
+++ b/External/Plugins/ASCompletion/Model/ASFileParser.cs
@@ -426,16 +426,9 @@ namespace ASCompletion.Model
             lock (typeof(ASFileParser))
             {
                 cachedPath = inPath;
-                ParseFile(file, inContext);
+                ParseFile(inContext.CreateFileModel(file));
                 cachedPath = null;
             }
-        }
-
-        static public FileModel ParseFile(string file, IASContext inContext)
-        {
-            FileModel fileModel = new FileModel(file);
-            fileModel.Context = inContext;
-            return ParseFile(fileModel);
         }
 
         static public FileModel ParseFile(FileModel fileModel)
@@ -815,7 +808,7 @@ namespace ASCompletion.Model
 
                                     // next model
                                     string realFile = directive.Substring(11);
-                                    FileModel newModel = model.Context.GetFileModel(realFile);
+                                    FileModel newModel = model.Context.CreateFileModel(realFile);
                                     newModel.LastWriteTime = cacheLastWriteTime;
                                     newModel.CachedModel = true;
                                     if (features != null && features.hasModules) 


### PR DESCRIPTION
So AS3Context can set HasFiltering to true in case of MXML file. Otherwise it would fail to parse MXML sometimes because it was parsing XML instead of filtered XML...
