### PR TITLE
Explicitly disable items in context surround menu

### DIFF
--- a/External/Plugins/CodeRefactor/Controls/SurroundMenu.cs
+++ b/External/Plugins/CodeRefactor/Controls/SurroundMenu.cs
@@ -10,6 +10,17 @@ namespace CodeRefactor.Controls
 {
     public class SurroundMenu : ToolStripMenuItem
     {
+        override public bool Enabled
+        {
+            set
+            {
+                base.Enabled = value;
+                // explicitly en- / disable drop down items, the menu can still open
+                foreach (ToolStripDropDownItem dropDownItem in DropDownItems)
+                    dropDownItem.Enabled = value;    
+            }
+        }
+
         private List<String> items;
 
         public SurroundMenu()


### PR DESCRIPTION
Apparently you can still open the menu if you open another dropdown menu first:

![](http://i.imgur.com/i9Opp9C.gif)

.NET / windows forms bug?
