### PR TITLE
Fixes Null References Error from ASCompletion.Context.ASContext->GetDeclarationAtLine()

### DIFF
--- a/External/Plugins/ASCompletion/Context/ASContext.cs
+++ b/External/Plugins/ASCompletion/Context/ASContext.cs
@@ -1070,7 +1070,7 @@ namespace ASCompletion.Context
         {
             ASResult result = new ASResult();
             result.InClass = ClassModel.VoidClass;
-
+            if (cFile == null) return result;
             // current class
             foreach (ClassModel aClass in cFile.Classes)
             {


### PR DESCRIPTION
Fixes Null References Error from ASCompletion.Context.ASContext->GetDeclarationAtLine() if ASCompletion.Context.ASContext->cFile == null

Before fix:
![](http://service.crazypanda.ru/v/clip2net/d/0/qNvq0bsfkN.png)

After fix:
![](http://service.crazypanda.ru/v/clip2net/Z/v/1XygGTzfg1.png)

test: https://github.com/SlavaRa/flashdevelop/blob/tests/tests/External/Plugins/ASCompletionTest/Context/ASContextTest.cs#L164-171
