### PR TITLE
Switch to a layout on debugger start.

### DIFF
--- a/External/Plugins/FlashDebugger/Debugger/DebuggerManager.cs
+++ b/External/Plugins/FlashDebugger/Debugger/DebuggerManager.cs
@@ -223,9 +223,26 @@ namespace FlashDebugger
 
         #endregion
 
-        #region PathHelpers
+		#region LayoutHelpers
 
-        /// <summary>
+		/// <summary>
+		/// Check if old layout is sotred and restores it. It also deletes this temporary layout file.
+		/// </summary>
+		public void RestoreOldLayout()
+		{
+			String oldLayoutFile = Path.Combine(Path.Combine(PathHelper.DataDir, "FlashDebugger"), "oldlayout.fdl");
+			if (File.Exists(oldLayoutFile))
+			{
+				PluginBase.MainForm.CallCommand("RestoreLayout", oldLayoutFile);
+				File.Delete(oldLayoutFile);
+			}
+		}
+
+		#endregion
+
+		#region PathHelpers
+
+		/// <summary>
         /// 
         /// </summary>
 		public String GetLocalPath(SourceFile file)
@@ -289,9 +306,9 @@ namespace FlashDebugger
 
         #endregion
 
-        #region FlashInterface Events
-        
-        /// <summary>
+		#region FlashInterface Events
+
+		/// <summary>
         /// 
         /// </summary>
         private void flashInterface_StartedEvent(object sender)
@@ -307,7 +324,14 @@ namespace FlashDebugger
 			UpdateMenuState(DebuggerState.Running);
             PluginBase.MainForm.ProgressBar.Visible = false;
             PluginBase.MainForm.ProgressLabel.Visible = false;
-			if (!PluginMain.settingObject.DisablePanelsAutoshow)
+			if (PluginMain.settingObject.SwitchToLayout != null)
+			{
+				// save current state
+				String oldLayoutFile = Path.Combine(Path.Combine(PathHelper.DataDir, "FlashDebugger"), "oldlayout.fdl");
+				PluginBase.MainForm.DockPanel.SaveAsXml(oldLayoutFile);
+				PluginBase.MainForm.CallCommand("RestoreLayout", PluginMain.settingObject.SwitchToLayout);
+			}
+			else if (!PluginMain.settingObject.DisablePanelsAutoshow)
 			{
                 PanelsHelper.watchPanel.Show();
                 PanelsHelper.pluginPanel.Show();
@@ -333,7 +357,11 @@ namespace FlashDebugger
 			}
 			CurrentLocation = null;
 			UpdateMenuState(DebuggerState.Stopped);
