### PR TITLE
Add Find and Relace to context menu of files in the Project Manager

### DIFF
--- a/External/Plugins/ProjectManager/Controls/Icons.cs
+++ b/External/Plugins/ProjectManager/Controls/Icons.cs
@@ -67,6 +67,7 @@ namespace ProjectManager.Controls
 		public static FDImage OpenFile;
         public static FDImage EditFile;
         public static FDImage Browse;
+        public static FDImage FindAndReplace;
         public static FDImage FindInFiles;
 		public static FDImage Cut;
 		public static FDImage Copy;
@@ -133,6 +134,8 @@ namespace ProjectManager.Controls
 			OpenFile = Get(214);
             EditFile = Get(282);
             Browse = Get(46);
+
+            FindAndReplace = Get(484);
             FindInFiles = Get(209);
 			Cut = Get(158);
 			Copy = Get(292);

--- a/External/Plugins/ProjectManager/Controls/TreeView/ProjectContextMenu.cs
+++ b/External/Plugins/ProjectManager/Controls/TreeView/ProjectContextMenu.cs
@@ -10,6 +10,7 @@ using ProjectManager.Projects;
 using ProjectManager.Projects.AS2;
 using PluginCore.Localization;
 using PluginCore.Helpers;
+using PluginCore;
 
 namespace ProjectManager.Controls.TreeView
 {
@@ -54,6 +55,7 @@ namespace ProjectManager.Controls.TreeView
         public ToolStripMenuItem BuildAllProjects = new ToolStripMenuItem(TextHelper.GetString("Label.BuildAllProjects"));
         public ToolStripMenuItem BuildProjectFile = new ToolStripMenuItem(TextHelper.GetString("Label.BuildProjectFile"), Icons.Gear.Img);
         public ToolStripMenuItem BuildProjectFiles = new ToolStripMenuItem(TextHelper.GetString("Label.BuildProjectFiles"), Icons.Gear.Img);
+        public ToolStripMenuItem FindAndReplace = new ToolStripMenuItem(TextHelper.GetString("Label.FindHere"), Icons.FindAndReplace.Img);
         public ToolStripMenuItem FindInFiles = new ToolStripMenuItem(TextHelper.GetString("Label.FindHere"), Icons.FindInFiles.Img);
         public ToolStripMenuItem CopyClassName = new ToolStripMenuItem(TextHelper.GetString("Label.CopyClassName"));
         public ToolStripMenuItem AddSourcePath = new ToolStripMenuItem(TextHelper.GetString("Label.AddSourcePath"), Icons.Classpath.Img);
@@ -343,6 +345,7 @@ namespace ProjectManager.Controls.TreeView
         {
             menu.Add(Open, 0);
             menu.Add(Execute, 0);
+            menu.Add(FindAndReplace, 0);
             menu.Add(ShellMenu, 0);
             AddCompileTargetItems(menu, path, false);
             AddFileItems(menu, path);
@@ -430,7 +433,8 @@ namespace ProjectManager.Controls.TreeView
             {
                 menu.Add(Open, 0);
                 menu.Add(Execute, 0);
-                menu.Add(ShellMenu, 0);
+                menu.Add(FindAndReplace, 0);
+                menu.Add(ShellMenu, 0); 
                 AddFileItems(menu, node.BackingPath);
             }
             else menu.Add(NoProjectOutput, 0);
@@ -463,6 +467,7 @@ namespace ProjectManager.Controls.TreeView
         {
             menu.Add(Open, 0);
             menu.Add(Execute, 0);
+            menu.Add(FindAndReplace, 0);
             menu.Add(ShellMenu, 0);
             menu.Add(Insert, 0);
             if (IsBuildable(path))

--- a/External/Plugins/ProjectManager/PluginMain.cs
+++ b/External/Plugins/ProjectManager/PluginMain.cs
@@ -274,6 +274,7 @@ namespace ProjectManager
             pluginUI.Menu.BuildProjectFiles.Click += delegate { BackgroundBuild(); };
             pluginUI.Menu.BuildAllProjects.Click += delegate { FullBuild(); };
             pluginUI.Menu.TestAllProjects.Click += delegate { TestBuild(); };
+            pluginUI.Menu.FindAndReplace.Click += delegate { FindAndReplace(); };
             pluginUI.Menu.FindInFiles.Click += delegate { FindInFiles(); };
             pluginUI.Menu.CopyClassName.Click += delegate { CopyClassName(); };
             pluginUI.Menu.AddSourcePath.Click += delegate { AddSourcePath(); };
@@ -1422,6 +1423,15 @@ namespace ProjectManager
             if (copyCP.Handled) // UI needs refresh on clipboard change...
             {
                 PluginBase.MainForm.RefreshUI();
+            }
+        }
+
+        private void FindAndReplace()
+        {
+            String path = Tree.SelectedPath;
+            if (path != null && File.Exists(path))
+            {
+                PluginBase.MainForm.CallCommand("FindAndReplaceFrom", path);
             }
         }
 

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -2575,6 +2575,22 @@ namespace FlashDevelop
         }
 
         /// <summary>
+        /// Opens a find and replace dialog with a location
+        /// </summary>
+        public void FindAndReplaceFrom(Object sender, System.EventArgs e)
+        {
+            ToolStripItem button = (ToolStripItem)sender;
+            String file = ((ItemData)button.Tag).Tag;
+
+            ((Form)PluginBase.MainForm).BeginInvoke((MethodInvoker)delegate
+            {
+                OpenEditableDocument(file);
+            });
+
+            this.frInDocDialog.Show();
+        }
+
+        /// <summary>
         /// Opens a find and replace in files dialog
         /// </summary>
         public void FindAndReplaceInFiles(Object sender, System.EventArgs e)


### PR DESCRIPTION
Been bothering me for a while that there's find and replace for directories but not individual files. This first opens the selected file because the find and replace dialog only works on the currently active file (as opposed to find and replace in).

![](http://i.imgur.com/5TPHNT2.png)
