### PR TITLE
Synchronize ScintillaMenu.xml with MainMenu.xml

### DIFF
--- a/FlashDevelop/Bin/Debug/Settings/ScintillaMenu.xml
+++ b/FlashDevelop/Bin/Debug/Settings/ScintillaMenu.xml
@@ -1,52 +1,59 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <scintillamenu>
 	<menu label="Label.Edit" name="EditMenu">
-		<button label="Label.CutLine" click="ScintillaCommand" tag="LineCut" />
-		<button label="Label.CopyLine" click="ScintillaCommand" tag="LineCopy" />
-		<button label="Label.DeleteLine" click="ScintillaCommand" tag="LineDelete" />
-		<button label="Label.MoveLineUp" click="ScintillaCommand" tag="MoveLineUp" />
-		<button label="Label.MoveLineDown" click="ScintillaCommand" tag="MoveLineDown" />
-		<button label="Label.TransposeLines" click="ScintillaCommand" tag="LineTranspose" />
-		<button label="Label.DuplicateSelection" click="ScintillaCommand" tag="SelectionDuplicate" />
-		<button label="Label.SortLineGroups" click="SortLineGroups" flags="Enable:Enable:HasSelection" />
-		<button label="Label.SortLines" click="SortLines" flags="Enable:Enable:HasSelection" />
+		<button label="Label.CutLine" click="ScintillaCommand" tag="LineCut" shortcut="Control|Shift|X" flags="Enable:IsEditable" />
+		<button label="Label.CopyLine" click="ScintillaCommand" tag="LineCopy" shortcut="Control|Shift|C" flags="Enable:IsEditable" />
+		<button label="Label.DeleteLine" click="ScintillaCommand" tag="LineDelete" shortcut="Control|Shift|D" flags="Enable:IsEditable" />
+		<button label="Label.MoveLineUp" click="ScintillaCommand" tag="MoveLineUp" shortcut="Control|Alt|Up" flags="Enable:IsEditable" />
+		<button label="Label.MoveLineDown" click="ScintillaCommand" tag="MoveLineDown" shortcut="Control|Alt|Down" flags="Enable:IsEditable" />
+		<button label="Label.TransposeLines" click="ScintillaCommand" tag="LineTranspose" shortcut="Control|T" flags="Enable:IsEditable" />
+		<button label="Label.DuplicateSelection" click="ScintillaCommand" tag="SelectionDuplicate" shortcut="Control|D" flags="Enable:IsEditable" />
+		<button label="Label.SortLineGroups" click="SortLineGroups" flags="Enable:IsEditable|Enable:HasSelection" />
+		<button label="Label.SortLines" click="SortLines" flags="Enable:IsEditable|Enable:HasSelection" />
 		<separator />
-		<button label="Label.ToUppercase" click="ScintillaCommand" tag="UpperCase" image="458" flags="Enable:HasSelection" />
-		<button label="Label.ToLowercase" click="ScintillaCommand" tag="LowerCase" image="446" flags="Enable:HasSelection" />
+		<button label="Label.ToUppercase" click="ScintillaCommand" tag="UpperCase" shortcut="Control|U" image="458" flags="Enable:IsEditable|HasSelection" />
+		<button label="Label.ToLowercase" click="ScintillaCommand" tag="LowerCase" shortcut="Control|L" image="446" flags="Enable:IsEditable|HasSelection" />
 		<separator />
-		<button label="Label.LineComment" click="ToggleLineComment" />
-		<button label="Label.BlockComment" click="ToggleBlockComment" />
+		<button label="Label.LineComment" click="ToggleLineComment" shortcut="Control|Q" flags="Enable:IsEditable" />
+		<button label="Label.BlockComment" click="ToggleBlockComment" shortcut="Control|Shift|Q" flags="Enable:IsEditable" />
 		<separator />
-		<button label="Label.SaveAsTemplate" click="SaveAsTemplate" flags="Enable:HasSelection" />
-		<button label="Label.SaveAsSnippet" click="SaveAsSnippet" flags="Enable:HasSelection" />
+		<button label="Label.SaveAsTemplate" click="SaveAsTemplate" flags="Enable:IsEditable|Enable:HasSelection" />
+		<button label="Label.SaveAsSnippet" click="SaveAsSnippet" flags="Enable:IsEditable|Enable:HasSelection" />
 	</menu>
 	<menu label="Label.Insert" name="InsertMenu">
-		<button label="Label.FromFile" click="InsertFile" tag="$(OpenFile)" />
-		<button label="Label.FileDetails" click="InsertFileDetails" flags="Enable:!IsUntitled" />
-		<button label="Label.Timestamp" click="InsertTimestamp" tag="g" />
+		<button label="Label.FromFile" click="InsertFile" tag="$(OpenFile)" flags="Enable:IsEditable" />
+		<button label="Label.FileDetails" click="InsertFileDetails" flags="Enable:IsEditable|!IsUntitled" />
+		<button label="Label.Timestamp" click="InsertTimestamp" tag="g" flags="Enable:IsEditable" />
 		<separator />
