### PR TITLE
macro keyword was forgotten in older pull request

### DIFF
--- a/FlashDevelop/Bin/Debug/Settings/Languages/Haxe.xml
+++ b/FlashDevelop/Bin/Debug/Settings/Languages/Haxe.xml
@@ -2,7 +2,7 @@
 <Scintilla xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<keyword-classes>
 		<keyword-class name="haxe-primary-keywords">
-			break case catch class continue default do else enum extends for function if implements import in interface new package return switch throw try typedef using var while abstract $type 
+			abstract break case catch class continue default do else enum extends for function if implements import in interface macro new package return switch throw try typedef using var while $type 
 		</keyword-class>
 		<keyword-class name="haxe-secondary-keywords">
 			null true false


### PR DESCRIPTION
Related to:
https://github.com/fdorg/flashdevelop/pull/95

The "macro" keyword was forgotten to be added to  the list.
I also put "abstract" in front in order to restore the alphabetic order.
