### PR TITLE
Updating code refactor menu items after file switching

### DIFF
--- a/External/Plugins/CodeRefactor/PluginMain.cs
+++ b/External/Plugins/CodeRefactor/PluginMain.cs
@@ -125,6 +125,7 @@ namespace CodeRefactor
             {
                 case EventType.FileSwitch:
                     this.GenerateSurroundMenuItems();
+                    UpdateMenuItems();
                     break;
 
                 case EventType.UIStarted:


### PR DESCRIPTION
Now active Main.as(AS3): ![2014-05-08 15 56 51](https://cloud.githubusercontent.com/assets/1700940/2915112/0b0eb39c-d6a8-11e3-9aa0-c13db13dd856.png)
Move to PluginMain.cs(CSharp): ![2014-05-08 15 57 20](https://cloud.githubusercontent.com/assets/1700940/2915116/19ed661a-d6a8-11e3-8723-20e4f94a025b.png)

After fix.
Move from Main.as to PluginMain.cs: ![2014-05-08 16 01 27](https://cloud.githubusercontent.com/assets/1700940/2915147/91750472-d6a8-11e3-8636-415a948da0fb.png)
