### PR TITLE
Added german translations from on 4.5 and fixed some typos

### DIFF
--- a/PluginCore/PluginCore/Resources/de_DE.resX
+++ b/PluginCore/PluginCore/Resources/de_DE.resX
@@ -5073,19 +5073,19 @@ Eigene Sprachumgebungen müssen eine Erweiterung der Standard-Sprachumgebung sei
     <value>Threads Panel</value>
   </data>
   <data name="MacroManager.Description.ShowInToolbar" xml:space="preserve">
-    <value>Zeigt das Makro in der Haupt Werkzeugleiste.</value>
+    <value>Zeigt das Makro in der Hauptwerkzeugleiste.</value>
     <comment>Added after 4.5.2</comment>
   </data>
   <data name="FlashDebugger.Description.SwitchToLayout" xml:space="preserve">
-    <value>Wechsel zum gewählten Layout beim Start des Debuggers. Beim Stop des Debuggers wird wieder das vorherige Layout gewählt. Wenn ein Layout angewählt ist, werden die Debug Fenster nicht automatisch angezeigt.</value>
+    <value>Wechsel zum gewählten Layout beim Start des Debuggers. Beim Stoppen des Debuggers wird wieder das vorherige Layout gewählt. Wenn ein Layout angewählt ist, werden die Debug Fenster nicht automatisch angezeigt.</value>
     <comment>Added after 4.5.2</comment>
   </data>
   <data name="FlashDevelop.Description.IndentView" xml:space="preserve">
-    <value>Type of the intendation guide behaviour.</value>
+    <value>Art des Verhaltens der Einrückungslinien.</value>
     <comment>Added after 4.6.0</comment>
   </data>
   <data name="FlashDebugger.Description.BreakOnThrow" xml:space="preserve">
-    <value>Unterbruch bei einer Exception, auch, wenn sie behandelt wurde.</value>
+    <value>Unterbrechung bei einer Exception, auch wenn sie behandelt wurde.</value>
     <comment>Added after 4.6.1</comment>
   </data>
   <data name="ProjectManager.Label.RunProject" xml:space="preserve">


### PR DESCRIPTION
Hi guys

Finally found some spare time to update the german translations. Thanks and keep on with the great work!

Griz

P.s: Would it be possible to start the (already helping) comments with the version number instead of the action (e.g. added in 4.5.1 --> 4.5.1 Added). In that way it would be a little easier to find all strings to translate (independent of them being added, edited oder whatever...)
