### PR TITLE
Improved HighDPI support by scaling images and sizes

### DIFF
--- a/External/Plugins/AS3Context/Controls/ProfilerUI.cs
+++ b/External/Plugins/AS3Context/Controls/ProfilerUI.cs
@@ -82,6 +82,7 @@ namespace AS3Context.Controls
 
             InitializeLocalization();
 
+            toolStrip.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             toolStrip.Renderer = new DockPanelStripRenderer();
             runButton.Image = PluginBase.MainForm.FindImage("127");
             gcButton.Image = PluginBase.MainForm.FindImage("90");

--- a/External/Plugins/ASClassWizard/Wizards/ClassBrowser.cs
+++ b/External/Plugins/ASClassWizard/Wizards/ClassBrowser.cs
@@ -65,6 +65,7 @@ namespace ASClassWizard.Wizards
             InitializeLocalization();
             this.Font = PluginBase.Settings.DefaultFont;
             this.itemList.ImageList = ASCompletion.Context.ASContext.Panel.TreeIcons;
+            this.itemList.ItemHeight = this.itemList.ImageList.ImageSize.Height;
             CenterToParent();
         }
 

--- a/External/Plugins/ASCompletion/CustomControls/ModelsExplorer.cs
+++ b/External/Plugins/ASCompletion/CustomControls/ModelsExplorer.cs
@@ -14,6 +14,7 @@ using WeifenLuo.WinFormsUI.Docking;
 using PluginCore.Managers;
 using ASCompletion.Completion;
 using System.Collections;
+using PluginCore.Helpers;
 
 namespace ASCompletion
 {
@@ -122,7 +123,7 @@ namespace ASCompletion
             searchButton.Image = PluginBase.MainForm.FindImage("251");
             refreshButton.Image = PluginBase.MainForm.FindImage("24");
             rebuildButton.Image = PluginBase.MainForm.FindImage("153");
-            toolStrip.Renderer = new DockPanelStripRenderer();
+            toolStrip.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
         }
 
         private void outlineContextMenuStrip_Opening(object sender, CancelEventArgs e)

--- a/External/Plugins/ASCompletion/PluginUI.cs
+++ b/External/Plugins/ASCompletion/PluginUI.cs
@@ -21,6 +21,7 @@ using PluginCore.Localization;
 using System.Drawing;
 using System.Reflection;
 using PluginCore.Controls;
