### PR TITLE
Fix shortening + auto-import of paths in Haxe metadata, closes #204

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -3878,11 +3878,7 @@ namespace ASCompletion.Completion
             // some haxe metadata needs paths will full packages, e.g. @:access(path)
             if (ASContext.Context.CurrentMember == null && ASContext.Context.CurrentModel.haXe)
             {
-                int curLine = sci.LineFromPosition(position);
-                int curPosInLine = position - sci.PositionFromLine(curLine);
-                String line = sci.GetLine(curLine);
-                int length = sci.MBSafeLengthFromBytes(line, curPosInLine);
-                String lineUntilCursor = line.Substring(0, length);
+                String lineUntilCursor = sci.GetLineUntilPosition(position);
                 
                 Regex openMetadata = new Regex("@:?(.*)\\(");
                 foreach (Match match in openMetadata.Matches(lineUntilCursor))

--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -3250,6 +3250,16 @@ namespace ScintillaNet
 		{
 			return (int) SPerform(2167, (uint)line, 0);
 		}
+
+        public String GetLineUntilPosition(int pos)
+        {
+            int curLine = LineFromPosition(pos);
+            int curPosInLine = pos - PositionFromLine(curLine);
+            String line = GetLine(curLine);
+            int length = MBSafeLengthFromBytes(line, curPosInLine);
+            String lineUntilPos = line.Substring(0, length);
+            return lineUntilPos;
+        }
 						
 		/// <summary>
 		/// Scroll horizontally and vertically.


### PR DESCRIPTION
Not sure if this is the best approach, but it sems to work fine.
