### PR TITLE
When setting Breakpoints use the lowest SourceFile Id.

### DIFF
--- a/External/Plugins/FlashDebugger/Debugger/FlashInterface.cs
+++ b/External/Plugins/FlashDebugger/Debugger/FlashInterface.cs
@@ -1099,7 +1099,7 @@ namespace FlashDebugger
 					{
 						if (!files.ContainsKey(bp.FileFullPath))
 						{
-							files.Add(bp.FileFullPath, 0);
+							files.Add(bp.FileFullPath, int.MaxValue);
 						}
 					}
 				}
@@ -1118,22 +1118,13 @@ namespace FlashDebugger
 						foreach (SourceFile src in swf.getSourceList(m_Session))
 						{
 							String localPath = PluginMain.debugManager.GetLocalPath(src);
-							if (localPath != null && files.ContainsKey(localPath) && files[localPath] == 0)
+							if (localPath != null && files.ContainsKey(localPath) && files[localPath] > src.getId())
 							{
 								files[localPath] = src.getId();
-								nFiles--;
-								if (nFiles == 0)
-								{
-									break;
-								}
 							}
 						}
 					}
 					catch (InProgressException) { }
-					if (nFiles == 0)
-					{
-						break;
-					}
 				}
 			}
 
@@ -1143,7 +1134,7 @@ namespace FlashDebugger
 				{
 					if (bp.IsEnabled && !bp.IsDeleted)
 					{
-						if (files.ContainsKey(bp.FileFullPath) && files[bp.FileFullPath] != 0)
+						if (files.ContainsKey(bp.FileFullPath) && files[bp.FileFullPath] != int.MaxValue)
 						{
 							Location l = (i_Session != null) ? i_Session.setBreakpoint(files[bp.FileFullPath], bp.Line + 1) : m_Session.setBreakpoint(files[bp.FileFullPath], bp.Line + 1);
                             if (l != null)


### PR DESCRIPTION
Background:
For projects that load many modules that all reference core libraries, the same source file may be loaded into the session several times.

The code that determine which location to use when adding breakpoints to
the session uses the first source file with matching path name it
encounter. However, FlashPlayer seems to 'run' the first instance of the source file  that was loaded.

This sets up a situation where the found location does not match the
running location. In those situations the breakpoints do not get hit.

Solution:
This fix changes the code that determines which location to use for
breakpoints. Instead of using the first matching location it will use the
location with the lowest source file id.

First change is to default the source file id for new breakpoints to
int.MaxValue, this way any found source file id will be lower. We change
the source file check from looking for unset file id to looking for file
id that is lower than we have found. Next we remove the early exit since
we are unsure when we've found the lowest file id for a location.