-            if (!PluginMain.settingObject.DisablePanelsAutoshow)
+			if (PluginMain.settingObject.SwitchToLayout != null)
+			{
+				RestoreOldLayout();
+			}
+            else if (!PluginMain.settingObject.DisablePanelsAutoshow)
             {
                 PanelsHelper.watchPanel.Hide();
                 PanelsHelper.pluginPanel.Hide();

--- a/External/Plugins/FlashDebugger/FlashDebugger.csproj
+++ b/External/Plugins/FlashDebugger/FlashDebugger.csproj
@@ -200,6 +200,10 @@
       <Name>ASCompletion</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="..\LayoutManager\LayoutManager.csproj">
+      <Project>{BD6AFBEA-DB64-432A-80F7-4672A7FF283E}</Project>
+      <Name>LayoutManager</Name>
+    </ProjectReference>
     <ProjectReference Include="..\ProjectManager\ProjectManager.csproj">
       <Project>{78101C01-E186-4954-B1DD-DEBB7905FAD8}</Project>
       <Name>ProjectManager</Name>

--- a/External/Plugins/FlashDebugger/PluginMain.cs
+++ b/External/Plugins/FlashDebugger/PluginMain.cs
@@ -134,6 +134,7 @@ namespace FlashDebugger
                 case EventType.UIStarted:
                     menusHelper.AddToolStripItems();
                     menusHelper.UpdateMenuState(this, DebuggerState.Initializing);
+					debugManager.RestoreOldLayout();
                     break;
                 
                 case EventType.UIClosing:

--- a/External/Plugins/FlashDebugger/Settings.cs
+++ b/External/Plugins/FlashDebugger/Settings.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Design;
 using System.Windows.Forms.Design;
 using System.Runtime.CompilerServices;
 using PluginCore.Localization;
+using LayoutManager;
 
 namespace FlashDebugger
 {
@@ -49,6 +50,7 @@ namespace FlashDebugger
         private Boolean m_DisablePanelsAutoshow = false;
         private Boolean m_VerboseOutput = false;
         private Boolean m_StartDebuggerOnTestMovie = true;
+		private String m_SwitchToLayout = null;
 
         [DisplayName("Save Breakpoints")]
         [LocalizedCategory("FlashDebugger.Category.Misc")]
@@ -70,7 +72,18 @@ namespace FlashDebugger
             set { m_DisablePanelsAutoshow = value; }
         }
 
-        [DisplayName("Verbose Output")]
+		[DisplayName("Switch to layout on debugger start")]
+		[LocalizedCategory("FlashDebugger.Category.Misc")]
+		[LocalizedDescription("FlashDebugger.Description.SwitchToLayout")]
+		[DefaultValue(null)]
+		[Editor(typeof(LayoutSelectorEditor), typeof(UITypeEditor))]
+		public String SwitchToLayout
+		{
+			get { return m_SwitchToLayout; }
+			set { m_SwitchToLayout = value; }
+		}
+
+		[DisplayName("Verbose Output")]
         [LocalizedCategory("FlashDebugger.Category.Misc")]
         [LocalizedDescription("FlashDebugger.Description.VerboseOutput")]
         [DefaultValue(false)]

--- a/External/Plugins/LayoutManager/LayoutManager.csproj
+++ b/External/Plugins/LayoutManager/LayoutManager.csproj
@@ -80,6 +80,7 @@
     <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LayoutSelectorEditor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PluginMain.cs" />
     <Compile Include="PluginUI.cs">

--- a/External/Plugins/LayoutManager/LayoutSelectorEditor.cs
+++ b/External/Plugins/LayoutManager/LayoutSelectorEditor.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.ComponentModel.Design;
+using System.IO;
+using PluginCore.Helpers;
+
+namespace LayoutManager
+{
+	public class LayoutSelectorEditor : ObjectSelectorEditor
+	{
+		protected override void FillTreeWithData(ObjectSelectorEditor.Selector selector, System.ComponentModel.ITypeDescriptorContext context, IServiceProvider provider)
+		{
+			base.FillTreeWithData(selector, context, provider);
+
+			selector.Nodes.Add(new SelectorNode("<None>", null));
+
+			String[] layouts = Directory.GetFiles(this.GetLayoutsDir(), "*.fdl");
+			for (Int32 i = 0; i < layouts.Length; i++)
+			{
+				String label = Path.GetFileNameWithoutExtension(layouts[i]);
+				SelectorNode item = new SelectorNode(label, layouts[i]);
+				selector.Nodes.Add(item);
+			}
+
+		}
+
+		/// <summary>
+		/// Gets the layouts directory
+		/// </summary>
+		private String GetLayoutsDir()
+		{
+			String userPath = Settings.Instance.CustomLayoutPath;
+			if (Directory.Exists(userPath)) return userPath;
+			else
+			{
+				String path = Path.Combine(this.GetDataDir(), "Layouts");
+				if (!Directory.Exists(path)) Directory.CreateDirectory(path);
+				return path;
+			}
+		}
+
+		/// <summary>
+		/// Gets the plugin data directory
+		/// </summary>
+		private String GetDataDir()
+		{
+			return Path.Combine(PathHelper.DataDir, "LayoutManager");
+		}
+
+
+	}
+}

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -5074,4 +5074,8 @@ Custom locales must be an extension of a default locale, e.g. en-US.</value>
     <value>Shows the macro in the main toolbar.</value>
     <comment>Added after 4.5.2</comment>
   </data>
+  <data name="FlashDebugger.Description.SwitchToLayout" xml:space="preserve">
+    <value>Switch to selected layout on debugger start. On debugger stop, previous layout is restored. If a layout is selected, debugger panels are not shown automatically.</value>
+    <comment>Aded after 4.5.2</comment>
+  </data>
 </root>


### PR DESCRIPTION
Add debugger setting to select a layout that is switched to on
debugger start. Existing layout is also stored in a temporary file and
is restored on debugger stop. The temporary file is then deleted. If
the temporary layout file exists on FD startup, it is assumed that
FD exited while debugger is still running, and restored to old layout
on startup.

Add LayoutSelectorEditor UI element for selecting an existing layout.
Because of this, FlashDebugger plugin now depends on LayoutManager plugin.
