### PR TITLE
Added break on handled error setting to FlashDebugger

### DIFF
--- a/External/Plugins/FlashDebugger/Debugger/FlashInterface.cs
+++ b/External/Plugins/FlashDebugger/Debugger/FlashInterface.cs
@@ -205,6 +205,7 @@ namespace FlashDebugger
                 }
                 catch (System.Exception){}
                 m_CurrentState = DebuggerState.Running;
+                m_Session.breakOnCaughtExceptions(PluginMain.settingObject.BreakOnThrow);
                 // now poke to see if the player is good enough
                 try
                 {
@@ -477,6 +478,15 @@ namespace FlashDebugger
             }
 		}
 
+        void settingObject_BreakOnThrowChanged(object sender, EventArgs e)
+        {
+            if (m_CurrentState != DebuggerState.Starting &&
+                m_CurrentState != DebuggerState.Stopped)
+            {
+                m_Session.breakOnCaughtExceptions(PluginMain.settingObject.BreakOnThrow);
+            }
+        }
+
 		internal virtual void initSession()
 		{
 			bool correctVersion = true;
@@ -499,6 +509,7 @@ namespace FlashDebugger
 			m_StepResume = false;
 
             runningIsolates = new Dictionary<int, IsolateInfo>();
+            PluginMain.settingObject.BreakOnThrowChanged += settingObject_BreakOnThrowChanged;
 		}
 
 		/// <summary> If we still have a socket try to send an exit message
@@ -506,6 +517,7 @@ namespace FlashDebugger
 		/// </summary>
 		internal virtual void exitSession()
 		{
+            PluginMain.settingObject.BreakOnThrowChanged -= settingObject_BreakOnThrowChanged;
             // clear out our watchpoint list and displays
 			// keep breakpoints around so that we can try to reapply them if we reconnect
 			if (m_Session != null)

--- a/External/Plugins/FlashDebugger/Settings.cs
+++ b/External/Plugins/FlashDebugger/Settings.cs
@@ -50,7 +50,10 @@ namespace FlashDebugger
         private Boolean m_DisablePanelsAutoshow = false;
         private Boolean m_VerboseOutput = false;
         private Boolean m_StartDebuggerOnTestMovie = true;
+        private Boolean m_BreakOnThrow = false;
 		private String m_SwitchToLayout = null;
+
+        public event EventHandler BreakOnThrowChanged;
 
         [DisplayName("Save Breakpoints")]
         [LocalizedCategory("FlashDebugger.Category.Misc")]
@@ -120,6 +123,24 @@ namespace FlashDebugger
             set { m_StartDebuggerOnTestMovie = value; }
         }
 
+        [DisplayName("Break When Error Is Thrown")]
+        [LocalizedCategory("FlashDebugger.Category.Misc")]
+        [LocalizedDescription("FlashDebugger.Description.BreakOnThrow")]
+        [DefaultValue(false)]
+        public bool BreakOnThrow
+        {
+            get { return m_BreakOnThrow; }
+            set 
+            {
+                if (m_BreakOnThrow == value)
+                    return;
+
+                m_BreakOnThrow = value;
+
+                if (BreakOnThrowChanged != null)
+                    BreakOnThrowChanged(this, EventArgs.Empty);
+            }
+        }
     }
 
 }

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -5090,4 +5090,8 @@ Custom locales must be an extension of a default locale, e.g. en-US.</value>
     <value>Type of the intendation guide behaviour.</value>
     <comment>Added after 4.6.0</comment>
   </data>
+  <data name="FlashDebugger.Description.BreakOnThrow" xml:space="preserve">
+    <value>Break when an exception is thrown, even if it is handled.</value>
+    <comment>Added after 4.6.1</comment>
+  </data>
 </root>


### PR DESCRIPTION
When maintaining an older code base it can be useful to break even when handled errors are thrown. I added this as a setting to FlashDebugger. When the setting is changed it will update even when debugging.

I added English strings but am unable to add others.
