### PR TITLE
Update for OpenFL 2.0.

### DIFF
--- a/FlashDevelop/Bin/Debug/Projects/380 Haxe - OpenFL Project/src/$(PackagePath)/Main.hx.template
+++ b/FlashDevelop/Bin/Debug/Projects/380 Haxe - OpenFL Project/src/$(PackagePath)/Main.hx.template
@@ -1,8 +1,8 @@
 package $(PackageName);
 
-import flash.display.Sprite;
-import flash.events.Event;
-import flash.Lib;
+import openfl.display.Sprite;
+import openfl.events.Event;
+import openfl.Lib;
 
 /**
 $(CBI)* ...
@@ -29,7 +29,7 @@ class Main extends Sprite $(CSLB){
 		// stage.stageWidth x stage.stageHeight @ stage.dpiScale
 		
 		// Assets:
-		// nme.Assets.getBitmapData("img/assetname.jpg");
+		// openfl.Assets.getBitmapData("img/assetname.jpg");
 	}
 
 	/* SETUP */


### PR DESCRIPTION
Replace "flash._" by "openfl._" Reference: http://www.openfl.org/blog/2014/05/29/openfl-2-0/
Replace "nme._" by "openfl._"
