### PR TITLE
Interpolation completion: fix inherited members not showing, fix context check

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -2283,13 +2283,12 @@ namespace ASCompletion.Completion
             MemberList members = new MemberList();
             ASExpr expr = GetExpression(sci, sci.CurrentPos);
 
-            if (expr.ContextFunction != null)
-            {
-                members.Merge(ctx.CurrentClass.GetSortedMembersList());
-                
-                if ((expr.ContextFunction.Flags & FlagType.Static) > 0)
-                    members.RemoveAllWithoutFlag(FlagType.Static);
-            }
+            members.Merge(ctx.CurrentClass.GetSortedMembersList());
+
+            if ((expr.ContextMember.Flags & FlagType.Static) > 0)
+                members.RemoveAllWithoutFlag(FlagType.Static);
+            else
+                members.Merge(ctx.CurrentClass.GetSortedInheritedMembersList());
 
             members.Merge(ParseLocalVars(expr));
             

--- a/External/Plugins/ASCompletion/Model/ClassModel.cs
+++ b/External/Plugins/ASCompletion/Model/ClassModel.cs
@@ -224,6 +224,27 @@ namespace ASCompletion.Model
             return items;
         }
 
+        /// <summary>
+        /// Returns all members inherited from super classes of this class.
+        /// Does not take static inheritance into account.
+        /// </summary>
+        internal MemberList GetSortedInheritedMembersList()
+        {
+            MemberList items = new MemberList();
+            ClassModel curClass = this;
+            do
+            {
+                curClass.ResolveExtends();
+                curClass = curClass.Extends;
+                MemberList newMembers = curClass.GetSortedMembersList();
+                items.Merge(newMembers);
+                
+            } while (curClass.Extends != ClassModel.VoidClass);
+            items.RemoveAllWithFlag(FlagType.Static);
+            items.Sort();
+            return items;
+        }
+
         #endregion
 
         #region Sorting


### PR DESCRIPTION
I didn't account for inheritance (wrongly assumed that `GetSortedMembersList()` covers that). Also the `ContextFunction` check was causing issues in string interpolation outside of functions.
