### PR TITLE
Shorten the shortcuts for Code Generator and Code Formatter

### DIFF
--- a/External/Plugins/CodeFormatter/PluginMain.cs
+++ b/External/Plugins/CodeFormatter/PluginMain.cs
@@ -175,7 +175,7 @@ namespace CodeFormatter
 		public void CreateMainMenuItem()
 		{
             String label = TextHelper.GetString("Label.CodeFormatter");
-            this.mainMenuItem = new ToolStripMenuItem(label, null, new EventHandler(this.Format), Keys.Control | Keys.Shift | Keys.D2);
+            this.mainMenuItem = new ToolStripMenuItem(label, null, new EventHandler(this.Format), Keys.Control | Keys.D2);
             PluginBase.MainForm.RegisterShortcutItem("RefactorMenu.CodeFormatter", this.mainMenuItem);
         }
         private void AttachMainMenuItem(ToolStripMenuItem mainMenu)

--- a/External/Plugins/CodeRefactor/Controls/RefactorMenu.cs
+++ b/External/Plugins/CodeRefactor/Controls/RefactorMenu.cs
@@ -32,7 +32,7 @@ namespace CodeRefactor.Controls
                 this.DropDownItems.Add(this.surroundMenu);
             }
             this.DropDownItems.Add(new ToolStripSeparator());
-            this.generatorMenuItem = new ToolStripMenuItem(TextHelper.GetString("Label.InvokeCodeGenerator"), null, null, createSurroundMenu ? Keys.Control | Keys.Shift | Keys.D1 : Keys.None);
+            this.generatorMenuItem = new ToolStripMenuItem(TextHelper.GetString("Label.InvokeCodeGenerator"), null, null, createSurroundMenu ? Keys.Control | Keys.D1 : Keys.None);
             this.DropDownItems.Add(this.generatorMenuItem);
             this.DropDownItems.Add(new ToolStripSeparator());
             this.organizeMenuItem = this.DropDownItems.Add(TextHelper.GetString("Label.OrganizeImports"), null) as ToolStripMenuItem;


### PR DESCRIPTION
Especially the Code Generator is very useful, but the shortcut for it is annoyingly long (3 keys). With the Ctrl+Number shortcuts being free now, that can be solved. :)
