### PR TITLE
Better Haxe AIR template

### DIFF
--- a/FlashDevelop/Bin/Debug/Projects/315 Haxe - AIR AS3 Projector/src/$(PackagePath)/Main.hx.template
+++ b/FlashDevelop/Bin/Debug/Projects/315 Haxe - AIR AS3 Projector/src/$(PackagePath)/Main.hx.template
@@ -12,7 +12,10 @@ class Main extends Sprite $(CSLB){
 	public function new() $(CSLB){
 		super();
 		
-		//Entry point
+		/**
+		 * Entry point.
+		 * New to AIR? Please read the readme.txt files *carefully*!
+		 */
 	}
 	static function main() $(CSLB){
 		Lib.current.addChild(new Main());


### PR DESCRIPTION
The Haxe AIR projector template has been overwrought for a long time. I don't see why it has to act like an AIR application init tutorial: Every time I make a new project I have to clean it up and it just seems silly.

This new Main.hx.template cleans things up considerably.
