### PR TITLE
Respect IS_DYNAMIC VariableAttribute flag when building variable path.

### DIFF
--- a/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
+++ b/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
@@ -214,8 +214,18 @@ namespace FlashDebugger.Controls
 			if (node is DataNode)
 			{
 				DataNode datanode = node as DataNode;
-				if (ret != "" && datanode.Variable != null) ret += ".";
-				if (datanode.Variable != null) ret += datanode.Variable.getName();
+				if (datanode.Variable != null)
+				{
+					if (ret == "") return datanode.Variable.getName();
+					if ((datanode.Variable.getAttributes() & 0x00020000) == 0x00020000) //VariableAttribute_.IS_DYNAMIC
+					{
+						ret += "[\"" + datanode.Variable.getName() + "\"]";
+					}
+					else
+					{
+						ret += "." + datanode.Variable.getName();
+					}
+				}
 			}
 			return ret;
 		}


### PR DESCRIPTION
- When adding array elements to Watch, the variable path was incorrect, because array element index was delimited with "." instead of [ ]

Fixes #406
