### PR TITLE
Fixing broken code that lead to no check for breakpoint condition.

### DIFF
--- a/External/Plugins/FlashDebugger/Debugger/BreakPointManager.cs
+++ b/External/Plugins/FlashDebugger/Debugger/BreakPointManager.cs
@@ -133,6 +133,11 @@ namespace FlashDebugger
 
 		public Boolean ShouldBreak(SourceFile file, int line)
 		{
+			return ShouldBreak(file, line, null);
+		}
+
+		public Boolean ShouldBreak(SourceFile file, int line, Frame frame)
+		{
 			String localPath = PluginMain.debugManager.GetLocalPath(file);
 			if (localPath == null)
 			{
@@ -158,7 +163,12 @@ namespace FlashDebugger
 				{
                     try
                     {
-                        var ctx = new ExpressionContext(PluginMain.debugManager.FlashInterface.Session, PluginMain.debugManager.FlashInterface.GetFrames()[PluginMain.debugManager.CurrentFrame]);
+						if (frame == null)
+						{
+							// take currently active worker and frame
+							frame = PluginMain.debugManager.FlashInterface.GetFrames()[PluginMain.debugManager.CurrentFrame];
+						}
+                        var ctx = new ExpressionContext(PluginMain.debugManager.FlashInterface.Session, frame);
                         var val = bpInfo.ParsedExpression.evaluate(ctx);
                         if (val is java.lang.Boolean)
                         {

--- a/External/Plugins/FlashDebugger/Debugger/DebuggerManager.cs
+++ b/External/Plugins/FlashDebugger/Debugger/DebuggerManager.cs
@@ -403,16 +403,7 @@ namespace FlashDebugger
         /// </summary>
         private void flashInterface_BreakpointEvent(object sender)
 		{
-			Location loc = FlashInterface.getCurrentLocation();
-			// todo checking for loc here, but should handle swfloaded case and wait with breakpoint event
-			if (loc != null && PluginMain.breakPointManager.ShouldBreak(loc.getFile(), loc.getLine()))
-			{
-				UpdateUI(DebuggerState.BreakHalt);
-			}
-			else
-			{
-				FlashInterface.StepResume();
-			}
+			UpdateUI(DebuggerState.BreakHalt);
 		}
 
         /// <summary>

--- a/External/Plugins/FlashDebugger/Debugger/ExpressionContext.cs
+++ b/External/Plugins/FlashDebugger/Debugger/ExpressionContext.cs
@@ -189,7 +189,7 @@ namespace FlashDebugger
 
         public int getIsolateId()
         {
-			if (contextVal == null) return 1;
+			if (contextVal == null) return frame.getIsolateId();
             return contextVal.getIsolateId();
         }
     }


### PR DESCRIPTION
- Extending ShouldBreak with frame, so expression can be evaluated for any isolate.
- Moved call to ShouldBreak out of DebuggerManager to FlashInterface.
- Small fix to ExpressionContext to always return proper isolate id.
- Better check on checking suspend reason for main worker and use ShouldBreak to fire BreakpointEvent.
- Moved isolate suspend() call to the debugger worker thread.
- Handle all suspend reasons of workers BreakEvent
