### PR TITLE
Missing CSLB on in Haxe typedef snippet

### DIFF
--- a/FlashDevelop/Bin/Debug/Snippets/haxe/typedef.fds
+++ b/FlashDevelop/Bin/Debug/Snippets/haxe/typedef.fds
@@ -1,3 +1,3 @@
-typedef $(EntryPoint) = {
+typedef $(EntryPoint) = $(CSLB){
 	
 }


### PR DESCRIPTION
There still is an extra space after `=` with newlines, similar to the issue with `package ;` in the templates... Perhaps there needs to be a way to only include a character when a `$()`-condition is true.
