### PR TITLE
Refactor->Move: don't mess up AS3 and Haxe package spacing

### DIFF
--- a/External/Plugins/CodeRefactor/Commands/Move.cs
+++ b/External/Plugins/CodeRefactor/Commands/Move.cs
@@ -204,6 +204,7 @@ namespace CodeRefactor.Commands
                 if (string.IsNullOrEmpty(oldFileModel.Package))
                 {
                     search = new FRSearch("package");
+                    search.WholeWord = true;
                     newType = Path.GetFileNameWithoutExtension(currentTarget.OldFilePath);
                 }
                 else


### PR DESCRIPTION
These are the operations that caused spacing to change. Using `-` to represent spaces as GitHub seems to hide multiple spaces in codeblocks.
#### Haxe:

From `sub` to root:
- `package sub;` -> prev: `package--;` | now: `package;`

From root to `sub`:
- `package;` -> prev: `package sub-;` | now: `package sub;`
#### AS3:

From `sub` to root:
- `package sub-{` -> prev: `package--{` | now: `package-{`
