### PR TITLE
Added a sort on the window list select menu to improve usability

### DIFF
--- a/PluginCore/DockPanelSuite/Customization/VS2005DockPaneStrip.cs
+++ b/PluginCore/DockPanelSuite/Customization/VS2005DockPaneStrip.cs
@@ -1343,8 +1343,11 @@ namespace WeifenLuo.WinFormsUI.Docking
             int x = 0;
             int y = ButtonWindowList.Location.Y + ButtonWindowList.Height;
 
+            List<Tab> tabs = new List<Tab>(Tabs);
+            tabs.Sort((a, b) => string.CompareOrdinal(a.Content.DockHandler.TabText, b.Content.DockHandler.TabText));
+            
             SelectMenu.Items.Clear();
-            foreach (TabVS2005 tab in Tabs)
+            foreach (TabVS2005 tab in tabs)
             {
                 IDockContent content = tab.Content;
                 ToolStripItem item = SelectMenu.Items.Add(content.DockHandler.TabText, content.DockHandler.Icon.ToBitmap());


### PR DESCRIPTION
I tend to have a number of tabs open at any given time (sometimes 20 or more) and in these cases the window list comes into play to access open files. I use the quick open dialog quite a bit to access most of my files, but a lot of the time I could access open files more quickly with the window list. 

This change simply sorts the tabs that appear in the window menu alphabetically to make it easier to find a specific file that is already open. All references to the correct tabs are maintained and no functionality is lost.
