### PR TITLE
Some shortcut improvements

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -4194,6 +4194,11 @@ namespace ASCompletion.Completion
                 return member.Name; 
             }
         }
+
+        public override string ToString()
+        {
+            return Label;
+        }
     }
 
     /// <summary>

--- a/External/Plugins/OutputPanel/PluginUI.cs
+++ b/External/Plugins/OutputPanel/PluginUI.cs
@@ -303,7 +303,7 @@ namespace OutputPanel
         /// </summary>
         public Boolean OnShortcut(Keys keys)
         {
-            if (this.textLog.Focused || this.findTextBox.Focused)
+            if (ContainsFocus)
             {
                 if (keys == Keys.F3)
                 {
@@ -319,6 +319,11 @@ namespace OutputPanel
                 {
                     ITabbedDocument doc = PluginBase.MainForm.CurrentDocument;
                     if (doc != null && doc.IsEditable) doc.SciControl.Focus();
+                }
+                else if (keys == (Keys.Control | Keys.F))
+                {
+                    findTextBox.Focus();
+                    return true;
                 }
             }
             return false;

--- a/External/Plugins/ProjectManager/Controls/FDMenus.cs
+++ b/External/Plugins/ProjectManager/Controls/FDMenus.cs
@@ -77,6 +77,8 @@ namespace ProjectManager.Controls
             ConfigurationSelector.FlatStyle = PluginBase.MainForm.Settings.ComboBoxFlatStyle;
             ConfigurationSelector.Font = PluginBase.Settings.DefaultFont;
             toolBar.Items.Add(ConfigurationSelector);
+            PluginBase.MainForm.RegisterShortcutItem("ProjectMenu.ConfigurationSelector", Keys.Control | Keys.F5);
+            PluginBase.MainForm.RegisterShortcutItem("ProjectMenu.ConfigurationSelectorToggle", Keys.Control | Keys.Shift | Keys.F5);
 
             TargetBuildSelector = new ToolStripComboBox();
             TargetBuildSelector.Name = "TargetBuildSelector";
@@ -90,6 +92,7 @@ namespace ProjectManager.Controls
             TargetBuildSelector.FlatStyle = PluginBase.MainForm.Settings.ComboBoxFlatStyle;
             TargetBuildSelector.Font = PluginBase.Settings.DefaultFont;
             toolBar.Items.Add(TargetBuildSelector);
+            PluginBase.MainForm.RegisterShortcutItem("ProjectMenu.TargetBuildSelector", Keys.Control | Keys.F6);
         }
 
         public bool DisabledForBuild
@@ -138,6 +141,12 @@ namespace ProjectManager.Controls
                 TargetBuildSelector.Visible = false;
                 TargetBuildSelector.Enabled = false;
             }
+        }
+
+        
+        public void ToggleDebugRelease()
+        {
+            ConfigurationSelector.SelectedIndex = (ConfigurationSelector.SelectedIndex + 1) % 2;
         }
     }
 
@@ -252,7 +261,6 @@ namespace ProjectManager.Controls
                 }
             }
         }
-
 	}
 
 }

--- a/External/Plugins/ProjectManager/PluginMain.cs
+++ b/External/Plugins/ProjectManager/PluginMain.cs
@@ -538,6 +538,20 @@ namespace ProjectManager
         private bool HandleKeyEvent(KeyEvent ke)
         {
             if (activeProject == null) return false;
+
+            if (ke.Value == PluginBase.MainForm.GetShortcutItemKeys("ProjectMenu.ConfigurationSelector"))
+            {
+                pluginUI.menus.ConfigurationSelector.Focus();
+            }
+            else if (ke.Value == PluginBase.MainForm.GetShortcutItemKeys("ProjectMenu.ConfigurationSelectorToggle"))
+            {
+                pluginUI.menus.ToggleDebugRelease();
+            }
+            else if (ke.Value == PluginBase.MainForm.GetShortcutItemKeys("ProjectMenu.TargetBuildSelector"))
+            {
+                pluginUI.menus.TargetBuildSelector.Focus();
+            }
+
             // Handle tree-level simple shortcuts like copy/paste/del
             else if (Tree.Focused && !pluginUI.IsEditingLabel && ke != null)
             {

--- a/External/Plugins/ProjectManager/PluginUI.cs
+++ b/External/Plugins/ProjectManager/PluginUI.cs
@@ -21,7 +21,7 @@ namespace ProjectManager
 {
     public class PluginUI : DockPanelControl
     {
-        FDMenus menus;
+        public FDMenus menus;
         TreeBar treeBar;
         Project project;
         PluginMain plugin;

--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -419,6 +419,7 @@ namespace FlashDevelop.Dialogs
             ShortcutDialog shortcutDialog = new ShortcutDialog();
             shortcutDialog.CenterToParent();
             shortcutDialog.Show(Globals.MainForm);
+            shortcutDialog.filterTextBox.Focus();
         }
 
         #endregion


### PR DESCRIPTION
- added shortcuts for focus of the debug / release and target selection combo boxes
- added a shortcut to toggle release / debug mode
- added Ctrl+F for the outline panel (#326)
- on opening the shortcut dialog, the filterTextBox has now focus
- added MemberItem#ToString()
