### PR TITLE
Allow passing jvm args via jvm.config or build.properties to ASC 2.0

### DIFF
--- a/External/Plugins/AS3Context/Compiler/FlexShells.cs
+++ b/External/Plugins/AS3Context/Compiler/FlexShells.cs
@@ -406,7 +406,7 @@ namespace AS3Context.Compiler
             currentSDK = flexPath;
             if (ascRunner != null && ascRunner.IsRunning) ascRunner.KillProcess();
 
-            string cmd = "-Duser.language=en -Duser.region=US"
+            string cmd = jvmConfig["java.args"]
                 + " -classpath \"" + ascPath + ";" + flexShellsPath + "\" AscShell";
             TraceManager.Add(TextHelper.GetString("Info.StartAscRunner") + "\n" 
                 + JvmConfigHelper.GetJavaEXE(jvmConfig) + " " + cmd, -1);


### PR DESCRIPTION
The ASC 2.0 installation doesn't include a jvm.config file in the bin/ directory, but this seems like the only viable way to pass in java memory opts. Once I made this change, added the jvm.config, and rebuilt FDBuild, everything was happy.

Here's the related explanation: http://www.flashdevelop.org/community/viewtopic.php?f=13&t=11608&sid=a1f331524e0f14270fe312219f0bb56d
