### PR TITLE
HaxeContext: Update haxe keyword list

### DIFF
--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -104,9 +104,9 @@ namespace HaXeContext
             features.typesPreKeys = new string[] { "import", "new", "extends", "implements", "using" };
             features.codeKeywords = new string[] { 
                 "enum", "typedef", "class", "interface", "var", "function", "new", "cast", "return", "break", 
-                "continue", "callback", "if", "else", "for", "while", "do", "switch", "case", "default", "type",
+                "continue", "if", "else", "for", "while", "do", "switch", "case", "default", "$type",
                 "null", "untyped", "true", "false", "try", "catch", "throw", "inline", "dynamic",
-                "extends", "using", "import", "implements", "abstract"
+                "extends", "using", "import", "implements", "abstract", "macro"
             };
             features.varKey = "var";
             features.overrideKey = "override";

--- a/FlashDevelop/Bin/Debug/Settings/Languages/Haxe.xml
+++ b/FlashDevelop/Bin/Debug/Settings/Languages/Haxe.xml
@@ -2,7 +2,7 @@
 <Scintilla xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<keyword-classes>
 		<keyword-class name="haxe-primary-keywords">
-			break callback case catch class continue default do else enum extends for function if implements import in interface new package return switch throw try typedef using var while abstract
+			break case catch class continue default do else enum extends for function if implements import in interface new package return switch throw try typedef using var while abstract $type 
 		</keyword-class>
 		<keyword-class name="haxe-secondary-keywords">
 			null true false


### PR DESCRIPTION
Removed `callback`, added `$type` and `macro` (the latter was excluded from the xml because highlighting would work incorrectly for imports).