-		<button label="Label.Snippet" click="InsertSnippet" tag="null" />
-		<button label="Label.Color" click="InsertColor" />
-		<button label="Label.GUID" click="InsertGUID" />
+		<button label="Label.Snippet" click="InsertSnippet" shortcut="Control|B" tag="null" flags="Enable:IsEditable" />
+		<button label="Label.Color" click="InsertColor" shortcut="Control|Shift|K" flags="Enable:IsEditable" />
+		<button label="Label.GUID" click="InsertGUID" shortcut="Control|Shift|I" flags="Enable:IsEditable" />
 		<separator />
-		<button label="Label.Hash" click="InsertHash" />
+		<button label="Label.Hash" click="InsertHash" shortcut="Control|Shift|H" flags="Enable:IsEditable" />
 	</menu>
 	<menu label="Label.Search" name="SearchMenu">
-		<button label="Label.GotoMatchingBrace" click="GoToMatchingBrace" image="67" />
-		<button label="Label.GotoPositionOrLine" click="GoTo" image="67" />
+		<button label="Label.QuickFind" click="QuickFind" shortcut="Control|F" image="299" />
+		<button label="Label.QuickFindNext" click="FindNext" shortcut="F3" image="484|9|3|-4" flags="Enable:IsEditable" />
+		<button label="Label.QuickFindPrevious" click="FindPrevious" shortcut="Shift|F3" image="484|1|3|-4" flags="Enable:IsEditable" />
 		<separator />
-		<button label="Label.ToggleBookmark" click="ToggleBookmark" image="402" flags="Enable:IsEditable" />
-		<button label="Label.NextBookmark" click="NextBookmark" image="402|9|3|3" flags="Enable:IsEditable|HasBookmarks" />
-		<button label="Label.PrevBookmark" click="PrevBookmark" image="402|1|-3|3" flags="Enable:IsEditable|HasBookmarks" />
+		<button label="Label.FindAndReplace" click="FindAndReplace" shortcut="Control|H" image="484" flags="Enable:IsEditable" />
+		<button label="Label.FindAndReplaceInFiles" click="FindAndReplaceInFiles" shortcut="Control|I" image="209" />
+		<separator />
+		<button label="Label.GotoPositionOrLine" click="GoTo" shortcut="Control|G" image="67" flags="Enable:IsEditable" />
+		<button label="Label.GotoMatchingBrace" click="GoToMatchingBrace" shortcut="Control|M" image="67" flags="Enable:IsEditable" />
+		<separator />
+		<button label="Label.ToggleBookmark" click="ToggleBookmark" shortcut="Control|F2" image="402" flags="Enable:IsEditable" />
+		<button label="Label.NextBookmark" click="NextBookmark" shortcut="F2" image="402|9|3|3" flags="Enable:IsEditable|HasBookmarks" />
+		<button label="Label.PrevBookmark" click="PrevBookmark" shortcut="Shift|F2" image="402|1|-3|3" flags="Enable:IsEditable|HasBookmarks" />
 		<button label="Label.ClearBookmarks" click="ClearBookmarks" image="402|4|4|4" flags="Enable:IsEditable|HasBookmarks" />
 	</menu>
 	<separator />
-	<button label="Label.Undo" click="ScintillaCommand" tag="Undo" image="73" flags="Enable:CanUndo" />
-	<button label="Label.Redo" click="ScintillaCommand" tag="Redo" image="65" flags="Enable:CanRedo" />
+	<button label="Label.Undo" click="ScintillaCommand" tag="Undo" shortcut="Control|Z" image="73" flags="Enable:IsEditable|CanUndo" />
+	<button label="Label.Redo" click="ScintillaCommand" tag="Redo" shortcut="Control|Y" image="65" flags="Enable:IsEditable|CanRedo"  />
 	<separator />
-	<button label="Label.Cut" click="ScintillaCommand" tag="CutAllowLine" image="158" />
-	<button label="Label.Copy" click="ScintillaCommand" tag="CopyAllowLineEx" image="278" />
-	<button label="Label.Paste" click="SmartPaste" image="283" flags="Enable:CanPaste" />
+	<button label="Label.Cut" click="ScintillaCommand" tag="CutAllowLine" shortcut="Control|X" image="158" flags="Enable:IsEditable" />
+	<button label="Label.Copy" click="ScintillaCommand" tag="CopyAllowLineEx" shortcut="Control|C" image="278" flags="Enable:IsEditable" />
+	<button label="Label.Paste" click="ScintillaCommand" tag="Paste" shortcut="Control|V" image="283" flags="Enable:IsEditable|CanPaste" />
 	<separator />
-	<button label="Label.SelectAll" click="ScintillaCommand" tag="SelectAll" />
+	<button label="Label.SelectAll" click="ScintillaCommand" tag="SelectAll" shortcut="Control|A" flags="Enable:IsEditable" />
 </scintillamenu>


### PR DESCRIPTION
...seems like this hasn't happened in quite a while, most items didn't have any flags and none had shortcuts.

This also adds some new items to the search context menu.

Guess there isn't a way to avoid the redundancy here? Maybe something like `<import menu="Label.Edit />` could be added, since this a custom xml format?
