### PR TITLE
FD Settings: rename "Controls" to "Completion List"

### DIFF
--- a/FlashDevelop/Settings/Accessors.cs
+++ b/FlashDevelop/Settings/Accessors.cs
@@ -774,11 +774,11 @@ namespace FlashDevelop.Settings
 
         #endregion
 
-        #region Controls
+        #region Completion List
 
         [DefaultValue(500)]
         [DisplayName("Hover Delay")]
-        [LocalizedCategory("FlashDevelop.Category.Controls")]
+        [LocalizedCategory("FlashDevelop.Category.CompletionList")]
         [LocalizedDescription("FlashDevelop.Description.HoverDelay")]
         public Int32 HoverDelay
         {
@@ -795,7 +795,7 @@ namespace FlashDevelop.Settings
 
         [DefaultValue(100)]
         [DisplayName("Display Delay")]
-        [LocalizedCategory("FlashDevelop.Category.Controls")]
+        [LocalizedCategory("FlashDevelop.Category.CompletionList")]
         [LocalizedDescription("FlashDevelop.Description.DisplayDelay")]
         public Int32 DisplayDelay
         {
@@ -805,7 +805,7 @@ namespace FlashDevelop.Settings
 
         [DefaultValue(false)]
         [DisplayName("Show Details")]
-        [LocalizedCategory("FlashDevelop.Category.Controls")]
+        [LocalizedCategory("FlashDevelop.Category.CompletionList")]
         [LocalizedDescription("FlashDevelop.Description.ShowDetails")]
         public Boolean ShowDetails
         {
@@ -815,7 +815,7 @@ namespace FlashDevelop.Settings
 
         [DefaultValue(true)]
         [DisplayName("Auto Filter List")]
-        [LocalizedCategory("FlashDevelop.Category.Controls")]
+        [LocalizedCategory("FlashDevelop.Category.CompletionList")]
         [LocalizedDescription("FlashDevelop.Description.AutoFilterList")]
         public Boolean AutoFilterList
         {
@@ -825,7 +825,7 @@ namespace FlashDevelop.Settings
 
         [DefaultValue(true)]
         [DisplayName("Enable AutoHide")]
-        [LocalizedCategory("FlashDevelop.Category.Controls")]
+        [LocalizedCategory("FlashDevelop.Category.CompletionList")]
         [LocalizedDescription("FlashDevelop.Description.EnableAutoHide")]
         public Boolean EnableAutoHide
         {
@@ -835,7 +835,7 @@ namespace FlashDevelop.Settings
 
         [DefaultValue(false)]
         [DisplayName("Wrap List")]
-        [LocalizedCategory("FlashDevelop.Category.Controls")]
+        [LocalizedCategory("FlashDevelop.Category.CompletionList")]
         [LocalizedDescription("FlashDevelop.Description.WrapList")]
         public Boolean WrapList
         {
@@ -845,7 +845,7 @@ namespace FlashDevelop.Settings
 
         [DefaultValue(false)]
         [DisplayName("Disable Smart Matching")]
-        [LocalizedCategory("FlashDevelop.Category.Controls")]
+        [LocalizedCategory("FlashDevelop.Category.CompletionList")]
         [LocalizedDescription("FlashDevelop.Description.DisableSmartMatch")]
         public Boolean DisableSmartMatch
         {
@@ -855,7 +855,7 @@ namespace FlashDevelop.Settings
 
         [DefaultValue("")]
         [DisplayName("Completion List Insertion Triggers")]
-        [LocalizedCategory("FlashDevelop.Category.Controls")]
+        [LocalizedCategory("FlashDevelop.Category.CompletionList")]
         [LocalizedDescription("FlashDevelop.Description.InsertionTriggers")]
         public String InsertionTriggers
         {

--- a/PluginCore/PluginCore/Resources/de_DE.resX
+++ b/PluginCore/PluginCore/Resources/de_DE.resX
@@ -492,8 +492,8 @@ Ansonsten kann Adobe Flash Professional auch zum Überprüfen der Syntax verwend
   <data name="FlashConnect.Info.InvalidMessage" xml:space="preserve">
     <value>Die erhaltene Xml-Nachricht war ungültig.</value>
   </data>
-  <data name="FlashDevelop.Category.Controls" xml:space="preserve">
-    <value>Steuerungen</value>
+  <data name="FlashDevelop.Category.CompletionList" xml:space="preserve">
+    <value>Codevervollständigung</value>
   </data>
   <data name="FlashDevelop.Category.Display" xml:space="preserve">
     <value>Anzeige</value>
@@ -691,7 +691,7 @@ Ansonsten kann Adobe Flash Professional auch zum Überprüfen der Syntax verwend
     <value>Letzter Fensterstatus (maximiert, minimiert, frei schwebend)</value>
   </data>
   <data name="FlashDevelop.Description.WrapList" xml:space="preserve">
-    <value>Überlauf an beiden Enden der Vervollständigungsliste.</value>
+    <value>Überlauf an beiden Enden der Vervollständigungsliste mit der nach oben / nach unten Taste.</value>
   </data>
   <data name="FlashDevelop.Description.WrapText" xml:space="preserve">
     <value>Bricht lange Zeilen im Editor um (nicht im zugrundeliegenden Dokument)</value>

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -474,8 +474,8 @@ Alternatively, Adobe Flash Professional can also be used for syntax checking - p
   <data name="FlashConnect.Info.InvalidMessage" xml:space="preserve">
     <value>The received xml message was invalid.</value>
   </data>
-  <data name="FlashDevelop.Category.Controls" xml:space="preserve">
-    <value>Controls</value>
+  <data name="FlashDevelop.Category.CompletionList" xml:space="preserve">
+    <value>Completion List</value>
   </data>
   <data name="FlashDevelop.Category.Display" xml:space="preserve">
     <value>Display</value>
@@ -673,7 +673,7 @@ Alternatively, Adobe Flash Professional can also be used for syntax checking - p
     <value>Last known window state of the program.</value>
   </data>
   <data name="FlashDevelop.Description.WrapList" xml:space="preserve">
-    <value>When navigating using keyboard.</value>
+    <value>When navigating using the up and down keys.</value>
   </data>
   <data name="FlashDevelop.Description.WrapText" xml:space="preserve">
     <value>Wraps the texts in the editor.</value>

--- a/PluginCore/PluginCore/Resources/eu_ES.resX
+++ b/PluginCore/PluginCore/Resources/eu_ES.resX
@@ -474,8 +474,9 @@ Alternatiba gisa, Adobe Flash Professional ere sintaxi egiaztapenerako erabil da
   <data name="FlashConnect.Info.InvalidMessage" xml:space="preserve">
     <value>Jasotako xml mezua baliogabea da.</value>
   </data>
-  <data name="FlashDevelop.Category.Controls" xml:space="preserve">
-    <value>Kontrolak</value>
+  <data name="FlashDevelop.Category.CompletionList" xml:space="preserve">
+    <value>Completion List</value>
+    <comment>Modified after 4.7.0</comment>
   </data>
   <data name="FlashDevelop.Category.Display" xml:space="preserve">
     <value>Bistaratu</value>
@@ -674,6 +675,7 @@ Alternatiba gisa, Adobe Flash Professional ere sintaxi egiaztapenerako erabil da
   </data>
   <data name="FlashDevelop.Description.WrapList" xml:space="preserve">
     <value>Nabigatzerakoan teklatua erabili.</value>
+    <comment>Modified after 4.7.0</comment>
   </data>
   <data name="FlashDevelop.Description.WrapText" xml:space="preserve">
     <value>Editorean testua biltzen da.</value>

--- a/PluginCore/PluginCore/Resources/ja_JP.resX
+++ b/PluginCore/PluginCore/Resources/ja_JP.resX
@@ -475,8 +475,9 @@
   <data name="FlashConnect.Info.InvalidMessage" xml:space="preserve">
     <value>XML メッセージの受信が無効です。</value>
   </data>
-  <data name="FlashDevelop.Category.Controls" xml:space="preserve">
-    <value>Controls | 操作</value>
+  <data name="FlashDevelop.Category.CompletionList" xml:space="preserve">
+    <value>Completion List</value>
+    <comment>Modified after 4.7.0</comment>
   </data>
   <data name="FlashDevelop.Category.Display" xml:space="preserve">
     <value>Display | 表示</value>
@@ -675,6 +676,7 @@
   </data>
   <data name="FlashDevelop.Description.WrapList" xml:space="preserve">
     <value>補完リストをキーボードで操作したときにループさせます。</value>
+    <comment>Modified after 4.7.0</comment>
   </data>
   <data name="FlashDevelop.Description.WrapText" xml:space="preserve">
     <value>エディターのテキストを右端で折り返します。</value>

--- a/PluginCore/PluginCore/Resources/zh_CN.resx
+++ b/PluginCore/PluginCore/Resources/zh_CN.resx
@@ -474,8 +474,9 @@
   <data name="FlashConnect.Info.InvalidMessage" xml:space="preserve">
     <value>收到的 XML 消息是无效的.</value>
   </data>
-  <data name="FlashDevelop.Category.Controls" xml:space="preserve">
-    <value>控制</value>
+  <data name="FlashDevelop.Category.CompletionList" xml:space="preserve">
+    <value>Completion List</value>
+    <comment>Modified after 4.7.0</comment>
   </data>
   <data name="FlashDevelop.Category.Display" xml:space="preserve">
     <value>显示</value>
@@ -674,6 +675,7 @@
   </data>
   <data name="FlashDevelop.Description.WrapList" xml:space="preserve">
     <value>使用键盘导航列表.</value>
+    <comment>Modified after 4.7.0</comment>
   </data>
   <data name="FlashDevelop.Description.WrapText" xml:space="preserve">
     <value>在文本编辑器中自动换行.</value>


### PR DESCRIPTION
"Controls" seemed misleading / inconsistent. Actually had to look up what "Wrap List" does in the code since it was missing context.
