### PR TITLE
Some ProjectManager "Synchronize" feature changes

### DIFF
--- a/External/Plugins/ProjectManager/Controls/TreeBar.cs
+++ b/External/Plugins/ProjectManager/Controls/TreeBar.cs
@@ -11,11 +11,11 @@ using PluginCore;
 
 namespace ProjectManager.Controls
 {
-	/// <summary>
-	/// Tree view top toolbar
-	/// </summary>
-	public class TreeBar : ToolStrip
-	{
+    /// <summary>
+    /// Tree view top toolbar
+    /// </summary>
+    public class TreeBar : ToolStrip
+    {
         public ToolStripButton ShowHidden;
         public ToolStripButton RefreshSelected;
         public ToolStripButton ProjectProperties;
@@ -52,9 +52,10 @@ namespace ProjectManager.Controls
             Synchronize = new ToolStripButton(Icons.SyncToFile.Img);
             Synchronize.ToolTipText = TextHelper.GetString("ToolTip.Synchronize");
             Synchronize.Padding = new Padding(0);
+            PluginBase.MainForm.RegisterShortcutItem("ProjectTree.LocateActiveFile", Keys.Shift | Keys.Alt | Keys.L);
 
             SynchronizeMain = new ToolStripButton(Icons.ActionScriptCompile.Img);
-            SynchronizeMain.ToolTipText = TextHelper.GetString("ToolTip.Synchronize");
+            SynchronizeMain.ToolTipText = TextHelper.GetString("ToolTip.SynchronizeMain");
             SynchronizeMain.Padding = new Padding(0);
 
             ProjectTypes = new ToolStripButton(Icons.AllClasses.Img);
@@ -82,6 +83,6 @@ namespace ProjectManager.Controls
                 ProjectProperties.Image = value ? Icons.OptionsWithIssues.Img : Icons.Options.Img;
             }
         }
-	}    
+    }    
 
 }

--- a/External/Plugins/ProjectManager/PluginMain.cs
+++ b/External/Plugins/ProjectManager/PluginMain.cs
@@ -64,8 +64,8 @@ namespace ProjectManager
         public const string BeforeSave = "ProjectManager.BeforeSave";
     }
 
