### PR TITLE
Fixes: Implementation is incorrect in this case: addChild(foo);

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -612,7 +612,9 @@ namespace ASCompletion.Completion
             ASResult exprAtCursor = ASComplete.GetExpressionType(Sci, Sci.WordEndPosition(currentPos, true));
             if (exprAtCursor == null || exprAtCursor.InClass == null || found.inClass.QualifiedName.Equals(exprAtCursor.RelClass.QualifiedName))
                 exprAtCursor = null;
-            ASResult exprLeft = ASComplete.GetExpressionType(Sci, Sci.WordStartPosition(currentPos, true) - 1);
+            ASResult exprLeft = null;
+            int curWordStartPos = Sci.WordStartPosition(currentPos, true);
+            if ((char)Sci.CharAt(curWordStartPos - 1) == '.') exprLeft = ASComplete.GetExpressionType(Sci, curWordStartPos - 1);
             if (exprLeft != null && exprLeft.Type == null) exprLeft = null;
             if (exprLeft != null)
             {


### PR DESCRIPTION
Pressing Ctrl+Shift+1 when the cursor is on foo only offers to generate a public function; I guess because addChild is declared in another class.
