### PR TITLE
FIX. Find all references in additional class paths and global class paths.

### DIFF
--- a/External/Plugins/CodeRefactor/Provider/RefactoringHelper.cs
+++ b/External/Plugins/CodeRefactor/Provider/RefactoringHelper.cs
@@ -316,9 +316,11 @@ namespace CodeRefactor.Provider
         /// </summary>
         public static Boolean IsProjectRelatedFile(IProject project, String file)
         {
-            foreach (String path in project.SourcePaths)
+            IASContext context = ASContext.GetLanguageContext(project.Language);
+            if (context == null) return false;
+            foreach (PathModel pathModel in context.Classpath)
             {
-                String absolute = project.GetAbsolutePath(path);
+                string absolute = project.GetAbsolutePath(pathModel.Path);
                 if (file.StartsWith(absolute)) return true;
             }
             // If no source paths are defined, is it under the project?
@@ -336,13 +338,13 @@ namespace CodeRefactor.Provider
         private static List<String> GetAllProjectRelatedFiles(IProject project)
         {
             List<String> files = new List<String>();
-
             string filter = GetSearchPatternFromLang(project.Language.ToLower());
-            if (string.IsNullOrEmpty(filter))
-                return files;
-
-            foreach (String path in project.SourcePaths)
+            if (string.IsNullOrEmpty(filter)) return files;
+            IASContext context = ASContext.GetLanguageContext(project.Language);
+            if (context == null) return files;
+            foreach (PathModel pathModel in context.Classpath)
             {
+                string path = pathModel.Path;
                 String absolute = project.GetAbsolutePath(path);
                 if (Directory.Exists(path))
                     files.AddRange(Directory.GetFiles(absolute, filter, SearchOption.AllDirectories));


### PR DESCRIPTION
Now(Haxe): ![2014-05-17 00 58 19](https://cloud.githubusercontent.com/assets/1700940/3002574/29d19548-dd41-11e3-947b-69c98d553209.png)
Result: ![2014-05-17 00 58 27](https://cloud.githubusercontent.com/assets/1700940/3002596/79444508-dd41-11e3-82a1-ded7e7a5f79a.png)
Now(AS3): ![2014-05-17 00 58 56](https://cloud.githubusercontent.com/assets/1700940/3002584/567c6384-dd41-11e3-924c-539eb7774baf.png)
Result: ![2014-05-17 00 59 02](https://cloud.githubusercontent.com/assets/1700940/3002588/650d68e4-dd41-11e3-8858-f13c098f6e6b.png)

Result after fix(Haxe): ![2014-05-17 01 33 47](https://cloud.githubusercontent.com/assets/1700940/3002612/ce19d7b4-dd41-11e3-9844-55ecf8da9e58.png)
Result after fix(AS3) : ![2014-05-17 01 34 56](https://cloud.githubusercontent.com/assets/1700940/3002620/f3f77fe0-dd41-11e3-84d3-71fa499680f8.png)
