### PR TITLE
Fix issue #289: Vector completion with complex index expression fails

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -3178,7 +3178,7 @@ namespace ASCompletion.Completion
                     else if (c == '(')
                     {
                         braceCount--;
-                        if (braceCount == 0)
+                        if (braceCount == 0 && sqCount == 0)
                         {
                             int testPos = position - 1;
                             string testWord = GetWordLeft(Sci, ref testPos);


### PR DESCRIPTION
After fix:
![](http://service.crazypanda.ru/v/clip2net/U/U/PLLXYCBoM3.png)
![](http://service.crazypanda.ru/v/clip2net/h/z/NmXPCiEWbt.png)
