### PR TITLE
Add nested function parameters when parsing local vars

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -3377,15 +3377,38 @@ namespace ASCompletion.Completion
 			FileModel model;
             if (expression.FunctionBody != null && expression.FunctionBody.Length > 0)
             {
-				MemberModel cm = expression.ContextMember;
-                model = ASContext.Context.GetCodeModel(expression.FunctionBody);
-                foreach (MemberModel member in model.Members)
+                MemberModel cm = expression.ContextMember;
+                string functionBody = Regex.Replace(expression.FunctionBody, "function\\s*\\(", "function __anonfunc__("); // name anonymous functions
+                model = ASContext.Context.GetCodeModel(functionBody);
+                int memberCount = model.Members.Count;
+                for (int memberIndex = 0; memberIndex < memberCount; memberIndex++)
                 {
-					if (cm.Equals(member)) continue;
+                    MemberModel member = model.Members[memberIndex];
+
+                    if (cm.Equals(member)) continue;
 
                     member.Flags |= FlagType.LocalVar;
                     member.LineFrom += expression.FunctionOffset;
                     member.LineTo += expression.FunctionOffset;
+
+                    if ((member.Flags & FlagType.Function) == FlagType.Function)
+                    {
+                        if (member.Name == "__anonfunc__")
+                        {
+                            model.Members.Remove(member);
+                            memberCount--;
+                            memberIndex--;
+                        }
+
+                        if (member.Parameters == null) continue;
+
+                        foreach (MemberModel parameter in member.Parameters)
+                        {
+                            parameter.LineFrom += expression.FunctionOffset;
+                            parameter.LineTo += expression.FunctionOffset;
+                            model.Members.Add(parameter);
+                        }
+                    }
                 }
             }
             else model = new FileModel();


### PR DESCRIPTION
ParseLocalVars was already bringing variables defined in nested functions into the autocomplete. However, It was not bringing nested function parameters. In the case below you would see `heightOfFormItemHeader` in the autocomplete but not `height`.

``` actionscript
private function getFormItemResizeFunction(item:FormItem):Function
{
    return function (height:Number):void {
        const heightOfFormItemHeader:int = 40;
        item.height = height + heightOfFormItemHeader;
    };
}
```

The change below names anonymous functions which is required for them to be added to the model.Members list. These functions are removed before returning the Members list.

I changed the foreach to a for loop so that I could manipulate the Members list from within the loop instead of having to cache function members and loop through them afterwards.

Autocomplete still has the problem of showing variables and parameters from nested functions whose scope you may not currently be within. However, that was already the case for variables from nested functions.
