### PR TITLE
ScopeChain is inspected when looking up variable

### DIFF
--- a/External/Plugins/FlashDebugger/Debugger/ExpressionContext.cs
+++ b/External/Plugins/FlashDebugger/Debugger/ExpressionContext.cs
@@ -87,6 +87,13 @@ namespace FlashDebugger
                 {
                     if (v.getName().Equals(par0)) return (java.lang.Object)v;
                 }
+                foreach (Variable scope in frame.getScopeChain(session))
+                {
+                    foreach (Variable v in scope.getValue().getMembers(session))
+                    {
+                        if (v.getName().Equals(par0)) return (java.lang.Object)v;
+                    }
+                }
                 var fullClassName = findClassName((java.lang.String)par0);
                 if (null != fullClassName)
                 {


### PR DESCRIPTION
To improve the debugging experience when using nested functions.

Allows the variables heightOfFormItemHeader and item to be inspected from within the nested function.

``` actionscript
private function getFormItemResizeFunction(item:FormItem):Function
{
    const heightOfFormItemHeader:int = 40;
    return function (height:Number):void {
        item.height = height + heightOfFormItemHeader;
    };
}
```
