### PR TITLE
XML completion bug fix

### DIFF
--- a/External/Plugins/XMLCompletion/XMLComplete.cs
+++ b/External/Plugins/XMLCompletion/XMLComplete.cs
@@ -345,6 +345,7 @@ namespace XMLCompletion
                     {
                         if ((position < 2) || ((Char)sci.CharAt(position-2) != '<')) return;
                         ctag = new XMLContextTag();
+                        ctag.Position = position - 2;
                         ctag.Closing = true;
                     }
                     else 


### PR DESCRIPTION
Set XMLContextTag position on closing tag char. Fixes getting its parent context tag.
