### PR TITLE
Add zoom control to View, add reset zoom functionality, closes #282

### DIFF
--- a/FlashDevelop/Bin/Debug/Settings/MainMenu.xml
+++ b/FlashDevelop/Bin/Debug/Settings/MainMenu.xml
@@ -4,7 +4,7 @@
 		<menu label="Label.New" name="NewMenu">
 			<button label="Label.BlankDocument" click="New" shortcut="Control|N" />
 			<separator />
-			<button label="Label.AS2Document" click="NewFromTemplate" tag="as;$(TemplateDir)\AS2.fdt" shortcut="Control|D0" />
+			<button label="Label.AS2Document" click="NewFromTemplate" tag="as;$(TemplateDir)\AS2.fdt" />
 			<button label="Label.AS3Document" click="NewFromTemplate" tag="as;$(TemplateDir)\AS3.fdt" shortcut="Control|D1" />
 			<button label="Label.HaxeDocument" click="NewFromTemplate" tag="hx;$(TemplateDir)\Haxe.fdt" shortcut="Control|D2" />
 			<button label="Label.MXMLDocument" click="NewFromTemplate" tag="mxml;$(TemplateDir)\MXML.fdt" shortcut="Control|D3" />
@@ -112,6 +112,10 @@
 		<separator />
 		<button label="Label.FullScreen" click="ToggleFullScreen" shortcut="Shift|Alt|Enter" flags="Check:IsFullScreen" />
 		<button label="Label.SplitView" click="ToggleSplitView" shortcut="Control|Shift|Enter" flags="Check:IsSplitted" />
+		<separator />
+		<button label="Label.ZoomIn" click="ZoomIn" shortcut="Control|Oemplus" />
+		<button label="Label.ZoomOut" click="ZoomOut" shortcut="Control|OemMinus" />
+		<button label="Label.ResetZoom" click="ResetZoom" shortcut="Control|D0" />
 		<separator />
 	</menu>
 	<menu label="Label.Search" name="SearchMenu">

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -1013,7 +1013,7 @@ namespace FlashDevelop
         }
 
         /// <summary>
-        /// Initalizes the windows state after show is called and
+        /// Initializes the windows state after show is called and
         /// check if we need to notify user for recovery files
         /// </summary>
         private void OnMainFormShow(Object sender, System.EventArgs e)
@@ -1499,7 +1499,6 @@ namespace FlashDevelop
                     else if (keyData == (Keys.Control | Keys.X)) return false;
                     else if (keyData == (Keys.Control | Keys.A)) return false;
                     else if (keyData == (Keys.Control | Keys.Z)) return false;
