### PR TITLE
HaXeCompletion: fix reListEntry for additional aittributes, closes #331

### DIFF
--- a/External/Plugins/HaXeContext/Completion/HaXeCompletion.cs
+++ b/External/Plugins/HaXeContext/Completion/HaXeCompletion.cs
@@ -17,7 +17,7 @@ namespace HaXeContext
 
     internal class HaXeCompletion
     {
-        private static readonly Regex reListEntry = new Regex("<i n=\"([^\"]+)\"><t>([^<]*)</t><d>([^<]*)</d></i>",
+        private static readonly Regex reListEntry = new Regex("<i n=\"([^\"]+)\".*?><t>([^<]*)</t><d>([^<]*)</d></i>",
                                                               RegexOptions.Compiled | RegexOptions.Singleline);
         private static readonly Regex reArg = new Regex("^(-cp)\\s*([^\"'].*)$", 
                                                         RegexOptions.Compiled | RegexOptions.IgnoreCase);


### PR DESCRIPTION
Tested @Simn's fix from #331, and it seems to be compatible with both Haxe 3.1.3 and the latest dev branch.
