### PR TITLE
HaxeContext#ResolveType(): fix error with toplevel import

### DIFF
--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -912,7 +912,8 @@ namespace HaXeContext
                             var type = import.Type;
                             int temp = type.IndexOf('<');
                             if (temp > 0) type = type.Substring(0, temp);
-                            package = type.Substring(0, type.LastIndexOf('.'));
+                            int dotIndex = type.LastIndexOf('.');
+                            if (dotIndex > 0) package = type.Substring(0, dotIndex);
                         }
                         break;
                     }


### PR DESCRIPTION
The following would produce an error because the code didn't consider the possibility of a toplevel-import / an import without a dot.

``` haxe
import Map;

abstract StringMapIterable<V>(Map<String,V>) from Map<String,V> {
        public function new(v:Map<String,V>) this = v;
        public function get() return this;
        static public function iterator<X>(i:StringMapIterable<X>) : StringMap.StringMapValueIterator<X> { return i.iterator(); }      
}
```