-                    else if (keyData == (Keys.Control | Keys.V)) return false;
                 }
                 /**
                 * Process special key combinations and allow "chaining" of 
@@ -2922,6 +2921,33 @@ namespace FlashDevelop
             {
                 this.CurrentDocument.IsSplitted = !this.CurrentDocument.IsSplitted;
                 ButtonManager.UpdateFlaggedButtons();
+            }
+        }
+
+        public void ZoomIn(Object sender, System.EventArgs e)
+        {
+            ScintillaControl sci = Globals.SciControl;
+            if (sci.Focused)
+            {
+                sci.ZoomIn();
+            }
+        }
+
+        public void ZoomOut(Object sender, System.EventArgs e)
+        {
+            ScintillaControl sci = Globals.SciControl;
+            if (sci.Focused)
+            {
+                sci.ZoomOut();
+            }
+        }
+
+        public void ResetZoom(Object sender, System.EventArgs e)
+        {
+            ScintillaControl sci = Globals.SciControl;
+            if (sci.Focused)
+            {
+                sci.ZoomLevel = 0;
             }
         }
 

--- a/PluginCore/PluginCore/Resources/de_DE.resX
+++ b/PluginCore/PluginCore/Resources/de_DE.resX
@@ -2500,6 +2500,18 @@ Bitte bedenken Sie, dass Sie viele Projektoptionen nicht mehr nutzen können, so
   <data name="FlashDevelop.Label.FullScreen" xml:space="preserve">
     <value>V&amp;ollbild</value>
   </data>
+  <data name="FlashDevelop.Label.ZoomIn" xml:space="preserve">
+    <value>Heranzoomen</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
+  <data name="FlashDevelop.Label.ZoomOut" xml:space="preserve">
+    <value>Herauszoomen</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
+  <data name="FlashDevelop.Label.ResetZoom" xml:space="preserve">
+    <value>Zoom zurücksetzen</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
   <data name="ASCompletion.Description.ReformatBraces" xml:space="preserve">
     <value>Formatiere automatisch die Klammern entsprechend der Coding Style Line Break Option in den FlashDevelop Haupteinstellungen.</value>
   </data>

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -2502,6 +2502,18 @@ Please note that with injection enabled, you will not be able to use many projec
   <data name="FlashDevelop.Label.FullScreen" xml:space="preserve">
     <value>F&amp;ull Screen</value>
   </data>
+  <data name="FlashDevelop.Label.ZoomIn" xml:space="preserve">
+    <value>Zoom In</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
+  <data name="FlashDevelop.Label.ZoomOut" xml:space="preserve">
+    <value>Zoom Out</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
+  <data name="FlashDevelop.Label.ResetZoom" xml:space="preserve">
+    <value>Reset Zoom</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
   <data name="ASCompletion.Description.ReformatBraces" xml:space="preserve">
     <value>Automatically reformat braces according to the Coding Style Line Break option in the main application settings.</value>
   </data>

--- a/PluginCore/PluginCore/Resources/eu_ES.resX
+++ b/PluginCore/PluginCore/Resources/eu_ES.resX
@@ -2492,6 +2492,18 @@ Kontutan izan injekzioa gaituz gero, ezin izanen diren proiektuaren hainbat auke
   <data name="FlashDevelop.Label.FullScreen" xml:space="preserve">
     <value>P&amp;antaila osoa</value>
   </data>
+  <data name="FlashDevelop.Label.ZoomIn" xml:space="preserve">
+    <value>Zoom In</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
+  <data name="FlashDevelop.Label.ZoomOut" xml:space="preserve">
+    <value>Zoom Out</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
+  <data name="FlashDevelop.Label.ResetZoom" xml:space="preserve">
+    <value>Reset Zoom</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
   <data name="ASCompletion.Description.ReformatBraces" xml:space="preserve">
     <value>Aplikazio nagusiaren ezarpenetako Kodetze Estiloa Lerro Saltoa aukeran adierazitako moduan giltzei automatikoki formatua eman.</value>
   </data>

--- a/PluginCore/PluginCore/Resources/ja_JP.resX
+++ b/PluginCore/PluginCore/Resources/ja_JP.resX
@@ -2498,6 +2498,18 @@ Never - 起動時にスタートページを表示しません。</value>
   <data name="FlashDevelop.Label.FullScreen" xml:space="preserve">
     <value>フルスクリーン(&amp;U)</value>
   </data>
+  <data name="FlashDevelop.Label.ZoomIn" xml:space="preserve">
+    <value>Zoom In</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
+  <data name="FlashDevelop.Label.ZoomOut" xml:space="preserve">
+    <value>Zoom Out</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
+  <data name="FlashDevelop.Label.ResetZoom" xml:space="preserve">
+    <value>Reset Zoom</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
   <data name="ASCompletion.Description.ReformatBraces" xml:space="preserve">
     <value>メイン設定にあるコーディングスタイル改行設定に従って括弧を自動で再フォーマットします。</value>
   </data>

--- a/PluginCore/PluginCore/Resources/zh_CN.resx
+++ b/PluginCore/PluginCore/Resources/zh_CN.resx
@@ -2498,6 +2498,18 @@
   <data name="FlashDevelop.Label.FullScreen" xml:space="preserve">
     <value>全屏模式(&amp;U)</value>
   </data>
+  <data name="FlashDevelop.Label.ZoomIn" xml:space="preserve">
+    <value>Zoom In</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
+  <data name="FlashDevelop.Label.ZoomOut" xml:space="preserve">
+    <value>Zoom Out</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
+  <data name="FlashDevelop.Label.ResetZoom" xml:space="preserve">
+    <value>Reset Zoom</value>
+	<comment>Added after 4.6.4</comment>
+  </data>
   <data name="ASCompletion.Description.ReformatBraces" xml:space="preserve">
     <value>按照主程序设置中的编码样式换行符选项，自动格式化大括号.</value>
   </data>


### PR DESCRIPTION
Zooming via Ctrl + NumpadPlus and Ctrl + NumpadMinus as well as Ctrl + MouseWheel was already supported. 

This adds zoom controls to the View Menu, support for the Ctrl + Plus and Ctrl + Minus shortcuts plus a new reset zoom functionality.

![](http://i.imgur.com/DCID4id.png)

The only thing missing right now is allowing Ctrl + Numpad0 to work as well for resetting the zoom, unfortunately `ToolStripMenuItem`s only support one `shortcutKey` it seems. Not sure what the best approach here is, I tried multiple things. An `OnKeyDown` listener in `MainForm` for example doesn't seem to fire while scintilla has focus.
