### PR TITLE
HaxeContext: Update keyword list

### DIFF
--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -101,13 +101,54 @@ namespace HaXeContext
             features.arrayKey = "Array<T>";
             features.importKey = "import";
             features.importKeyAlt = "using";
-            features.typesPreKeys = new string[] { "import", "new", "extends", "implements", "using" };
-            features.codeKeywords = new string[] { 
-                "enum", "typedef", "class", "interface", "var", "function", "new", "cast", "return", "break", 
-                "continue", "callback", "if", "else", "for", "while", "do", "switch", "case", "default", "type",
-                "null", "untyped", "true", "false", "try", "catch", "throw", "inline", "dynamic",
-                "extends", "using", "import", "implements", "abstract"
-            };
+            features.typesPreKeys = new string[] {  "import", 
+                                                    "new", 
+                                                    "extends", 
+                                                    "implements", 
+                                                    "using" };
+
+            features.codeKeywords = new string[] {  "function",
+                                                    "class",
+                                                    "static",
+                                                    "var",
+                                                    "if",
+                                                    "else",
+                                                    "while",
+                                                    "do",
+                                                    "for",
+                                                    "break",
+                                                    "return",
+                                                    "continue",
+                                                    "extends",
+                                                    "implements",
+                                                    "import",
+                                                    "switch",
+                                                    "case",
+                                                    "default",
+                                                    "private",
+                                                    "public",
+                                                    "try",
+                                                    "catch",
+                                                    "new",
+                                                    "this",
+                                                    "throw",
+                                                    "extern",
+                                                    "enum",
+                                                    "in",
+                                                    "interface",
+                                                    "untyped",
+                                                    "cast",
+                                                    "override",
+                                                    "typedef",
+                                                    "dynamic",
+                                                    "package",
+                                                    "inline",
+                                                    "using",
+                                                    "null",
+                                                    "true",
+                                                    "false",
+                                                    "abstract",
+                                                    "macro"  };
             features.varKey = "var";
             features.overrideKey = "override";
             features.functionKey = "function";


### PR DESCRIPTION
This updates the keyword list in `Context.cs` directly [based on the keywords defined in the Haxe compiler](https://github.com/HaxeFoundation/haxe/blob/development/ast.ml#L492) (thanks @Simn for pointing me there). I also changed the format to be a bit more readable.

Effectively, this adds `static`, `private`, `public`, `this`, `extern`, `in`, `override`, `package` and `macro` to the list - I'm not sure, is there a reason for them not having been there before? Is FD's definition of a keyword different?

It also removes `type` and `callback`, which are not keywords.

I'm thinking I must have missed something, because `calback` is still highlighted in blue after rebuilding FD (albeit doesn't show up as a template in auto completion anymore) - I assume syntax highlighting elsewhere? If so, shouldn't it use the same list of keywords?
