### PR TITLE
Fix issue #320: Bug in haxe generator

### DIFF
--- a/External/Plugins/AS2Context/Context.cs
+++ b/External/Plugins/AS2Context/Context.cs
@@ -702,7 +702,7 @@ namespace AS2Context
                 if (pkg == package && aFile.Classes.Count > 0)
                 {
                     foreach (ClassModel aClass in aFile.Classes)
-                        if (aClass.Name == cname && (aFile.Module == "" || aFile.Module == aClass.Name))
+                        if (aClass.Name == cname && (pkg == "" || aFile.Module == "" || aFile.Module == aClass.Name))
                         {
                             found = aClass;
                             return false;


### PR DESCRIPTION
After fix: 
make "Assign statement for variable" to 1;
we got 
var float:Float = 1;

make "Assign statement for variable" to true or false;
we got 
var t:Bool = true;
var f:Bool = false;
