### PR TITLE
Updated it so project templates can use all keywords for folders

### DIFF
--- a/External/Plugins/ProjectManager/Helpers/ProjectCreator.cs
+++ b/External/Plugins/ProjectManager/Helpers/ProjectCreator.cs
@@ -123,9 +123,7 @@ namespace ProjectManager.Helpers
 			foreach (string dir in Directory.GetDirectories(sourceDir))
 			{
 				string dirName = Path.GetFileName(dir);
-                dirName = ReplaceKeywords(dirName);
-                if (dirName.ToUpper() == "$(PACKAGENAME)" || dirName.ToUpper() == "$(PACKAGEPATH)") 
-                    dirName = packagePath;
+		                dirName = ReplaceKeywords(dirName);
 				string destSubDir = Path.Combine(destDir, dirName);
 
 				// don't copy like .svn and stuff


### PR DESCRIPTION
It would be good to use this for project templates.
Some times I like to have extra folder imported into my directory like this:
- src - package name - project name - project classes
- src - package name - extensions - module 1 classes
- src - package name - extensions - module 2 classes

I've tested and it works for almost all cases. Just doesn't work for the $(timestamp), however flashdevelop delivers you an error about the folder not being about to be created. However if you're messing around with variables in the project templates in folders, you should understand why that error would have occurred.
