### PR TITLE
Try-catch GetDirectories() call in PathExplorer#ExploreFolder()

### DIFF
--- a/External/Plugins/ASCompletion/Model/PathExplorer.cs
+++ b/External/Plugins/ASCompletion/Model/PathExplorer.cs
@@ -380,15 +380,19 @@ namespace ASCompletion.Model
             }
             catch { }
 
-            // explore subfolders
-            string[] dirs = Directory.GetDirectories(path);
-            foreach (string dir in dirs)
+            try
             {
-                if (!explored.Contains(dir) 
-                    && (File.GetAttributes(dir) & FileAttributes.Hidden) == 0
-                    && !IgnoreDirectory(dir))
-                    ExploreFolder(dir, masks);
+                // explore subfolders
+                string[] dirs = Directory.GetDirectories(path);
+                foreach (string dir in dirs)
+                {
+                    if (!explored.Contains(dir) 
+                        && (File.GetAttributes(dir) & FileAttributes.Hidden) == 0
+                        && !IgnoreDirectory(dir))
+                        ExploreFolder(dir, masks);
+                }
             }
+            catch { }
 		}
 
         private bool IgnoreDirectory(string dir)


### PR DESCRIPTION
Reported [here](http://stackoverflow.com/questions/26084448/haxe-crashes-flashdevelop-permissions-error), and I also just ran into it myself (with a different path) while working with SourceTree.
