### PR TITLE
Don't add null locations to breakpointLocations

### DIFF
--- a/External/Plugins/FlashDebugger/Debugger/FlashInterface.cs
+++ b/External/Plugins/FlashDebugger/Debugger/FlashInterface.cs
@@ -1129,7 +1129,10 @@ namespace FlashDebugger
 						if (files.ContainsKey(bp.FileFullPath) && files[bp.FileFullPath] != 0)
 						{
 							Location l = (i_Session != null) ? i_Session.setBreakpoint(files[bp.FileFullPath], bp.Line + 1) : m_Session.setBreakpoint(files[bp.FileFullPath], bp.Line + 1);
-							breakpointLocations.Add(bp, l);
+                            if (l != null)
+                            {
+                                breakpointLocations.Add(bp, l);
+                            }
 						}
 					}
 				}


### PR DESCRIPTION
While debugging I accidentally added a breakpoint on an empty line. When I removed the breakpoint FD crashed on me. I traced it back to Location coming back null when setting a breakpoint for a blank line. It would then get added to breakpointLocations and when cleared it would throw a NullReferenceExpection. With this change the breakpoint never gets added to breakpointLocations, but does show up in UI as expected. Can add and remove the breakpoint without crash and other breakpoints still break appropriately.
