### PR TITLE
Rewrite of the #204 fix to support multiline metadata

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -3722,7 +3722,7 @@ namespace ASCompletion.Completion
                 c = next;
                 next = (char)sci.CharAt(i);
 
-                if (c == ')')
+                if (c == ')' || c == '}' || c == ';')
                     return false;
                 if (c == '(')
                     openingBracket = true;


### PR DESCRIPTION
Now working with metadata like this:

``` haxe
@:allow(path.Type,
        path.Type2)
```

Didn't work previously because only the current line was examined.