-	public class PluginMain : IPlugin
-	{
+    public class PluginMain : IPlugin
+    {
         const string pluginName = "ProjectManager";
         const string pluginAuth = "FlashDevelop Team";
         const string pluginGuid = "30018864-fadd-1122-b2a5-779832cbbf23";
@@ -165,13 +165,13 @@ namespace ProjectManager
         public string Help { get { return pluginHelp; } }
         [Browsable(false)] // explicit implementation so we can reuse the "Settings" var name
         object IPlugin.Settings { get { return Settings; } }
-		
-		#endregion
-		
-		#region Initialize/Dispose
-		
-		public void Initialize()
-		{
+        
+        #endregion
+        
+        #region Initialize/Dispose
+        
+        public void Initialize()
+        {
             LoadSettings();
             pluginImage = MainForm.FindImage("100");
             pluginDesc = TextHelper.GetString("Info.Description");
@@ -336,9 +336,9 @@ namespace ProjectManager
             if (e.KeyCode == Keys.Enter) // leave target build input field to apply
                 PluginBase.MainForm.CurrentDocument.Activate();
         }
-		
-		public void Dispose()
-		{
+        
+        public void Dispose()
+        {
             // we have to fiddle this a little since we only get once change to save our settings!
             // (further saves will be ignored by FD design)
             Project project = activeProject; 
@@ -347,14 +347,14 @@ namespace ProjectManager
             Settings.LastProject = lastProject;
             FlexCompilerShell.Cleanup(); // in case it was used
             SaveSettings();
-		}
-		
+        }
+        
         #endregion
 
         #region Plugin Events
 
         public void HandleEvent(Object sender, NotifyEvent e, HandlingPriority priority)
-		{
+        {
             TextEvent te = e as TextEvent;
             DataEvent de = e as DataEvent;
             Project project;
@@ -433,6 +433,7 @@ namespace ProjectManager
 
                 case EventType.FileSwitch:
                     TabColors.UpdateTabColors(Settings);
+                    if (Settings.TrackActiveDocument) TreeSyncToCurrentFile();
                     break;
 
                 case EventType.ProcessStart:
@@ -570,6 +571,10 @@ namespace ProjectManager
             {
                 pluginUI.menus.TargetBuildSelector.Focus();
             }
+            else if (ke.Value == PluginBase.MainForm.GetShortcutItemKeys("ProjectTree.LocateActiveFile"))
+            {
+                TreeSyncToCurrentFile();
+            }
 
             // Handle tree-level simple shortcuts like copy/paste/del
             else if (Tree.Focused && !pluginUI.IsEditingLabel && ke != null)
@@ -585,8 +590,8 @@ namespace ProjectManager
             else return false;
             return true;
         }
-		
-		#endregion
+        
+        #endregion
 
         #region Custom Methods
 
@@ -939,7 +944,7 @@ namespace ProjectManager
             }
         }
         
-		#endregion
+        #endregion
 
         #region Event Handlers
 
@@ -1597,7 +1602,7 @@ namespace ProjectManager
         }
 
         #endregion
-	}
+    }
 
     public enum ProjectManagerUIStatus
     {

--- a/External/Plugins/ProjectManager/Settings.cs
+++ b/External/Plugins/ProjectManager/Settings.cs
@@ -106,7 +106,7 @@ namespace ProjectManager
         [LocalizedCategory("ProjectManager.Category.OtherOptions")]
         [DefaultValue(10)]
         public Int32 MaxRecentProjects
-		{
+        {
             get { return maxRecentProjects; }
             set { maxRecentProjects = value; FireChanged("MaxRecentProjects"); }
         }
@@ -135,10 +135,10 @@ namespace ProjectManager
         [LocalizedDescription("ProjectManager.Description.ExcludedFileTypes")]
         [LocalizedCategory("ProjectManager.Category.Exclusions")]
         public string[] ExcludedFileTypes
-		{
+        {
             get { return excludedFileTypes; }
             set { excludedFileTypes = value; FireChanged("ExcludedFileTypes"); }
-		}
+        }
 
         [DisplayName("Executable File Types")]
         [LocalizedDescription("ProjectManager.Description.ExecutableFileTypes")]
@@ -153,10 +153,10 @@ namespace ProjectManager
         [LocalizedDescription("ProjectManager.Description.ExcludedDirectories")]
         [LocalizedCategory("ProjectManager.Category.Exclusions")]
         public string[] ExcludedDirectories
-		{
+        {
             get { return excludedDirectories; }
             set { excludedDirectories = value; FireChanged("ExcludedDirectories"); }
-		}
+        }
 
         [DisplayName("Filtered Directory Names")]
         [LocalizedDescription("ProjectManager.Description.FilteredDirectoryNames")]
@@ -172,17 +172,17 @@ namespace ProjectManager
         [LocalizedCategory("ProjectManager.Category.ProjectTree")]
         [DefaultValue(true)]
         public bool ShowProjectClasspaths
-		{
+        {
             get { return showProjectClasspaths; }
             set { showProjectClasspaths = value; FireChanged("ShowProjectClasspaths"); }
-		}
+        }
 
         [DisplayName("Show Global Classpaths")]
         [LocalizedDescription("ProjectManager.Description.ShowGlobalClasspaths")]
         [LocalizedCategory("ProjectManager.Category.ProjectTree")]
         [DefaultValue(false)]
         public bool ShowGlobalClasspaths
-		{
+        {
             get { return showGlobalClasspaths; }
             set { showGlobalClasspaths = value; FireChanged("DisableMxmlMapping"); }
         }
@@ -206,6 +206,12 @@ namespace ProjectManager
             get { return tabHighlightType; }
             set { tabHighlightType = value; }
         }
+
+        [DisplayName("Track Active Document")]
+        [LocalizedDescription("ProjectManager.Description.TrackActiveDocument")]
+        [LocalizedCategory("ProjectManager.Category.ProjectTree")]
+        [DefaultValue(false)]
+        public bool TrackActiveDocument { get; set; }
 
         #endregion
 

--- a/PluginCore/PluginCore/Resources/de_DE.resX
+++ b/PluginCore/PluginCore/Resources/de_DE.resX
@@ -3639,7 +3639,12 @@ Bitte bedenken Sie, dass Sie viele Projektoptionen nicht mehr nutzen können, so
     <value>Fehlerzeile:</value>
   </data>
   <data name="ProjectManager.ToolTip.Synchronize" xml:space="preserve">
-    <value>Synchronisieren</value>
+    <value>Locate Active Document</value>
+    <comment>Modified after 4.7.0</comment>
+  </data>
+  <data name="ProjectManager.ToolTip.SynchronizeMain" xml:space="preserve">
+    <value>Locate Document Class</value>
+    <comment>Added after 4.7.0</comment>
   </data>
   <data name="FlashDevelop.Info.FilterSettings" xml:space="preserve">
     <value>Suche:</value>
@@ -5333,6 +5338,10 @@ Eigene Sprachumgebungen müssen eine Erweiterung der Standard-Sprachumgebung sei
   </data>
   <data name="FlashDevelop.Info.ColorizeMarkerMargin" xml:space="preserve">
     <value>Colorize first margin with 'gdefault' foreground color</value>
+    <comment>Added after 4.7.0</comment>
+  </data>
+  <data name="ProjectManager.Description.TrackActiveDocument" xml:space="preserve">
+    <value>Track current active document in Project Tree.</value>
     <comment>Added after 4.7.0</comment>
   </data>
 </root>

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -3653,7 +3653,12 @@ Please note that with injection enabled, you will not be able to use many projec
     <value>Error line:</value>
   </data>
   <data name="ProjectManager.ToolTip.Synchronize" xml:space="preserve">
-    <value>Synchronize</value>
+    <value>Locate Active Document</value>
+    <comment>Modified after 4.7.0</comment>
+  </data>
+  <data name="ProjectManager.ToolTip.SynchronizeMain" xml:space="preserve">
+    <value>Locate Document Class</value>
+    <comment>Added after 4.7.0</comment>
   </data>
   <data name="FlashDevelop.Info.FilterSettings" xml:space="preserve">
     <value>Filter settings:</value>
@@ -5343,6 +5348,10 @@ Custom locales must be an extension of a default locale, e.g. en-US.</value>
   </data>
   <data name="FlashDevelop.Info.ColorizeMarkerMargin" xml:space="preserve">
     <value>Colorize first margin with 'gdefault' foreground color</value>
+    <comment>Added after 4.7.0</comment>
+  </data>
+  <data name="ProjectManager.Description.TrackActiveDocument" xml:space="preserve">
+    <value>Track current active document in Project Tree.</value>
     <comment>Added after 4.7.0</comment>
   </data>
 </root>

--- a/PluginCore/PluginCore/Resources/eu_ES.resX
+++ b/PluginCore/PluginCore/Resources/eu_ES.resX
@@ -3637,7 +3637,12 @@ Kontutan izan injekzioa gaituz gero, ezin izanen diren proiektuaren hainbat auke
     <value>Errore lerroa:</value>
   </data>
   <data name="ProjectManager.ToolTip.Synchronize" xml:space="preserve">
-    <value>Sinkronizatu</value>
+    <value>Locate Active Document</value>
+    <comment>Modified after 4.7.0</comment>
+  </data>
+  <data name="ProjectManager.ToolTip.SynchronizeMain" xml:space="preserve">
+    <value>Locate Document Class</value>
+    <comment>Added after 4.7.0</comment>
   </data>
   <data name="FlashDevelop.Info.FilterSettings" xml:space="preserve">
     <value>Filtroen ezarpenak:</value>
@@ -5330,6 +5335,10 @@ Lokalizazio pertsonalizatuek lehenetsiaren luzapen bat izan behar dute, adb. en-
   </data>
   <data name="FlashDevelop.Info.ColorizeMarkerMargin" xml:space="preserve">
     <value>Colorize first margin with 'gdefault' foreground color</value>
+    <comment>Added after 4.7.0</comment>
+  </data>
+  <data name="ProjectManager.Description.TrackActiveDocument" xml:space="preserve">
+    <value>Track current active document in Project Tree.</value>
     <comment>Added after 4.7.0</comment>
   </data>
 </root>

--- a/PluginCore/PluginCore/Resources/ja_JP.resX
+++ b/PluginCore/PluginCore/Resources/ja_JP.resX
@@ -3639,7 +3639,12 @@ AfterSimilarAccessorMethod: 同様のアクセサメソッドの後に配置。"
     <value>エラー行の背景:</value>
   </data>
   <data name="ProjectManager.ToolTip.Synchronize" xml:space="preserve">
-    <value>同期</value>
+    <value>Locate Active Document</value>
+    <comment>Modified after 4.7.0</comment>
+  </data>
+  <data name="ProjectManager.ToolTip.SynchronizeMain" xml:space="preserve">
+    <value>Locate Document Class</value>
+    <comment>Added after 4.7.0</comment>
   </data>
   <data name="AS3Context.Label.AutoStartProfilerOFF" xml:space="preserve">
     <value>プロファイラーの自動開始:無効</value>
@@ -5395,6 +5400,10 @@ UseData:"</value>
   </data>
   <data name="FlashDevelop.Info.ColorizeMarkerMargin" xml:space="preserve">
     <value>Colorize first margin with 'gdefault' foreground color</value>
+    <comment>Added after 4.7.0</comment>
+  </data>
+  <data name="ProjectManager.Description.TrackActiveDocument" xml:space="preserve">
+    <value>Track current active document in Project Tree.</value>
     <comment>Added after 4.7.0</comment>
   </data>
 </root>

--- a/PluginCore/PluginCore/Resources/zh_CN.resx
+++ b/PluginCore/PluginCore/Resources/zh_CN.resx
@@ -3645,7 +3645,12 @@
     <value>错误行:</value>
   </data>
   <data name="ProjectManager.ToolTip.Synchronize" xml:space="preserve">
-    <value>同步</value>
+    <value>Locate Active Document</value>
+    <comment>Modified after 4.7.0</comment>
+  </data>
+  <data name="ProjectManager.ToolTip.SynchronizeMain" xml:space="preserve">
+    <value>Locate Document Class</value>
+    <comment>Added after 4.7.0</comment>
   </data>
   <data name="FlashDevelop.Info.FilterSettings" xml:space="preserve">
     <value>过滤设置:</value>
@@ -5343,6 +5348,10 @@
   </data>
   <data name="FlashDevelop.Info.ColorizeMarkerMargin" xml:space="preserve">
     <value>Colorize first margin with 'gdefault' foreground color</value>
+    <comment>Added after 4.7.0</comment>
+  </data>
+  <data name="ProjectManager.Description.TrackActiveDocument" xml:space="preserve">
+    <value>Track current active document in Project Tree.</value>
     <comment>Added after 4.7.0</comment>
   </data>
 </root>


### PR DESCRIPTION
Renamed the two Project Tree Synchronize tooltips because they were confusing.
Added shortcut for locating active document in Project Tree. Default Shift+Alt+L.
Created new setting to keep track of the current document in the project tree.
Standardized spacing in files.