+using PluginCore.Helpers;
 
 namespace ASCompletion
 {
@@ -119,7 +120,7 @@ namespace ASCompletion
         private void InitializeControls()
         {
             InitializeComponent();
-
+            treeIcons.ImageSize = ScaleHelper.Scale(new Size(16, 16));
             treeIcons.Images.AddRange( new Bitmap[] {
                 new Bitmap(GetStream("FilePlain.png")),
                 new Bitmap(GetStream("FolderClosed.png")),
@@ -159,6 +160,7 @@ namespace ASCompletion
             });
 
             toolStrip.Renderer = new DockPanelStripRenderer();
+            toolStrip.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             toolStrip.Padding = new Padding(2, 1, 2, 2);
             sortDropDown.Font = PluginBase.Settings.DefaultFont;
             sortDropDown.Image = PluginBase.MainForm.FindImage("444");

--- a/External/Plugins/FileExplorer/PluginUI.cs
+++ b/External/Plugins/FileExplorer/PluginUI.cs
@@ -246,6 +246,7 @@ namespace FileExplorer
         private void InitializeContextMenu()
         {
             this.menu = new ContextMenuStrip();
+            this.menu.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             this.menu.Items.Add(new ToolStripMenuItem(TextHelper.GetString("Label.RefreshView"), null, new EventHandler(this.RefreshFileView)));
             this.menu.Items.Add(new ToolStripMenuItem(TextHelper.GetString("Label.SynchronizeView"), null, new EventHandler(this.SynchronizeView)));
             this.menu.Items.Add(new ToolStripSeparator());
@@ -277,7 +278,7 @@ namespace FileExplorer
         private void InitializeGraphics()
         {
             this.imageList = new ImageList();
-            this.imageList.ImageSize = GetSmallIconSize();
+            this.imageList.ImageSize = ScaleHelper.Scale(new Size(16, 16));
             this.imageList.ColorDepth = ColorDepth.Depth32Bit;
             this.syncronizeButton.Image = PluginBase.MainForm.FindImage("203|9|-3|-3");
             this.browseButton.Image = PluginBase.MainForm.FindImage("203");
@@ -305,6 +306,7 @@ namespace FileExplorer
         private void InitializeLayout()
         {
             this.toolStrip.Renderer = new DockPanelStripRenderer();
+            this.toolStrip.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             this.selectedPath.FlatStyle = PluginBase.Settings.ComboBoxFlatStyle;
         }
 
@@ -1093,7 +1095,7 @@ namespace FileExplorer
         private int ExtractIconIfNecessary(String path)
         {
             Icon icon;
-            Size size = GetSmallIconSize();
+            Size size = ScaleHelper.Scale(new Size(16, 16));
             if (File.Exists(path)) icon = IconExtractor.GetFileIcon(path, false, true);
             else icon = IconExtractor.GetFolderIcon(path, false, true);
             Image image = ImageKonverter.ImageResize(icon.ToBitmap(), size.Width, size.Height);
@@ -1109,20 +1111,9 @@ namespace FileExplorer
             this.imageList.Images.Clear();
             this.imageList.Dispose();
             this.imageList = new ImageList();
-            this.imageList.ImageSize = GetSmallIconSize();
+            this.imageList.ImageSize = ScaleHelper.Scale(new Size(16, 16));
             this.imageList.ColorDepth = ColorDepth.Depth32Bit;
             this.fileView.SmallImageList = this.imageList;
-        }
-        
-        /// <summary>
-        /// Gets the small icon size. High dpi has slightly bigger icons
-        /// </summary>
-        /// <returns></returns>
-        private Size GetSmallIconSize()
-        {
-            Size size = SystemInformation.SmallIconSize;
-            if (size.Width > 16) return new Size(18, 18);
-            else return size;
         }
 
         #endregion

--- a/External/Plugins/FlashDebugger/Helpers/ScintillaHelper.cs
+++ b/External/Plugins/FlashDebugger/Helpers/ScintillaHelper.cs
@@ -6,6 +6,7 @@ using ScintillaNet;
 using PluginCore;
 using ScintillaNet.Configuration;
 using PluginCore.Managers;
+using PluginCore.Helpers;
 
 namespace FlashDebugger
 {
@@ -45,9 +46,9 @@ namespace FlashDebugger
 			mask |= GetMarkerMask(markerBPNotAvailable);
 			mask |= GetMarkerMask(markerCurrentLine);
 			sci.SetMarginMaskN(0, mask);
-			sci.MarkerDefinePixmap(markerBPEnabled, ScintillaNet.XPM.ConvertToXPM(Properties.Resource.Enabled, "#00FF00"));
-			sci.MarkerDefinePixmap(markerBPDisabled, ScintillaNet.XPM.ConvertToXPM(Properties.Resource.Disabled, "#00FF00"));
-            sci.MarkerDefinePixmap(markerCurrentLine, ScintillaNet.XPM.ConvertToXPM(Properties.Resource.CurLine, "#00FF00"));
+            sci.MarkerDefinePixmap(markerBPEnabled, ScintillaNet.XPM.ConvertToXPM(ScaleHelper.Stretch(Properties.Resource.Enabled), "#00FF00"));
+            sci.MarkerDefinePixmap(markerBPDisabled, ScintillaNet.XPM.ConvertToXPM(ScaleHelper.Stretch(Properties.Resource.Disabled), "#00FF00"));
+            sci.MarkerDefinePixmap(markerCurrentLine, ScintillaNet.XPM.ConvertToXPM(ScaleHelper.Stretch(Properties.Resource.CurLine), "#00FF00"));
             Language lang = PluginBase.MainForm.SciConfig.GetLanguage("as3"); // default
 			sci.MarkerSetBack(markerBPEnabled, lang.editorstyle.ErrorLineBack); // enable
             sci.MarkerSetBack(markerBPDisabled, lang.editorstyle.DisabledLineBack); // disable

--- a/External/Plugins/FlashLogViewer/PluginUI.cs
+++ b/External/Plugins/FlashLogViewer/PluginUI.cs
@@ -274,6 +274,7 @@ namespace FlashLogViewer
         private void InitializeContextMenu()
         {
             ContextMenuStrip menu = new ContextMenuStrip();
+            menu.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             menu.Font = PluginBase.Settings.DefaultFont;
             menu.Renderer = new DockPanelStripRenderer(false);
             menu.Items.Add(new ToolStripMenuItem(TextHelper.GetString("Label.ClearLog"), null, new EventHandler(this.ClearOutput)));
@@ -301,6 +302,7 @@ namespace FlashLogViewer
             this.logComboBox.FlatStyle = PluginBase.Settings.ComboBoxFlatStyle;
             this.filterComboBox.FlatStyle = PluginBase.Settings.ComboBoxFlatStyle;
             this.toolStrip.Renderer = new DockPanelStripRenderer();
+            this.toolStrip.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             this.refreshTimer = new Timer();
             this.refreshTimer.Interval = this.GetUpdateInterval();
             this.refreshTimer.Tick += new EventHandler(this.RefreshTimerTick);

--- a/External/Plugins/LayoutManager/PluginUI.cs
+++ b/External/Plugins/LayoutManager/PluginUI.cs
@@ -160,6 +160,7 @@ namespace LayoutManager
         private void InitializeGraphics()
         {
             this.imageList = new ImageList();
+            this.imageList.ImageSize = PluginCore.Helpers.ScaleHelper.Scale(new Size(16, 16));
             this.imageList.ColorDepth = ColorDepth.Depth32Bit;
             this.imageList.TransparentColor = Color.Transparent;
             this.imageList.Images.Add(PluginBase.MainForm.FindImage("48"));
@@ -185,6 +186,7 @@ namespace LayoutManager
         private void InitializeContextMenu()
         {
             ContextMenuStrip menu = new ContextMenuStrip();
+            menu.ImageScalingSize = PluginCore.Helpers.ScaleHelper.Scale(new Size(16, 16));
             this.menuLoadButton = new ToolStripMenuItem(TextHelper.GetString("Label.LoadLayout"), null, new EventHandler(this.LoadButtonClick));
             this.menuDeleteButton = new ToolStripMenuItem(TextHelper.GetString("Label.DeleteLayout"), null, new EventHandler(this.DeleteButtonClick));
             this.menuSaveButton = new ToolStripMenuItem(TextHelper.GetString("Label.SaveCurrent"), null, new EventHandler(this.SaveButtonClick));
@@ -213,6 +215,7 @@ namespace LayoutManager
         private void FormLoaded(Object sender, EventArgs e)
         {
             this.toolStrip.Renderer = new DockPanelStripRenderer();
+            this.toolStrip.ImageScalingSize = PluginCore.Helpers.ScaleHelper.Scale(new Size(16, 16));
             this.infoListViewItem = new ListViewItem(TextHelper.GetString("Info.NoLayoutsFound"), 1);
             String file = Path.Combine(this.GetLayoutsDir(), "DefaultLayout.fdl");
             if (!File.Exists(file)) WriteDefaultLayout(file);

--- a/External/Plugins/MacroManager/ManagerDialog.cs
+++ b/External/Plugins/MacroManager/ManagerDialog.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using PluginCore.Localization;
 using PluginCore.Utilities;
 using PluginCore;
+using PluginCore.Helpers;
 
 namespace MacroManager
 {
@@ -182,6 +183,7 @@ namespace MacroManager
             imageList.Images.Add(PluginBase.MainForm.FindImage("338|13|0|0"));
             this.pictureBox.Image = PluginBase.MainForm.FindImage("229");
             this.listView.SmallImageList = imageList;
+            this.listView.SmallImageList.ImageSize = ScaleHelper.Scale(new Size(16, 16));
             this.columnHeader.Width = -2;
         }
 

--- a/External/Plugins/OutputPanel/PluginUI.cs
+++ b/External/Plugins/OutputPanel/PluginUI.cs
@@ -11,6 +11,7 @@ using PluginCore.Managers;
 using PluginCore.Localization;
 using PluginCore.Controls;
 using PluginCore;
+using PluginCore.Helpers;
 
 namespace OutputPanel
 {
@@ -100,6 +101,7 @@ namespace OutputPanel
             // 
             this.toolStrip.CanOverflow = false;
             this.toolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+            this.toolStrip.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             this.toolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toggleButton,
             this.toolStripSeparator1,

--- a/External/Plugins/ProjectManager/Controls/Icons.cs
+++ b/External/Plugins/ProjectManager/Controls/Icons.cs
@@ -8,6 +8,7 @@ using PluginCore.Utilities;
 using PluginCore;
 using ProjectManager.Projects;
 using System.IO;
+using PluginCore.Helpers;
 
 namespace ProjectManager.Controls
 {
@@ -101,7 +102,7 @@ namespace ProjectManager.Controls
 
 			imageList = new ImageList();
 			imageList.ColorDepth = ColorDepth.Depth32Bit;
-			imageList.ImageSize = new Size(16, 16);
+            imageList.ImageSize = ScaleHelper.Scale(new Size(16, 16));
 			imageList.TransparentColor = Color.Transparent;
 
             BulletAdd = Get(0);
@@ -187,7 +188,7 @@ namespace ProjectManager.Controls
 
 		public static FDImage GetResource(string resourceID)
 		{
-            Image image;
+            Bitmap image;
             try
             {
                 resourceID = "ProjectManager." + resourceID;
@@ -197,7 +198,7 @@ namespace ProjectManager.Controls
             catch {
                 image = new Bitmap(16, 16);
             }
-			imageList.Images.Add(image);
+			imageList.Images.Add(ScaleHelper.Scale(image));
 			return new FDImage(image,imageList.Images.Count-1);
 		}
 
@@ -242,7 +243,7 @@ namespace ProjectManager.Controls
             else
             {
                 Icon icon = IconExtractor.GetFileIcon(file, true);
-                Image image = ImageKonverter.ImageResize(icon.ToBitmap(), 16, 16);
+                Image image = ScaleHelper.Scale(icon.ToBitmap());
                 icon.Dispose(); imageList.Images.Add(image);
                 int index = imageList.Images.Count - 1; // of the icon we just added
                 FDImage fdImage = new FDImage(image, index);
@@ -256,7 +257,7 @@ namespace ProjectManager.Controls
             Bitmap composed = image.Clone() as Bitmap;
             using (Graphics destination = Graphics.FromImage(composed))
             {
-                destination.DrawImage(overlay, new Rectangle(x, y, 16, 16), new Rectangle(0, 0, 16, 16), GraphicsUnit.Pixel);
+                destination.DrawImage(overlay, new Rectangle(x, y, overlay.Width, overlay.Height), new Rectangle(0, 0, overlay.Width, overlay.Height), GraphicsUnit.Pixel);
             }
             return composed;
         }

--- a/External/Plugins/ProjectManager/Controls/TreeBar.cs
+++ b/External/Plugins/ProjectManager/Controls/TreeBar.cs
@@ -6,6 +6,7 @@ using PluginCore.Localization;
 using ProjectManager.Controls.TreeView;
 using System.Drawing.Drawing2D;
 using System.Drawing;
+using PluginCore.Helpers;
 
 namespace ProjectManager.Controls
 {
@@ -27,6 +28,7 @@ namespace ProjectManager.Controls
         public TreeBar(FDMenus menus, ProjectContextMenu treeMenu)
         {
             this.treeMenu = treeMenu;
+            this.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             this.Size = new Size(200, 26);
             this.Renderer = new DockPanelStripRenderer();
             this.GripStyle = ToolStripGripStyle.Hidden;

--- a/External/Plugins/ProjectManager/Controls/TreeView/ProjectContextMenu.cs
+++ b/External/Plugins/ProjectManager/Controls/TreeView/ProjectContextMenu.cs
@@ -67,6 +67,7 @@ namespace ProjectManager.Controls.TreeView
         {
             this.Renderer = new DockPanelStripRenderer();
             this.Font = PluginCore.PluginBase.Settings.DefaultFont;
+            this.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             NothingToDo.Enabled = false;
             NoProjectOutput.Enabled = false;
         }

--- a/External/Plugins/ResultsPanel/PluginUI.cs
+++ b/External/Plugins/ResultsPanel/PluginUI.cs
@@ -140,6 +140,7 @@ namespace ResultsPanel
 			// 
 			// toolStripFilters
 			// 
+            this.toolStripFilters.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             this.toolStripFilters.CanOverflow = false;
             this.toolStripFilters.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
             this.toolStripFilters.Padding = new System.Windows.Forms.Padding(1, 1, 2, 2);

--- a/FlashDevelop/Controls/QuickFind.cs
+++ b/FlashDevelop/Controls/QuickFind.cs
@@ -17,6 +17,7 @@ using PluginCore.Controls;
 using ScintillaNet.Configuration;
 using ScintillaNet;
 using PluginCore;
+using PluginCore.Helpers;
 
 namespace FlashDevelop.Controls
 {
@@ -69,6 +70,7 @@ namespace FlashDevelop.Controls
 
         public void InitializeComponent()
         {
+            this.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             this.highlightTimer = new Timer();
             this.wholeWordCheckBox = new CheckBox();
             this.matchCaseCheckBox = new CheckBox();

--- a/FlashDevelop/Dialogs/AboutDialog.cs
+++ b/FlashDevelop/Dialogs/AboutDialog.cs
@@ -79,6 +79,8 @@ namespace FlashDevelop.Dialogs
             // 
             // AboutDialog
             //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(450, 244);
             this.Controls.Add(this.copyLabel);
             this.Controls.Add(this.versionLabel);

--- a/FlashDevelop/Dialogs/ArgumentDialog.cs
+++ b/FlashDevelop/Dialogs/ArgumentDialog.cs
@@ -11,6 +11,7 @@ using FlashDevelop.Settings;
 using FlashDevelop.Helpers;
 using PluginCore.Utilities;
 using PluginCore;
+using PluginCore.Helpers;
 
 namespace FlashDevelop.Dialogs
 {
@@ -251,6 +252,7 @@ namespace FlashDevelop.Dialogs
             imageList.Images.Add(Globals.MainForm.FindImage("242"));
             this.infoPictureBox.Image = Globals.MainForm.FindImage("229");
             this.argsListView.SmallImageList = imageList;
+            this.argsListView.SmallImageList.ImageSize = ScaleHelper.Scale(new Size(16, 16));
         }
 
         /// <summary>

--- a/FlashDevelop/Dialogs/EditorDialog.cs
+++ b/FlashDevelop/Dialogs/EditorDialog.cs
@@ -996,6 +996,7 @@ namespace FlashDevelop.Dialogs
             ImageList imageList = new ImageList();
             imageList.Images.Add(PluginBase.MainForm.FindImage("129"));
             this.itemListView.SmallImageList = imageList;
+            this.itemListView.SmallImageList.ImageSize = ScaleHelper.Scale(new Size(16, 16));
         }
 
         /// <summary>

--- a/FlashDevelop/Dialogs/SettingDialog.cs
+++ b/FlashDevelop/Dialogs/SettingDialog.cs
@@ -13,6 +13,7 @@ using FlashDevelop.Helpers;
 using PluginCore.Managers;
 using PluginCore.Controls;
 using PluginCore;
+using PluginCore.Helpers;
 
 namespace FlashDevelop.Dialogs
 {
@@ -264,6 +265,7 @@ namespace FlashDevelop.Dialogs
             this.clearFilterButton.Image = Globals.MainForm.FindImage("153");
             this.infoPictureBox.Image = Globals.MainForm.FindImage("229");
             this.itemListView.SmallImageList = imageList;
+            this.itemListView.SmallImageList.ImageSize = ScaleHelper.Scale(new Size(16, 16));
         }
 
         /// <summary>

--- a/FlashDevelop/Dialogs/SnippetDialog.cs
+++ b/FlashDevelop/Dialogs/SnippetDialog.cs
@@ -301,6 +301,7 @@ namespace FlashDevelop.Dialogs
             this.exportButton.Image = PluginBase.MainForm.FindImage("342|9|3|3");
             imageList.Images.Add(PluginBase.MainForm.FindImage("341"));
             this.snippetListView.SmallImageList = imageList;
+            this.snippetListView.SmallImageList.ImageSize = ScaleHelper.Scale(new Size(16, 16));
         }
 
         /// <summary>

--- a/FlashDevelop/Managers/ImageManager.cs
+++ b/FlashDevelop/Managers/ImageManager.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Windows.Forms;
 using System.Collections.Generic;
 using FlashDevelop.Helpers;
+using PluginCore.Helpers;
 
 namespace FlashDevelop.Managers
 {
@@ -49,6 +50,7 @@ namespace FlashDevelop.Managers
                 ry = (Bullet / 16) * 16;
                 destination.DrawImage(Source, new Rectangle(X, Y, 16, 16), new Rectangle(rx, ry, 16, 16), GraphicsUnit.Pixel);
             }
+            composed = ScaleHelper.Scale(composed);
             Cache[data] = composed;
             return composed;
         }

--- a/FlashDevelop/Managers/ScintillaManager.cs
+++ b/FlashDevelop/Managers/ScintillaManager.cs
@@ -223,21 +223,21 @@ namespace FlashDevelop.Managers
                 * Set correct line number margin width
                 */
                 Boolean viewLineNumbers = Globals.Settings.ViewLineNumbers;
-                if (viewLineNumbers) sci.SetMarginWidthN(1, 31);
+                if (viewLineNumbers) sci.SetMarginWidthN(1, ScaleHelper.Scale(31));
                 else sci.SetMarginWidthN(1, 0);
                 /**
                 * Set correct bookmark margin width
                 */
                 Boolean viewBookmarks = Globals.Settings.ViewBookmarks;
-                if (viewBookmarks) sci.SetMarginWidthN(0, 14);
+                if (viewBookmarks) sci.SetMarginWidthN(0, ScaleHelper.Scale(14));
                 else sci.SetMarginWidthN(0, 0);
                 /**
                 * Set correct folding margin width
                 */
                 Boolean useFolding = Globals.Settings.UseFolding;
                 if (!useFolding && !viewBookmarks && !viewLineNumbers) sci.SetMarginWidthN(2, 0);
-                else if (useFolding) sci.SetMarginWidthN(2, 15);
-                else sci.SetMarginWidthN(2, 2);
+                else if (useFolding) sci.SetMarginWidthN(2, ScaleHelper.Scale(15));
+                else sci.SetMarginWidthN(2, ScaleHelper.Scale(2));
                 /**
                 * Adjust the print margin
                 */
@@ -326,7 +326,7 @@ namespace FlashDevelop.Managers
             sci.ZoomLevel = 0;
             sci.UsePopUp(false);
             sci.SetMarginTypeN(0, 0);
-            sci.SetMarginWidthN(0, 14);
+            sci.SetMarginWidthN(0, ScaleHelper.Scale(14));
             sci.SetMarginTypeN(1, 1);
             sci.SetMarginMaskN(1, 0);
             sci.SetMarginTypeN(2, 0);

--- a/FlashDevelop/Managers/StripBarManager.cs
+++ b/FlashDevelop/Managers/StripBarManager.cs
@@ -9,6 +9,7 @@ using PluginCore.Managers;
 using PluginCore.Controls;
 using PluginCore.Helpers;
 using PluginCore;
+using System.Drawing;
 
 namespace FlashDevelop.Managers
 {
@@ -48,7 +49,8 @@ namespace FlashDevelop.Managers
         /// </summary>
         public static ToolStrip GetToolStrip(String file)
         {
-            ToolStripEx toolStrip = new ToolStripEx();
+            ToolStripEx toolStrip = new ToolStripEx();            
+			toolStrip.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             XmlNode rootNode = XmlHelper.LoadXmlDocument(file);
             foreach (XmlNode subNode in rootNode.ChildNodes)
             {
@@ -63,6 +65,7 @@ namespace FlashDevelop.Managers
         public static ContextMenuStrip GetContextMenu(String file)
         {
             ContextMenuStrip contextMenu = new ContextMenuStrip();
+            contextMenu.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             XmlNode rootNode = XmlHelper.LoadXmlDocument(file);
             foreach (XmlNode subNode in rootNode.ChildNodes)
             {
@@ -77,6 +80,7 @@ namespace FlashDevelop.Managers
         public static MenuStrip GetMenuStrip(String file)
         {
             MenuStrip menuStrip = new MenuStrip();
+            menuStrip.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             XmlNode rootNode = XmlHelper.LoadXmlDocument(file);
             foreach (XmlNode subNode in rootNode.ChildNodes)
             {

--- a/PluginCore/DockPanelSuite/Customization/DockPanelStripRenderer.cs
+++ b/PluginCore/DockPanelSuite/Customization/DockPanelStripRenderer.cs
@@ -5,6 +5,7 @@ using System.Drawing.Drawing2D;
 using System.Collections.Generic;
 using PluginCore.Managers;
 using PluginCore;
+using PluginCore.Helpers;
 
 namespace System.Windows.Forms
 {
@@ -277,13 +278,13 @@ namespace System.Windows.Forms
             {
                 Color back = PluginBase.MainForm.GetThemeColor("ToolStripItem.BackColor");
                 Color border = PluginBase.MainForm.GetThemeColor("ToolStripItem.BorderColor");
-                Rectangle borderRect = new Rectangle(4, 2, 18, 18);
-                Rectangle backRect = new Rectangle(5, 3, 16, 16);
+                Rectangle borderRect = new Rectangle(4, 2, ScaleHelper.Scale(18), ScaleHelper.Scale(18));
+                Rectangle backRect = new Rectangle(5, 3, borderRect.Width - 2, borderRect.Height - 2);
                 SolidBrush borderBrush = new SolidBrush(border == Color.Empty ? DockDrawHelper.ColorSelectedBG_Border : border);
                 LinearGradientBrush backBrush = new LinearGradientBrush(backRect, back == Color.Empty ? DockDrawHelper.ColorSelectedBG_White : back, back == Color.Empty ? DockDrawHelper.ColorSelectedBG_Blue : back, LinearGradientMode.Vertical);
                 e.Graphics.FillRectangle(borderBrush, borderRect);
                 e.Graphics.FillRectangle(backBrush, backRect);
-                e.Graphics.DrawImage(e.Image, new Point(5, 3));
+                e.Graphics.DrawImage(e.Image, 5 + ((backRect.Width - e.ImageRectangle.Width) / 2), 3 + ((backRect.Height - e.ImageRectangle.Height) / 2), e.ImageRectangle.Width, e.ImageRectangle.Height);
             }
             else renderer.DrawItemCheck(e);
         }

--- a/PluginCore/DockPanelSuite/Customization/VS2005AutoHideStrip.cs
+++ b/PluginCore/DockPanelSuite/Customization/VS2005AutoHideStrip.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Windows.Forms;
 using System.Drawing.Drawing2D;
 using System.ComponentModel;
+using PluginCore.Helpers;
 
 namespace WeifenLuo.WinFormsUI.Docking
 {
@@ -90,57 +91,57 @@ namespace WeifenLuo.WinFormsUI.Docking
 
 		private static int ImageHeight
 		{
-			get	{	return _ImageHeight;	}
+			get	{	return ScaleHelper.Scale(_ImageHeight);	}
 		}
 
 		private static int ImageWidth
 		{
-			get	{	return _ImageWidth;	}
+            get { return ScaleHelper.Scale(_ImageWidth); }
 		}
 
 		private static int ImageGapTop
 		{
-			get	{	return _ImageGapTop;	}
+			get	{	return ScaleHelper.Scale(_ImageGapTop);	}
 		}
 
 		private static int ImageGapLeft
 		{
-			get	{	return _ImageGapLeft;	}
+			get	{	return ScaleHelper.Scale(_ImageGapLeft);	}
 		}
 
 		private static int ImageGapRight
 		{
-			get	{	return _ImageGapRight;	}
+			get	{	return ScaleHelper.Scale(_ImageGapRight);	}
 		}
 
 		private static int ImageGapBottom
 		{
-			get	{	return _ImageGapBottom;	}
+			get	{	return ScaleHelper.Scale(_ImageGapBottom);	}
 		}
 
 		private static int TextGapLeft
 		{
-			get	{	return _TextGapLeft;	}
+			get	{	return ScaleHelper.Scale(_TextGapLeft);	}
 		}
 
 		private static int TextGapRight
 		{
-			get	{	return _TextGapRight;	}
+			get	{	return ScaleHelper.Scale(_TextGapRight);	}
 		}
 
 		private static int TabGapTop
 		{
-			get	{	return _TabGapTop;	}
+			get	{	return ScaleHelper.Scale(_TabGapTop);	}
 		}
 
 		private static int TabGapLeft
 		{
-			get	{	return _TabGapLeft;	}
+			get	{	return ScaleHelper.Scale(_TabGapLeft);	}
 		}
 
 		private static int TabGapBetween
 		{
-			get	{	return _TabGapBetween;	}
+			get	{	return ScaleHelper.Scale(_TabGapBetween);	}
 		}
 
 		private static Brush BrushTabBackground

--- a/PluginCore/DockPanelSuite/Customization/VS2005DockPaneCaption.cs
+++ b/PluginCore/DockPanelSuite/Customization/VS2005DockPaneCaption.cs
@@ -66,7 +66,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             get
             {
                 if (_imageButtonClose == null)
-                    _imageButtonClose = Resources.DockPane_Close;
+                    _imageButtonClose = PluginCore.Helpers.ScaleHelper.Stretch(Resources.DockPane_Close);
 
                 return _imageButtonClose;
             }
@@ -95,7 +95,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             get
             {
                 if (_imageButtonAutoHide == null)
-                    _imageButtonAutoHide = Resources.DockPane_AutoHide;
+                    _imageButtonAutoHide = PluginCore.Helpers.ScaleHelper.Stretch(Resources.DockPane_AutoHide);
 
                 return _imageButtonAutoHide;
             }
@@ -107,7 +107,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             get
             {
                 if (_imageButtonDock == null)
-                    _imageButtonDock = Resources.DockPane_Dock;
+                    _imageButtonDock = PluginCore.Helpers.ScaleHelper.Stretch(Resources.DockPane_Dock);
 
                 return _imageButtonDock;
             }

--- a/PluginCore/DockPanelSuite/Customization/VS2005DockPaneStrip.cs
+++ b/PluginCore/DockPanelSuite/Customization/VS2005DockPaneStrip.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Collections;
 using System.Collections.Generic;
 using PluginCore.DockPanelSuite;
+using PluginCore.Helpers;
 
 namespace WeifenLuo.WinFormsUI.Docking
 {
@@ -132,7 +133,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             get
             {
                 if (_imageButtonClose == null)
-                    _imageButtonClose = Resources.DockPane_Close;
+                    _imageButtonClose = PluginCore.Helpers.ScaleHelper.Stretch(Resources.DockPane_Close);
 
                 return _imageButtonClose;
             }
@@ -161,7 +162,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             get
             {
                 if (_imageButtonWindowList == null)
-                    _imageButtonWindowList = Resources.DockPane_Option;
+                    _imageButtonWindowList = PluginCore.Helpers.ScaleHelper.Stretch(Resources.DockPane_Option);
 
                 return _imageButtonWindowList;
             }
@@ -173,7 +174,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             get
             {
                 if (_imageButtonWindowListOverflow == null)
-                    _imageButtonWindowListOverflow = Resources.DockPane_OptionOverflow;
+                    _imageButtonWindowListOverflow = PluginCore.Helpers.ScaleHelper.Stretch(Resources.DockPane_OptionOverflow);
 
                 return _imageButtonWindowListOverflow;
             }
@@ -211,67 +212,67 @@ namespace WeifenLuo.WinFormsUI.Docking
 		#region Customizable Properties
         private static int ToolWindowStripGapTop
         {
-            get { return _ToolWindowStripGapTop; }
+            get { return ScaleHelper.Scale(_ToolWindowStripGapTop); }
         }
-
+        
         private static int ToolWindowStripGapBottom
         {
-            get { return _ToolWindowStripGapBottom; }
+            get { return ScaleHelper.Scale(_ToolWindowStripGapBottom); }
         }
 
 		private static int ToolWindowStripGapLeft
 		{
-			get	{	return _ToolWindowStripGapLeft;	}
+			get	{	return ScaleHelper.Scale(_ToolWindowStripGapLeft);	}
 		}
 
 		private static int ToolWindowStripGapRight
 		{
-			get	{	return _ToolWindowStripGapRight;	}
+			get	{	return ScaleHelper.Scale(_ToolWindowStripGapRight);	}
 		}
 
 		private static int ToolWindowImageHeight
 		{
-			get	{	return _ToolWindowImageHeight;	}
+			get	{	return ScaleHelper.Scale(_ToolWindowImageHeight);	}
 		}
 
 		private static int ToolWindowImageWidth
 		{
-			get	{	return _ToolWindowImageWidth;	}
+            get { return ScaleHelper.Scale(_ToolWindowImageWidth); }
 		}
 
 		private static int ToolWindowImageGapTop
 		{
-			get	{	return _ToolWindowImageGapTop;	}
+			get	{	return ScaleHelper.Scale(_ToolWindowImageGapTop);	}
 		}
 
 		private static int ToolWindowImageGapBottom
 		{
-			get	{	return _ToolWindowImageGapBottom;	}
+			get	{	return ScaleHelper.Scale(_ToolWindowImageGapBottom);	}
 		}
 
 		private static int ToolWindowImageGapLeft
 		{
-			get	{	return _ToolWindowImageGapLeft;	}
+			get	{	return ScaleHelper.Scale(_ToolWindowImageGapLeft);	}
 		}
 
 		private static int ToolWindowImageGapRight
 		{
-			get	{	return _ToolWindowImageGapRight;	}
+			get	{	return ScaleHelper.Scale(_ToolWindowImageGapRight);	}
 		}
 
 		private static int ToolWindowTextGapRight
 		{
-			get	{	return _ToolWindowTextGapRight;	}
+			get	{	return ScaleHelper.Scale(_ToolWindowTextGapRight);	}
 		}
 
 		private static int ToolWindowTabSeperatorGapTop
 		{
-			get	{	return _ToolWindowTabSeperatorGapTop;	}
+			get	{	return ScaleHelper.Scale(_ToolWindowTabSeperatorGapTop);	}
 		}
 
 		private static int ToolWindowTabSeperatorGapBottom
 		{
-			get	{	return _ToolWindowTabSeperatorGapBottom;	}
+			get	{	return ScaleHelper.Scale(_ToolWindowTabSeperatorGapBottom);	}
 		}
 
 		private static string _toolTipClose;
@@ -341,72 +342,72 @@ namespace WeifenLuo.WinFormsUI.Docking
 
 		private static int DocumentTabMaxWidth
 		{
-			get	{	return _DocumentTabMaxWidth;	}
+			get	{	return ScaleHelper.Scale(_DocumentTabMaxWidth);	}
 		}
 
 		private static int DocumentButtonGapTop
 		{
-			get	{	return _DocumentButtonGapTop;	}
+			get	{	return ScaleHelper.Scale(_DocumentButtonGapTop);	}
 		}
 
 		private static int DocumentButtonGapBottom
 		{
-			get	{	return _DocumentButtonGapBottom;	}
+			get	{	return ScaleHelper.Scale(_DocumentButtonGapBottom);	}
 		}
 
 		private static int DocumentButtonGapBetween
 		{
-			get	{	return _DocumentButtonGapBetween;	}
+			get	{	return ScaleHelper.Scale(_DocumentButtonGapBetween);	}
 		}
 
 		private static int DocumentButtonGapRight
 		{
-			get	{	return _DocumentButtonGapRight;	}
+			get	{	return ScaleHelper.Scale(_DocumentButtonGapRight);	}
 		}
 
 		private static int DocumentTabGapTop
 		{
-			get	{	return _DocumentTabGapTop;	}
+			get	{	return ScaleHelper.Scale(_DocumentTabGapTop);	}
 		}
 
 		private static int DocumentTabGapLeft
 		{
-			get	{	return _DocumentTabGapLeft;	}
+			get	{	return ScaleHelper.Scale(_DocumentTabGapLeft);	}
 		}
 
 		private static int DocumentTabGapRight
 		{
-			get	{	return _DocumentTabGapRight;	}
+			get	{	return ScaleHelper.Scale(_DocumentTabGapRight);	}
 		}
 
         private static int DocumentIconGapBottom
         {
-            get { return _DocumentIconGapBottom; }
+            get { return ScaleHelper.Scale(_DocumentIconGapBottom); }
         }
 
 		private static int DocumentIconGapLeft
 		{
-            get { return _DocumentIconGapLeft; }
+            get { return ScaleHelper.Scale(_DocumentIconGapLeft); }
 		}
 
         private static int DocumentIconGapRight
         {
-            get { return _DocumentIconGapRight; }
+            get { return ScaleHelper.Scale(_DocumentIconGapRight); }
         }
 
 		private static int DocumentIconWidth
 		{
-			get	{	return _DocumentIconWidth;	}
+			get	{	return ScaleHelper.Scale(_DocumentIconWidth);	}
 		}
 
 		private static int DocumentIconHeight
 		{
-			get	{	return _DocumentIconHeight;	}
+			get	{	return ScaleHelper.Scale(_DocumentIconHeight);	}
 		}
 
         private static int DocumentTextGapRight
         {
-            get { return _DocumentTextGapRight; }
+            get { return ScaleHelper.Scale(_DocumentTextGapRight); }
         }
 
 		private static Pen PenToolWindowTabBorder
@@ -515,6 +516,7 @@ namespace WeifenLuo.WinFormsUI.Docking
 			m_toolTip = new ToolTip(Components);
             m_selectMenu = new ContextMenuStrip(Components);
             m_selectMenu.Font = PluginCore.PluginBase.Settings.DefaultFont;
+            m_selectMenu.ImageScalingSize = ScaleHelper.Scale(new Size(16, 16));
             m_selectMenu.Renderer = new DockPanelStripRenderer(false);
 
 			ResumeLayout();
@@ -1172,10 +1174,10 @@ namespace WeifenLuo.WinFormsUI.Docking
             Rectangle rectText = rectIcon;
 
             // CHANGED - NICK
-            rectText.Y += 2;
+            rectText.Y += ScaleHelper.Scale(2);
 
             // CHANGED - MIKA
-            if (Font.SizeInPoints <= 8F) rectText.Y -= 1;
+            if (Font.SizeInPoints <= 8F) rectText.Y -= ScaleHelper.Scale(1);
 
             if (DockPane.DockPanel.ShowDocumentIcon)
             {

--- a/PluginCore/PluginCore.csproj
+++ b/PluginCore/PluginCore.csproj
@@ -311,6 +311,7 @@
     </Compile>
     <Compile Include="PluginCore\Controls\WinFormUtils.cs" />
     <Compile Include="PluginCore\Helpers\ConfigHelper.cs" />
+    <Compile Include="PluginCore\Helpers\ScaleHelper.cs" />
     <Compile Include="PluginCore\Helpers\JvmConfigHelper.cs" />
     <Compile Include="PluginCore\Helpers\ProcessHelper.cs" />
     <Compile Include="PluginCore\Helpers\ResourceHelper.cs" />

--- a/PluginCore/PluginCore/Controls/CompletionList.cs
+++ b/PluginCore/PluginCore/Controls/CompletionList.cs
@@ -262,7 +262,7 @@ namespace PluginCore.Controls
                 needResize = false;
                 Graphics g = cl.CreateGraphics();
                 SizeF size = g.MeasureString(widestLabel, cl.Font);
-                cl.Width = (int)Math.Min(Math.Max(size.Width + 40, 100), 400) + 10;
+                cl.Width = (int)Math.Min(Math.Max(size.Width + 40, 100), 400) + ScaleHelper.Scale(10);
             }
             int newHeight = Math.Min(cl.Items.Count, 10) * cl.ItemHeight + 4;
             if (newHeight != cl.Height) cl.Height = newHeight;
@@ -359,7 +359,7 @@ namespace PluginCore.Controls
             bool selected = (e.State & DrawItemState.Selected) > 0;
 			Brush textBrush = (selected) ? SystemBrushes.HighlightText : fore == Color.Empty ? SystemBrushes.WindowText : new SolidBrush(fore);
             Brush packageBrush = Brushes.Gray;
-			Rectangle tbounds = new Rectangle(18, e.Bounds.Top + 1, e.Bounds.Width, e.Bounds.Height);
+			Rectangle tbounds = new Rectangle(ScaleHelper.Scale(18), e.Bounds.Top + 1, e.Bounds.Width, e.Bounds.Height);
 			if (item != null)
 			{
                 Graphics g = e.Graphics;

--- a/PluginCore/PluginCore/Controls/MessageBar.cs
+++ b/PluginCore/PluginCore/Controls/MessageBar.cs
@@ -102,6 +102,8 @@ namespace PluginCore.Controls
 			// 
 			// MessageBar
 			//
+            this.AutoScaleDimensions = new SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.BackColor = System.Drawing.SystemColors.Info;
             this.ForeColor = System.Drawing.SystemColors.InfoText;
 			this.Controls.Add(this.buttonClose);

--- a/PluginCore/PluginCore/Helpers/ScaleHelper.cs
+++ b/PluginCore/PluginCore/Helpers/ScaleHelper.cs
@@ -1,0 +1,115 @@
+﻿using PluginCore.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Text;
+
+namespace PluginCore.Helpers
+{
+    public class ScaleHelper
+    {
+        private static double _scale = double.MinValue;
+
+        /// <summary>
+        /// Gets the display scale. Ideally would probably keep separate scales for X and Y.
+        /// </summary>
+        private static double GetScale()
+        {
+            if (_scale != double.MinValue)
+                return _scale;
+
+            using (var g = Graphics.FromHwnd(PluginBase.MainForm.Handle))
+            {
+                _scale = g.DpiX / 96f;
+            }
+
+            return _scale;
+        }
+
+        /// <summary>
+        /// Resizes based on display scale.
+        /// </summary>
+        public static int Scale(int value)
+        {
+            return (int)(value * GetScale());
+        }
+
+        /// <summary>
+        /// Resizes based on display scale.
+        /// </summary>
+        public static long Scale(long value)
+        {
+            return (long)(value * GetScale());
+        }
+
+        /// <summary>
+        /// Resizes based on display scale.
+        /// </summary>
+        public static float Scale(float value)
+        {
+            return (float)(value * GetScale());
+        }
+
+        /// <summary>
+        /// Resizes based on display scale.
+        /// </summary>
+        public static double Scale(double value)
+        {
+            return value * GetScale();
+        }
+
+        /// <summary>
+        /// Resizes based on display scale.
+        /// </summary>
+        public static Size Scale(Size value)
+        {
+            return new Size(Scale(value.Width), Scale(value.Height));
+        }
+
+        /// <summary>
+        /// Resizes based on display scale.
+        /// </summary>
+        public static SizeF Scale(SizeF value)
+        {
+            return new SizeF(Scale(value.Width), Scale(value.Height));
+        }
+
+        /// <summary>
+        /// Resizes the image based on the display scale. Uses high quality settings.
+        /// </summary>
+        public static Bitmap Scale(Bitmap image)
+        {
+            if (GetScale() == 1)
+                return image;
+
+            if (GetScale() >= 2)
+                return Stretch(image);
+
+            int width = Scale(image.Width);
+            int height = Scale(image.Height);
+
+            return (Bitmap)ImageKonverter.ImageResize(image, width, height);
+        }
+
+        /// <summary>
+        /// Resizes the image based on the display scale. Uses default quality settings. Necessary to not break the DockPanel bitmaps.
+        /// </summary>
+        public static Bitmap Stretch(Bitmap image)
+        {
+            if (GetScale() == 1)
+                return image;
+
+            int width = Scale(image.Width);
+            int height = Scale(image.Height);
+
+            Bitmap bitmap = new Bitmap(width, height, image.PixelFormat);
+            Graphics graphicsImage = Graphics.FromImage(bitmap);
+            graphicsImage.SmoothingMode = SmoothingMode.HighQuality;
+            graphicsImage.InterpolationMode = InterpolationMode.NearestNeighbor;
+            graphicsImage.DrawImage(image, 0, 0, bitmap.Width, bitmap.Height);
+            graphicsImage.Dispose();
+            return bitmap;
+        }
+    }
+}


### PR DESCRIPTION
After purchasing a Lenovo Yoga Pro 2, I noticed that FlashDevelop had poor support for HighDPI.

Taking the suggestion of how [Microsoft scaled their images for Visual Studio.](http://blogs.msdn.com/b/visualstudio/archive/2014/03/19/improving-high-dpi-support-for-visual-studio-2013.aspx) I performed similar scaling in FlashDevelop. Updated ImageSize and ImageScalingSize where appropriate. Adjusting Tab rendering to take into account the scaling.

Before
![flashdevelop-4 5 2 scaled](https://f.cloud.github.com/assets/611219/2474999/39fc8804-b052-11e3-937e-e24e098db215.png)

After
![flashdevelop-with hdpi scaled](https://f.cloud.github.com/assets/611219/2475006/5af0c106-b052-11e3-9f23-51a3aacad9af.png)

*Images scaled to 50%

I attempted to be as thorough as possible although it is likely there are still dialogs or controls sized wrongly.
