### PR TITLE
Real classes that begin with '_' will have a Package name

### DIFF
--- a/External/Plugins/AS3Context/AbcConverter.cs
+++ b/External/Plugins/AS3Context/AbcConverter.cs
@@ -183,7 +183,7 @@ namespace AS3Context
                         }
                         else genericTypes[genType] = model;
                     }
-                    else if (type.Name.StartsWith("_"))
+                    else if (type.Name.StartsWith("_") && string.IsNullOrEmpty(model.Package))
                     {
                         type.Access = Visibility.Private;
                         type.Namespace = "private";


### PR DESCRIPTION
A large project that I support uses a modified version of Underscore.as. This works fine when referencing the source but once it is compiled into a swc those classes become invisible to the autocomplete. 

After testing on a project with a large amount of swc references, the difference between a compiler generated class that starts with '_' and a real class is that the generated class does not have a package name. 
