### PR TITLE
Hide AIR properties button / menu item instead of disabling them

### DIFF
--- a/External/Plugins/AirProperties/PluginMain.cs
+++ b/External/Plugins/AirProperties/PluginMain.cs
@@ -213,7 +213,7 @@ namespace AirProperties
                 ProjectManager.Projects.Project project = (ProjectManager.Projects.Project)PluginBase.CurrentProject;
                 pluginActive = project.MovieOptions.Platform.StartsWith("AIR");
             }
-            this.pluginMenuItem.Enabled = this.pmMenuButton.Enabled = pluginActive;
+            this.pluginMenuItem.Visible = this.pmMenuButton.Visible = pluginActive;
         }
                
         /// <summary>


### PR DESCRIPTION
As far as I'm concerned, you don't need to know these exist if you're not currently in an AIR project - can't do anything with them anyway, it's just wasted UI space. :)
