### PR TITLE
Removed autoindent in comment after colon

### DIFF
--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -5448,7 +5448,7 @@ namespace ScintillaNet
                                     previousIndent += TabWidth;
                             }
                             // TODO: Should this test a config variable for indenting after case : statements?
-                            if (Lexer == 3 && tempText.EndsWith(":") && !tempText.EndsWith("::"))
+                            if (Lexer == 3 && tempText.EndsWith(":") && !tempText.EndsWith("::") && !this.PositionIsOnComment(PositionFromLine(tempLine)))
                             {
                                 int prevLine = tempLine;
                                 while (--prevLine > 0)


### PR DESCRIPTION
Fixed scenario when auto indent has been applied after `:` in comment block

before:
![before](https://cloud.githubusercontent.com/assets/4076929/5367130/95b84d0a-7ff9-11e4-803c-2053a0aab443.gif)

after:
![after](https://cloud.githubusercontent.com/assets/4076929/5367132/9ba0f3de-7ff9-11e4-9cfb-5fbffccbbf98.gif)
