### PR TITLE
Fix formatting start declaration with access modifiers for generate override gettersetter

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -3894,7 +3894,7 @@ namespace ASCompletion.Completion
                     }
                     decl += tpl;
                 }
-                decl = "$(Boundary)" + TemplateUtils.ReplaceTemplateVariable(decl, "BlankLine", "");
+                decl = TemplateUtils.ReplaceTemplateVariable(decl, "BlankLine", "");
             }
             else
             {


### PR DESCRIPTION
Now:
![](http://service.crazypanda.ru/v/clip2net/A/p/wr4bL1oGN6.png)
![](http://service.crazypanda.ru/v/clip2net/n/H/8QHELD80AA.png)

Result after fix:
![](http://service.crazypanda.ru/v/clip2net/T/B/r5e9qhqnLe.png)
