### PR TITLE
Refactor->Rename: don't reload renamed files

### DIFF
--- a/External/Plugins/CodeRefactor/Commands/Rename.cs
+++ b/External/Plugins/CodeRefactor/Commands/Rename.cs
@@ -221,16 +221,8 @@ namespace CodeRefactor.Commands
 
             if (string.IsNullOrEmpty(oldFileName) || oldFileName.Equals(newFileName)) return;
 
-            foreach (ITabbedDocument doc in PluginBase.MainForm.Documents)
-                if (doc.FileName.Equals(oldFileName))
-                {
-                    doc.Save();
-                    doc.Close();
-                    break;
-                }
-
             RefactoringHelper.Move(oldFileName, newFileName);
-            AssociatedDocumentHelper.LoadDocument(newFileName);
+           
             if (results.ContainsKey(oldFileName))
             {
                 results[newFileName] = results[oldFileName];


### PR DESCRIPTION
This way, the history is preserved and you can `Edit->Undo` if you want (although the file renaming isn't covered by that, of course). 
