### PR TITLE
Project tree refactoring fixes

### DIFF
--- a/External/Plugins/AS2Context/Context.cs
+++ b/External/Plugins/AS2Context/Context.cs
@@ -795,7 +795,7 @@ namespace AS2Context
                 {
                     string pathname = package.Replace('.', Path.DirectorySeparatorChar);
                     string fullpath = Path.GetDirectoryName(cFile.FileName);
-                    if (!fullpath.ToUpper().EndsWith(pathname.ToUpper()))
+                    if (!fullpath.EndsWith(pathname))
                     {
                         if (settings.FixPackageAutomatically && CurSciControl != null)
                         {

--- a/External/Plugins/CodeRefactor/Commands/FindAllReferences.cs
+++ b/External/Plugins/CodeRefactor/Commands/FindAllReferences.cs
@@ -18,7 +18,12 @@ namespace CodeRefactor.Commands
         private ASResult currentTarget;
         private Boolean outputResults;
         private Boolean ignoreDeclarationSource;
-        
+
+        /// <summary>
+        /// Gets or sets if searching is only performed on user defined classpaths
+        /// </summary>
+        public Boolean OnlySourceFiles { get; set; }
+
         /// <summary>
         /// The current declaration target that references are being found to.
         /// </summary>
@@ -76,7 +81,7 @@ namespace CodeRefactor.Commands
             UserInterfaceManager.ProgressDialog.Show();
             UserInterfaceManager.ProgressDialog.SetTitle(TextHelper.GetString("Info.FindingReferences"));
             UserInterfaceManager.ProgressDialog.UpdateStatusMessage(TextHelper.GetString("Info.SearchingFiles"));
-            RefactoringHelper.FindTargetInFiles(currentTarget, new FRProgressReportHandler(this.RunnerProgress), new FRFinishedHandler(this.FindFinished), true);
+            RefactoringHelper.FindTargetInFiles(currentTarget, new FRProgressReportHandler(this.RunnerProgress), new FRFinishedHandler(this.FindFinished), true, OnlySourceFiles);
         }
 
         /// <summary>

--- a/External/Plugins/CodeRefactor/Commands/Move.cs
+++ b/External/Plugins/CodeRefactor/Commands/Move.cs
@@ -21,7 +21,9 @@ namespace CodeRefactor.Commands
         public bool OutputResults;
         private bool renaming;
         private List<MoveTargetHelper> targets;
-        private MoveTargetHelper currentTarget;
+        private List<String> filesToReopen;
+        private int currentTargetIndex;
+        private ASResult currentTargetResult;
 
         #region Constructors
 
@@ -42,7 +44,6 @@ namespace CodeRefactor.Commands
             OutputResults = outputResults;
             this.renaming = renaming;
             Results = new Dictionary<string, List<SearchMatch>>();
-            CreateListOfMoveTargets();
         }
 
         #endregion
@@ -52,13 +53,20 @@ namespace CodeRefactor.Commands
         protected override void ExecutionImplementation()
         {
             string msg;
-            string title = "";
+            string title = null;
+
+            // To get the initial open documents, finding all references will interfere if we try later
+            // We may already have an AssociatedDocumentHelper
+            RegisterDocumentHelper(AssociatedDocumentHelper);
+
+            CreateListOfMoveTargets();
+
             if (renaming)
             {
                 msg = TextHelper.GetString("Info.RenamingDirectory");
-                foreach (KeyValuePair<string, string> item in OldPathToNewPath)
+                foreach (string path in OldPathToNewPath.Keys)
                 {
-                    title = string.Format(TextHelper.GetString("Title.RenameDialog"), Path.GetFileName(item.Key));
+                    title = string.Format(TextHelper.GetString("Title.RenameDialog"), Path.GetFileName(path));
                     break;
                 }
             }
@@ -67,14 +75,16 @@ namespace CodeRefactor.Commands
                 msg = TextHelper.GetString("Info.MovingFile");
                 title = TextHelper.GetString("Title.MoveDialog");
             }
-            if (MessageBox.Show(msg, title, MessageBoxButtons.YesNo) == DialogResult.Yes)
+            if (targets.Count > 0 && MessageBox.Show(msg, title, MessageBoxButtons.YesNo) == DialogResult.Yes)
             {
-                MoveTargets();
+                // We must keep the original files for validating references
+                CopyTargets();
                 UpdateReferencesNextTarget();
             }
             else
             {
                 MoveTargets();
+                ReopenInitialFiles();
                 FireOnRefactorComplete();
             }
         }
@@ -91,43 +101,73 @@ namespace CodeRefactor.Commands
         private void CreateListOfMoveTargets()
         {
             targets = new List<MoveTargetHelper>();
+            filesToReopen = new List<String>();
+            IProject project = PluginBase.CurrentProject;
+            if (project == null) return;
+            IASContext context = ASContext.GetLanguageContext(project.Language);
+            if (context == null) return;
+            string filterMask = project.DefaultSearchFilter;
             foreach (KeyValuePair<string, string> item in OldPathToNewPath)
             {
                 string oldPath = item.Key;
                 string newPath = item.Value;
+                ITabbedDocument doc;
                 if (File.Exists(oldPath))
                 {
-                    if (IsValidFile(oldPath)) targets.Add(GetMoveTarget(oldPath, Path.Combine(item.Value, Path.GetFileName(oldPath))));
+                    newPath = Path.Combine(newPath, Path.GetFileName(oldPath));
+
+                    if (AssociatedDocumentHelper.InitiallyOpenedFiles.TryGetValue(oldPath, out doc))
+                    {
+                        doc.Save();
+                        doc.Close();
+
+                        filesToReopen.Add(newPath);
+
+                        // We need to remove it from the collection so later it may be closed by CloseTemporarilyOpenedDocuments,
+                        // otherwise there may be problems updating contents.
+                        AssociatedDocumentHelper.InitiallyOpenedFiles.Remove(oldPath);
+                    }
+                    if (AssociatedDocumentHelper.InitiallyOpenedFiles.TryGetValue(newPath, out doc))
+                    {
+                        doc.Save();
+                        doc.Close();
+                        // We need to remove it from the collection so later it may be closed by CloseTemporarilyOpenedDocuments,
+                        // otherwise there may be problems updating contents.
+                        AssociatedDocumentHelper.InitiallyOpenedFiles.Remove(newPath);
+                    }
+
+                    if (FileHelper.FileMatchesSearchFilter(oldPath, filterMask))
+                    {
+                        targets.Add(GetMoveTarget(context, oldPath, newPath, null));
+                        break;
+                    }
                 }
                 else if(Directory.Exists(oldPath))
                 {
                     newPath = renaming ? Path.Combine(Path.GetDirectoryName(oldPath), newPath) : Path.Combine(newPath, Path.GetFileName(oldPath));
-                    foreach (string oldFilePath in Directory.GetFiles(oldPath, "*.*", SearchOption.AllDirectories))
-                    {
-                        if (IsValidFile(oldFilePath)) targets.Add(GetMoveTarget(oldFilePath, oldFilePath.Replace(oldPath, newPath)));
-                    }
+
+                    CloseDocuments(oldPath, newPath);
+
+                    // Do not load every file and check for matches to save memory and computation time
+                    foreach (string mask in filterMask.Split(';'))
+                        foreach (string oldFilePath in Directory.GetFiles(oldPath, mask, SearchOption.AllDirectories))
+                            targets.Add(GetMoveTarget(context, oldFilePath, oldFilePath.Replace(oldPath, newPath), oldPath));
                 }
             }
         }
 
-        private bool IsValidFile(string file)
-        {
-            if (PluginBase.CurrentProject == null) return false;
-            string ext = Path.GetExtension(file);
-            return ext == ".as" || FileHelper.IsHaxeExtension(ext) || ext == ".ls" && PluginBase.CurrentProject.DefaultSearchFilter.Contains(ext);
-        }
-
-        private MoveTargetHelper GetMoveTarget(string oldFilePath, string newPath)
+        private MoveTargetHelper GetMoveTarget(IASContext context, string oldFilePath, string newPath, string ownerPath)
         {
             MoveTargetHelper result = new MoveTargetHelper();
             result.OldFilePath = oldFilePath;
             result.OldFileModel = ASContext.Context.GetFileModel(oldFilePath);
             result.NewFilePath = newPath;
+            result.OwnerPath = ownerPath;
             IProject project = PluginBase.CurrentProject;
             string newPackage = project.GetAbsolutePath(Path.GetDirectoryName(newPath));
             if (!string.IsNullOrEmpty(newPackage))
             {
-                foreach (PathModel pathModel in ASContext.Context.Classpath)
+                foreach (PathModel pathModel in context.Classpath)
                 {
                     string path = project.GetAbsolutePath(pathModel.Path);
                     if (path == newPackage)
@@ -146,46 +186,63 @@ namespace CodeRefactor.Commands
             return result;
         }
 
+        private void CopyTargets()
+        {
+            MessageBar.Locked = true;
+            foreach (var target in targets)
+            {
+                string oldPath = target.OldFilePath;
+                string newPath = target.NewFilePath;
+                if (File.Exists(oldPath))
+                {
+                    if (oldPath.Equals(newPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // name casing changed
+                        // we cannot append to the extension, as it will break finding possibly needed references
+                        // we don't use folders to avoid several possible problems and ease some logic
+                        newPath = target.TmpFilePath = Path.Combine(Path.GetDirectoryName(oldPath),
+                                                                    Path.GetFileNameWithoutExtension(oldPath) +
+                                                                    "$renaming$" +
+                                                                    Path.GetExtension(oldPath));
+                    }
+                    if (!Path.IsPathRooted(newPath)) newPath = Path.Combine(Path.GetDirectoryName(oldPath), newPath);
+                    string newDirectory = Path.GetDirectoryName(newPath);
+                    if (!Directory.Exists(newDirectory)) Directory.CreateDirectory(newDirectory);
+                    RefactoringHelper.Copy(oldPath, newPath, true, true);
+                }
+            }
+            MessageBar.Locked = false;
+        }
+
         private void MoveTargets()
         {
-            Dictionary<string, ITabbedDocument> fileNameToOpenedDoc = new Dictionary<string, ITabbedDocument>();
-            foreach (ITabbedDocument doc in PluginBase.MainForm.Documents)
-            {
-                fileNameToOpenedDoc.Add(doc.FileName, doc);
-            }
             MessageBar.Locked = true;
             foreach (KeyValuePair<string, string> item in OldPathToNewPath)
             {
                 string oldPath = item.Key;
                 string newPath = item.Value;
-                if (Path.HasExtension(oldPath))
+                if (File.Exists(oldPath))
                 {
-                    if (fileNameToOpenedDoc.ContainsKey(oldPath))
-                    {
-                        fileNameToOpenedDoc[oldPath].Save();
-                        fileNameToOpenedDoc[oldPath].Close();
-                    }
-                    newPath = Path.Combine(item.Value, Path.GetFileName(oldPath));
+                    newPath = Path.Combine(newPath, Path.GetFileName(oldPath));
                     // refactor failed or was refused
                     if (Path.GetFileName(oldPath).Equals(newPath, StringComparison.OrdinalIgnoreCase))
                     {
                         // name casing changed
                         string tmpPath = oldPath + "$renaming$";
-                        File.Move(oldPath, tmpPath);
+                        RefactoringHelper.Move(oldPath, tmpPath);
                         oldPath = tmpPath;
                     }
                     if (!Path.IsPathRooted(newPath)) newPath = Path.Combine(Path.GetDirectoryName(oldPath), newPath);
-                    RefactoringHelper.Move(oldPath, newPath);
+                    RefactoringHelper.Move(oldPath, newPath, true);
                 }
-                else
+                else if (Directory.Exists(oldPath))
                 {
-                    foreach (string file in Directory.GetFiles(oldPath, "*.*", SearchOption.AllDirectories))
+                    if (Path.GetFileName(oldPath).Equals(newPath, StringComparison.OrdinalIgnoreCase))
                     {
-                        if (fileNameToOpenedDoc.ContainsKey(file))
-                        {
-                            fileNameToOpenedDoc[file].Save();
-                            fileNameToOpenedDoc[file].Close();
-                        }
+                        // name casing changed
+                        string tmpPath = oldPath + "$renaming$";
+                        RefactoringHelper.Move(oldPath, tmpPath);
+                        oldPath = tmpPath;
                     }
                     RefactoringHelper.Move(oldPath, newPath, renaming);
                 }
@@ -193,32 +250,63 @@ namespace CodeRefactor.Commands
             MessageBar.Locked = false;
         }
 
+        private void CloseDocuments(string oldDirectory, string newDirectory)
+        {
+            string oldPathAddBacklash = oldDirectory.Contains(Path.DirectorySeparatorChar.ToString())
+                                         ? oldDirectory + Path.DirectorySeparatorChar
+                                         : oldDirectory + Path.AltDirectorySeparatorChar;
+            string newPathAddBacklash = newDirectory.Contains(Path.DirectorySeparatorChar.ToString())
+                                         ? newDirectory + Path.DirectorySeparatorChar
+                                         : newDirectory + Path.AltDirectorySeparatorChar;
+
+            var fileMatches = new List<string>();
+            foreach (var item in AssociatedDocumentHelper.InitiallyOpenedFiles)
+            {
+                if (item.Key.StartsWith(oldPathAddBacklash))
+                {
+                    item.Value.Save();
+                    item.Value.Close();
+                    filesToReopen.Add(item.Key.Replace(oldPathAddBacklash, newPathAddBacklash));
+                    fileMatches.Add(item.Key);
+                }
+                else if (item.Key.StartsWith(newPathAddBacklash))
+                {
+                    item.Value.Save();
+                    item.Value.Close();
+                    fileMatches.Add(item.Key);
+                }
+            }
+
+            // We need to remove files from the collection so later it may be closed by CloseTemporarilyOpenedDocuments,
+            // otherwise there may be problems updating contents.
+            foreach (var file in fileMatches) AssociatedDocumentHelper.InitiallyOpenedFiles.Remove(file);
+        }
+
         private void UpdateReferencesNextTarget()
         {
-            if (targets.Count > 0)
+            if (currentTargetIndex < targets.Count)
             {
-                currentTarget = targets[0];
-                targets.Remove(currentTarget);
+                var currentTarget = targets[currentTargetIndex];
                 FileModel oldFileModel = currentTarget.OldFileModel;
                 FRSearch search;
-                string newType;
+                string oldType;
                 if (string.IsNullOrEmpty(oldFileModel.Package))
                 {
                     search = new FRSearch("package");
                     search.WholeWord = true;
-                    newType = Path.GetFileNameWithoutExtension(currentTarget.OldFilePath);
+                    oldType = Path.GetFileNameWithoutExtension(currentTarget.OldFilePath);
                 }
                 else
                 {
                     search = new FRSearch("package\\s+(" + oldFileModel.Package + ")");
-                    newType = oldFileModel.Package + "." + Path.GetFileNameWithoutExtension(currentTarget.OldFilePath);
+                    oldType = oldFileModel.Package + "." + Path.GetFileNameWithoutExtension(currentTarget.OldFilePath);
                 }
                 search.IsRegex = true;
                 search.Filter = SearchFilter.None;
-                newType = newType.Trim('.');
+                oldType = oldType.Trim('.');
                 MessageBar.Locked = true;
                 string newFilePath = currentTarget.NewFilePath;
-                ScintillaControl sci = AssociatedDocumentHelper.LoadDocument(newFilePath);
+                ScintillaControl sci = AssociatedDocumentHelper.LoadDocument(currentTarget.TmpFilePath ?? newFilePath);
                 List<SearchMatch> matches = search.Matches(sci.Text);
                 string packageReplacement = "package";
                 if (currentTarget.NewPackage != "")
@@ -231,18 +319,110 @@ namespace CodeRefactor.Commands
                     match.LineText = sci.GetLine(match.Line - 1);
                     match.Value = currentTarget.NewPackage;
                 }
-                if (!Results.ContainsKey(newFilePath)) Results[newFilePath] = new List<SearchMatch>();
-                Results[newFilePath].AddRange(matches.ToArray());
+                if (matches.Count > 0)
+                {
+                    if (!Results.ContainsKey(newFilePath)) Results[newFilePath] = new List<SearchMatch>();
+                    Results[newFilePath].AddRange(matches);
+                }
+                //Do we want to open modified files?
+                //if (sci.IsModify) AssociatedDocumentHelper.MarkDocumentToKeep(file);
                 PluginBase.MainForm.CurrentDocument.Save();
-                if (sci.IsModify) AssociatedDocumentHelper.MarkDocumentToKeep(currentTarget.OldFilePath);
                 MessageBar.Locked = false;
                 UserInterfaceManager.ProgressDialog.Show();
                 UserInterfaceManager.ProgressDialog.SetTitle(TextHelper.GetString("Info.FindingReferences"));
                 UserInterfaceManager.ProgressDialog.UpdateStatusMessage(TextHelper.GetString("Info.SearchingFiles"));
-                ASResult target = new ASResult() { Member = new MemberModel(newType, newType, FlagType.Import, 0) };
-                RefactoringHelper.FindTargetInFiles(target, UserInterfaceManager.ProgressDialog.UpdateProgress, FindFinished, true);
+                currentTargetResult = new ASResult
+                                      {
+                                          IsStatic = true,
+                                          Member = new MemberModel(oldType, oldType, FlagType.Constructor, 0), 
+                                          Type = ASContext.Context.ResolveType(oldType, oldFileModel),
+                                      };
+                RefactoringHelper.FindTargetInFiles(currentTargetResult, UserInterfaceManager.ProgressDialog.UpdateProgress, FindFinished, true);
             }
-            else FireOnRefactorComplete();
+            else
+            {
+                MoveRefactoredFiles();
+                ReopenInitialFiles();
+                FireOnRefactorComplete();
+            }
+        }
+
+        private void MoveRefactoredFiles()
+        {
+            MessageBar.Locked = true;
+            AssociatedDocumentHelper.CloseTemporarilyOpenedDocuments();
+            foreach (var target in targets)
+            {
+                File.Delete(target.OldFilePath);
+
+                if (target.OwnerPath == null)
+                    OldPathToNewPath.Remove(target.OldFilePath);
+
+                // Casing changes, we cannot move directly here, there may be conflicts, better leave it to the next step
+                if (target.TmpFilePath != null)
+                    RefactoringHelper.Move(target.TmpFilePath, target.NewFilePath);
+            }
+            // Move non-source files and whole folders
+            foreach (KeyValuePair<string, string> item in OldPathToNewPath)
+            {
+                string oldPath = item.Key;
+                string newPath = item.Value;
+                if (File.Exists(oldPath))
+                {
+                    newPath = Path.Combine(newPath, Path.GetFileName(oldPath));
+                    if (!Path.IsPathRooted(newPath)) newPath = Path.Combine(Path.GetDirectoryName(oldPath), newPath);
+                    RefactoringHelper.Move(oldPath, newPath, true);
+                }
+                else if (Directory.Exists(oldPath))
+                {
+                    newPath = renaming ? Path.Combine(Path.GetDirectoryName(oldPath), newPath) : Path.Combine(newPath, Path.GetFileName(oldPath));
+
+                    // Look for document class changes
+                    // Do not use RefactoringHelper to avoid possible dialogs that we don't want
+                    ProjectManager.Projects.Project project = (ProjectManager.Projects.Project)PluginBase.CurrentProject;
+                    string newDocumentClass = null;
+                    string searchPattern = project.DefaultSearchFilter;
+                    foreach (string pattern in searchPattern.Split(';'))
+                    {
+                        foreach (string file in Directory.GetFiles(oldPath, pattern, SearchOption.AllDirectories))
+                        {
+                            if (project.IsDocumentClass(file))
+                            {
+                                newDocumentClass = file.Replace(oldPath, newPath);
+                                break;
+                            }
+                        }
+                        if (newDocumentClass != null) break;
+                    }
+
+                    // Check if this is a name casing change
+                    if (oldPath.Equals(newPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        string tmpPath = oldPath + "$renaming$";
+                        FileHelper.ForceMoveDirectory(oldPath, tmpPath);
+                        PluginCore.Managers.DocumentManager.MoveDocuments(oldPath, tmpPath);
+                        oldPath = tmpPath;
+                    }
+
+                    // Move directory contents to final location
+                    FileHelper.ForceMoveDirectory(oldPath, newPath);
+                    PluginCore.Managers.DocumentManager.MoveDocuments(oldPath, newPath);
+
+                    if (!string.IsNullOrEmpty(newDocumentClass))
+                    {
+                        project.SetDocumentClass(newDocumentClass, true);
+                        project.Save();
+                    }
+                }
+            }
+
+            MessageBar.Locked = false;
+        }
+
+        private void ReopenInitialFiles()
+        {
+            foreach (string file in filesToReopen)
+                PluginBase.MainForm.OpenEditableDocument(file, false);
         }
 
         #endregion
@@ -254,44 +434,81 @@ namespace CodeRefactor.Commands
             UserInterfaceManager.ProgressDialog.Show();
             UserInterfaceManager.ProgressDialog.SetTitle(TextHelper.GetString("Info.UpdatingReferences"));
             MessageBar.Locked = true;
+            var currentTarget = targets[currentTargetIndex];
             bool isNotHaxe = !PluginBase.CurrentProject.Language.StartsWith("haxe");
-            bool packageIsNotEmpty = !string.IsNullOrEmpty(currentTarget.OldFileModel.Package);
             string targetName = Path.GetFileNameWithoutExtension(currentTarget.OldFilePath);
             string oldType = (currentTarget.OldFileModel.Package + "." + targetName).Trim('.');
             string newType = (currentTarget.NewPackage + "." + targetName).Trim('.');
+
             foreach (KeyValuePair<string, List<SearchMatch>> entry in results)
             {
                 List<SearchMatch> matches = entry.Value;
-                if (matches.Count == 0) continue;
-                string path = entry.Key;
-                UserInterfaceManager.ProgressDialog.UpdateStatusMessage(TextHelper.GetString("Info.Updating") + " \"" + path + "\"");
-                ScintillaControl sci = AssociatedDocumentHelper.LoadDocument(path);
-                if (isNotHaxe && path != currentTarget.NewFilePath && ASContext.Context.CurrentModel.Imports.Search(targetName, FlagType.Class & FlagType.Function & FlagType.Namespace, 0) == null)
+                if (matches.Count == 0 || entry.Key == currentTarget.OldFilePath || 
+                    entry.Key == currentTarget.NewFilePath) continue;
+                string file = entry.Key;
+                UserInterfaceManager.ProgressDialog.UpdateStatusMessage(TextHelper.GetString("Info.Updating") + " \"" + file + "\"");
+                ScintillaControl sci;
+                var actualMatches = new List<SearchMatch>();
+                foreach (SearchMatch match in entry.Value)
                 {
-                    ASGenerator.InsertImport(new MemberModel(targetName, newType, FlagType.Import, 0), false);
+                    // we have to open/reopen the entry's file
+                    // there are issues with evaluating the declaration targets with non-open, non-current files
+                    // we have to do it each time as the process of checking the declaration source can change the currently open file!
+                    sci = AssociatedDocumentHelper.LoadDocument(file);
+                    // if the search result does point to the member source, store it
+                    if (RefactoringHelper.DoesMatchPointToTarget(sci, match, currentTargetResult, this.AssociatedDocumentHelper))
+                        actualMatches.Add(match);
                 }
-                if (packageIsNotEmpty) RefactoringHelper.ReplaceMatches(matches, sci, newType);
-                else
+                if (actualMatches.Count == 0) continue;
+                int currLine = -1;
+                sci = AssociatedDocumentHelper.LoadDocument(file);
+                for (int i = actualMatches.Count - 1; i >= 0; i--)
                 {
-                    foreach (SearchMatch sm in matches)
+                    var sm = actualMatches[i];
+                    if (sm.LineText.Contains(oldType))
                     {
-                        if (sm.LineText.TrimStart().StartsWith("import"))
-                        {
-                            RefactoringHelper.SelectMatch(sci, sm);
-                            sci.ReplaceSel(newType);
-                        }
+                        sm.Index -= sci.MBSafeTextLength(oldType) - sci.MBSafeTextLength(targetName);
+                        sm.Value = oldType;
+                        RefactoringHelper.SelectMatch(sci, sm);
+                        sm.Column = sm.Index - sm.LineStart;
+                        sci.ReplaceSel(newType);
+                        sm.LineEnd = sci.SelectionEnd;
+                        sm.LineText = sci.GetLine(sm.Line - 1);
+                        sm.Value = newType;
+                    }
+                    else
+                    {
+                        if (currLine == -1) currLine = sm.Line - 1;
+                        actualMatches.RemoveAt(i);
                     }
                 }
-                foreach (SearchMatch match in matches)
+                string directory = Path.GetDirectoryName(file);
+                // directory != currentTarget.OwnerPath -> renamed owner directory, so both files in the same place
+                if (isNotHaxe && directory != Path.GetDirectoryName(currentTarget.NewFilePath) && directory != currentTarget.OwnerPath 
+                    && ASContext.Context.CurrentModel.Imports.Search(targetName, FlagType.Class & FlagType.Function & FlagType.Namespace, 0) == null)
                 {
-                    match.LineText = sci.GetLine(match.Line - 1);
-                    match.Value = newType;
+                    sci.GotoLine(currLine);
+                    ASGenerator.InsertImport(new MemberModel(targetName, newType, FlagType.Import, 0), false);
+                    int newLine = sci.LineFromPosition(sci.Text.IndexOf(newType));
+                    var sm = new SearchMatch();
+                    sm.Line = newLine + 1;
+                    sm.LineText = sci.GetLine(newLine);
+                    sm.Column = 0;
+                    sm.Length = sci.MBSafeTextLength(sm.LineText);
+                    sm.Value = sm.LineText;
+
+                    actualMatches.Insert(0, sm);
                 }
-                if (!Results.ContainsKey(path)) Results[path] = new List<SearchMatch>();
-                Results[path].AddRange(matches.ToArray());
+                if (actualMatches.Count == 0) continue;
+                if (!Results.ContainsKey(file)) Results[file] = new List<SearchMatch>();
+                Results[file].AddRange(actualMatches);
+                //Do we want to open modified files?
+                //if (sci.IsModify) AssociatedDocumentHelper.MarkDocumentToKeep(file);
                 PluginBase.MainForm.CurrentDocument.Save();
-                if (sci.IsModify) AssociatedDocumentHelper.MarkDocumentToKeep(path);
             }
+
+            currentTargetIndex++;
+
             UserInterfaceManager.ProgressDialog.Hide();
             MessageBar.Locked = false;
             UpdateReferencesNextTarget();
@@ -308,10 +525,8 @@ namespace CodeRefactor.Commands
         public FileModel OldFileModel;
         public string NewFilePath;
         public string NewPackage;
-
-        public MoveTargetHelper()
-        {
-        }
+        public string TmpFilePath;
+        public string OwnerPath;
     }
 
     #endregion

--- a/External/Plugins/CodeRefactor/Commands/Move.cs
+++ b/External/Plugins/CodeRefactor/Commands/Move.cs
@@ -307,24 +307,24 @@ namespace CodeRefactor.Commands
 
         private void CloseDocuments(string oldDirectory, string newDirectory)
         {
-            string oldPathAddBacklash = oldDirectory.Contains(Path.DirectorySeparatorChar.ToString())
-                                         ? oldDirectory + Path.DirectorySeparatorChar
-                                         : oldDirectory + Path.AltDirectorySeparatorChar;
-            string newPathAddBacklash = newDirectory.Contains(Path.DirectorySeparatorChar.ToString())
-                                         ? newDirectory + Path.DirectorySeparatorChar
-                                         : newDirectory + Path.AltDirectorySeparatorChar;
+            string oldPath = oldDirectory.Contains(Path.DirectorySeparatorChar.ToString())
+                                 ? oldDirectory + Path.DirectorySeparatorChar
+                                 : oldDirectory + Path.AltDirectorySeparatorChar;
+            string newPath = newDirectory.Contains(Path.DirectorySeparatorChar.ToString())
+                                 ? newDirectory + Path.DirectorySeparatorChar
+                                 : newDirectory + Path.AltDirectorySeparatorChar;
 
             var fileMatches = new List<string>();
             foreach (var item in AssociatedDocumentHelper.InitiallyOpenedFiles)
             {
-                if (item.Key.StartsWith(oldPathAddBacklash))
+                if (item.Key.StartsWith(oldPath))
                 {
                     item.Value.Save();
                     item.Value.Close();
-                    filesToReopen.Add(item.Key.Replace(oldPathAddBacklash, newPathAddBacklash));
+                    filesToReopen.Add(item.Key.Replace(oldPath, newPath));
                     fileMatches.Add(item.Key);
                 }
-                else if (item.Key.StartsWith(newPathAddBacklash))
+                else if (item.Key.StartsWith(newPath))
                 {
                     item.Value.Save();
                     item.Value.Close();

--- a/External/Plugins/CodeRefactor/Commands/Rename.cs
+++ b/External/Plugins/CodeRefactor/Commands/Rename.cs
@@ -126,8 +126,18 @@ namespace CodeRefactor.Commands
         /// </summary>
         protected override void ExecutionImplementation()
         {
-            if (renamePackage != null) renamePackage.Execute();
-            else this.findAllReferencesCommand.Execute();
+            if (renamePackage != null)
+            {
+                renamePackage.RegisterDocumentHelper(AssociatedDocumentHelper);
+                renamePackage.Execute();
+            }
+            else
+            {
+                // To get the initial open documents, finding all references will interfere if we try later
+                // We may already have an AssociatedDocumentHelper
+                RegisterDocumentHelper(AssociatedDocumentHelper);
+                findAllReferencesCommand.Execute();
+            }
         }
 
         /// <summary>
@@ -154,14 +164,16 @@ namespace CodeRefactor.Commands
             {
                 UserInterfaceManager.ProgressDialog.UpdateStatusMessage(TextHelper.GetString("Info.Updating") + " \"" + entry.Key + "\"");
                 // re-open the document and replace all the text
-                PluginBase.MainForm.OpenEditableDocument(entry.Key);
-                ScintillaControl sci = ASContext.CurSciControl;
+                var sci = AssociatedDocumentHelper.LoadDocument(entry.Key);
                 // replace matches in the current file with the new name
                 RefactoringHelper.ReplaceMatches(entry.Value, sci, this.newName);
-                if (sci.IsModify) this.AssociatedDocumentHelper.MarkDocumentToKeep(sci.FileName);
+                //Uncomment if we want to keep modified files
+                //if (sci.IsModify) AssociatedDocumentHelper.MarkDocumentToKeep(entry.Key);
+                PluginBase.MainForm.CurrentDocument.Save();
             }
             RenameFile(eventArgs.Results);
             this.Results = eventArgs.Results;
+            AssociatedDocumentHelper.CloseTemporarilyOpenedDocuments();
             if (this.outputResults) this.ReportResults();
             UserInterfaceManager.ProgressDialog.Hide();
             PluginCore.Controls.MessageBar.Locked = false;
@@ -221,13 +233,34 @@ namespace CodeRefactor.Commands
 
             if (string.IsNullOrEmpty(oldFileName) || oldFileName.Equals(newFileName)) return;
 
-            RefactoringHelper.Move(oldFileName, newFileName);
-           
+            // We close previous files to avoid unwanted "file modified" dialogs
+            ITabbedDocument doc;
+            Boolean reopen = false;
+            if (AssociatedDocumentHelper.InitiallyOpenedFiles.TryGetValue(oldFileName, out doc))
+            {
+                doc.Close();
+                reopen = true;
+            }
+            if (AssociatedDocumentHelper.InitiallyOpenedFiles.TryGetValue(newFileName, out doc))
+                doc.Close();
+
+            // name casing changed
+            if (oldFileName.Equals(newFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                string tmpPath = oldFileName + "$renaming$";
+                RefactoringHelper.Move(oldFileName, tmpPath);
+                RefactoringHelper.Move(tmpPath, newFileName);
+            }
+            else
+                RefactoringHelper.Move(oldFileName, newFileName);
+            
             if (results.ContainsKey(oldFileName))
             {
                 results[newFileName] = results[oldFileName];
                 results.Remove(oldFileName);
             }
+            if (reopen)
+                PluginBase.MainForm.OpenEditableDocument(newFileName);
         }
 
         /// <summary>

--- a/External/Plugins/CodeRefactor/Commands/Rename.cs
+++ b/External/Plugins/CodeRefactor/Commands/Rename.cs
@@ -114,7 +114,7 @@ namespace CodeRefactor.Commands
 
             // create a FindAllReferences refactor to get all the changes we need to make
             // we'll also let it output the results, at least until we implement a way of outputting the renamed results later
-            this.findAllReferencesCommand = new FindAllReferences(target, false, ignoreDeclarationSource);
+            this.findAllReferencesCommand = new FindAllReferences(target, false, ignoreDeclarationSource) {OnlySourceFiles = true};
             // register a completion listener to the FindAllReferences so we can rename the entries
             this.findAllReferencesCommand.OnRefactorComplete += OnFindAllReferencesCompleted;
         }

--- a/External/Plugins/CodeRefactor/Commands/Rename.cs
+++ b/External/Plugins/CodeRefactor/Commands/Rename.cs
@@ -242,7 +242,10 @@ namespace CodeRefactor.Commands
                 reopen = true;
             }
             if (AssociatedDocumentHelper.InitiallyOpenedFiles.TryGetValue(newFileName, out doc))
+            {
                 doc.Close();
+                reopen = true;
+            }
 
             // name casing changed
             if (oldFileName.Equals(newFileName, StringComparison.OrdinalIgnoreCase))

--- a/External/Plugins/CodeRefactor/Commands/RenameFile.cs
+++ b/External/Plugins/CodeRefactor/Commands/RenameFile.cs
@@ -71,6 +71,7 @@ namespace CodeRefactor.Commands
                 {
                     sci.SelectText(oldFileName, sci.PositionFromLine(line));
                     Rename command = new Rename(RefactoringHelper.GetDefaultRefactorTarget(), true, newFileName);
+                    command.RegisterDocumentHelper(AssociatedDocumentHelper);
                     command.Execute();
                     return;
                 }

--- a/External/Plugins/CodeRefactor/PluginMain.cs
+++ b/External/Plugins/CodeRefactor/PluginMain.cs
@@ -212,8 +212,7 @@ namespace CodeRefactor
                 || !Regex.Match(Path.GetFileNameWithoutExtension(file), REG_IDENTIFIER, RegexOptions.Singleline).Success)
                 return false;
             if (Directory.Exists(file)) return true;
-            string ext = Path.GetExtension(file);
-            return (ext == ".as" || FileHelper.IsHaxeExtension(ext) || ext == ".ls") && project.DefaultSearchFilter.Contains(ext);
+            return FileHelper.FileMatchesSearchFilter(file, project.DefaultSearchFilter);
         }
 
         #endregion

--- a/External/Plugins/CodeRefactor/Provider/DocumentHelper.cs
+++ b/External/Plugins/CodeRefactor/Provider/DocumentHelper.cs
@@ -82,6 +82,14 @@ namespace CodeRefactor.Provider
         }
 
         /// <summary>
+        /// Gets the collection of files opened when this DocumentHelper was created.
+        /// </summary>
+        public IDictionary<String, ITabbedDocument> InitiallyOpenedFiles
+        {
+            get { return initiallyOpenedFiles; }
+        }
+
+        /// <summary>
         /// Retrieves a list of the currently open documents.
         /// </summary>
         protected IDictionary<String, ITabbedDocument> GetOpenDocuments()

--- a/External/Plugins/CodeRefactor/Provider/RefactoringHelper.cs
+++ b/External/Plugins/CodeRefactor/Provider/RefactoringHelper.cs
@@ -351,7 +351,8 @@ namespace CodeRefactor.Provider
             if (project.SourcePaths.Length == 0)
             {
                 String projRoot = Path.GetDirectoryName(project.ProjectPath);
-                files.AddRange(Directory.GetFiles(projRoot, filter, SearchOption.AllDirectories));
+                foreach (string filterMask in filter.Split(';'))
+                    files.AddRange(Directory.GetFiles(projRoot, filterMask, SearchOption.AllDirectories));
             }
             return files;
         }

--- a/External/Plugins/ProjectManager/Actions/FileActions.cs
+++ b/External/Plugins/ProjectManager/Actions/FileActions.cs
@@ -405,6 +405,21 @@ namespace ProjectManager.Actions
                 return false;
             }
 
+            bool isDirectory = Directory.Exists(oldPath);
+
+            if (!isDirectory)
+            {
+                string oldExt = Path.GetExtension(oldPath);
+                string newExt = Path.GetExtension(newName);
+
+                string caption = " " + TextHelper.GetString("FlashDevelop.Title.ConfirmDialog");
+                string message = TextHelper.GetString("Info.ExtensionChangeWarning");
+
+                if (oldExt.ToUpperInvariant() != newExt.ToUpperInvariant() &&
+                    MessageBox.Show(message, caption, MessageBoxButtons.YesNo) == DialogResult.No)
+                    return false;
+            }
+
             if (CancelAction(ProjectFileActionsEvents.FileRename, new string[] { oldPath, newName })) return false;
 
             try
@@ -416,7 +431,7 @@ namespace ProjectManager.Actions
 
                 OnFileCreated(newPath);
 
-                if (Directory.Exists(oldPath))
+                if (isDirectory)
                 {
                     // this is required for renaming directories, don't ask me why
                     string oldPathFixed = (oldPath.EndsWith("\\")) ? oldPath : oldPath + "\\";
@@ -428,7 +443,10 @@ namespace ProjectManager.Actions
                         Directory.Move(oldPathFixed, tmpPath);
                         oldPathFixed = tmpPath;
                     }
-                    Directory.Move(oldPathFixed, newPathFixed);
+                    if (FileHelper.ConfirmOverwrite(newPathFixed))
+                    {
+                        FileHelper.ForceMove(oldPathFixed, newPathFixed);
+                    }
                 }
                 else
                 {

--- a/External/Plugins/ProjectManager/Actions/FileActions.cs
+++ b/External/Plugins/ProjectManager/Actions/FileActions.cs
@@ -504,7 +504,7 @@ namespace ProjectManager.Actions
 
                 OnFileCreated(toPath);
 
-                if (Directory.Exists(fromPath)) MoveDirectory(fromPath, toPath);
+                if (Directory.Exists(fromPath)) FileHelper.ForceMoveDirectory(fromPath, toPath);
                 else File.Move(fromPath, toPath);
 
                 OnFileMoved(fromPath, toPath);
@@ -515,27 +515,6 @@ namespace ProjectManager.Actions
                 ErrorManager.ShowError(exception);
             }
             finally { PopCurrentDirectory(); }
-        }
-
-        private void MoveDirectory(string fromPath, string toPath)
-        {
-            if (Directory.GetDirectoryRoot(fromPath) == Directory.GetDirectoryRoot(toPath)
-                && !Directory.Exists(toPath))
-            {
-                Directory.Move(fromPath, toPath);
-            }
-            else
-            {
-                try
-                {
-                    CopyDirectory(fromPath, toPath);
-                    Directory.Delete(fromPath, true);
-                }
-                catch (Exception)
-                {
-                    throw;
-                }
-            }
         }
 
         public void Copy(string fromPath, string toPath)
@@ -590,7 +569,7 @@ namespace ProjectManager.Actions
 
                 OnFileCreated(toPath);
 
-                if (Directory.Exists(fromPath)) CopyDirectory(fromPath, toPath);
+                if (Directory.Exists(fromPath)) FileHelper.CopyDirectory(fromPath, toPath, true);
                 else File.Copy(fromPath, toPath, true);
 
                 OnFilePasted(fromPath, toPath);
@@ -602,26 +581,6 @@ namespace ProjectManager.Actions
             catch (Exception exception)
             {
                 ErrorManager.ShowError(exception);
-            }
-        }
-
-        private void CopyDirectory(string fromPath, string toPath)
-        {
-            if (!Directory.Exists(toPath))
-                Directory.CreateDirectory(toPath);
-
-            foreach (string file in Directory.GetFiles(fromPath))
-            {
-                string name = Path.GetFileName(file);
-                string destFile = Path.Combine(toPath, name);
-                File.Copy(file, destFile, true);
-            }
-
-            foreach (string subdir in Directory.GetDirectories(fromPath))
-            {
-                string name = Path.GetFileName(subdir);
-                string destDir = Path.Combine(toPath, name);
-                CopyDirectory(subdir, destDir);
             }
         }
 

--- a/External/Plugins/ProjectManager/Actions/FileActions.cs
+++ b/External/Plugins/ProjectManager/Actions/FileActions.cs
@@ -443,10 +443,11 @@ namespace ProjectManager.Actions
                         Directory.Move(oldPathFixed, tmpPath);
                         oldPathFixed = tmpPath;
                     }
-                    if (FileHelper.ConfirmOverwrite(newPathFixed))
+                    if (FileHelper.ConfirmOverwrite(newPath))
                     {
-                        FileHelper.ForceMove(oldPathFixed, newPathFixed);
+                        FileHelper.ForceMoveDirectory(oldPathFixed, newPathFixed);
                     }
+                    else return false;
                 }
                 else
                 {

--- a/External/Plugins/ProjectManager/Projects/Haxe/HaxeProject.cs
+++ b/External/Plugins/ProjectManager/Projects/Haxe/HaxeProject.cs
@@ -27,7 +27,7 @@ namespace ProjectManager.Projects.Haxe
         public override bool ReadOnly { get { return false; } }
         public override bool HasLibraries { get { return OutputType == OutputType.Application && IsFlashOutput; } }
         public override bool RequireLibrary { get { return IsFlashOutput; } }
-        public override string DefaultSearchFilter { get { return "*.hx"; } }
+        public override string DefaultSearchFilter { get { return "*.hx;*.hxp"; } }
 
         public override String LibrarySWFPath
         {

--- a/PluginCore/PluginCore/Helpers/FileHelper.cs
+++ b/PluginCore/PluginCore/Helpers/FileHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using System.Collections.Generic;
 using PluginCore.Utilities;
@@ -28,7 +29,7 @@ namespace PluginCore.Helpers
         }
 
         /// <summary>
-        /// Reads the file and returns it's contents (autodetects encoding and fallback codepage)
+        /// Reads the file and returns its contents (autodetects encoding and fallback codepage)
         /// </summary>
         public static String ReadFile(String file)
         {
@@ -37,8 +38,8 @@ namespace PluginCore.Helpers
         }
 
         /// <summary>
-		/// Reads the file and returns it's contents
-		/// </summary>
+        /// Reads the file and returns its contents
+        /// </summary>
         public static String ReadFile(String file, Encoding encoding)
         {
             using (StreamReader sr = new StreamReader(file, encoding))
@@ -289,6 +290,62 @@ namespace PluginCore.Helpers
         }
 
         /// <summary>
+        /// Moves a folder, overwriting the files at the new location if there are matches.
+        /// </summary>
+        public static void CopyDirectory(String oldPath, String newPath, Boolean overwrite)
+        {
+            var stack = new Stack<String>();
+            stack.Push(string.Empty);
+
+            int length = oldPath.EndsWith(Path.DirectorySeparatorChar.ToString()) ||
+                         oldPath.EndsWith(Path.AltDirectorySeparatorChar.ToString())
+                             ? oldPath.Length : oldPath.Length + 1;
+            while (stack.Count > 0)
+            {
+                var subPath = stack.Pop();
+                var sourcePath = Path.Combine(oldPath, subPath);
+                var targetPath = Path.Combine(newPath, subPath);
+                if (!Directory.Exists(targetPath))
+                    Directory.CreateDirectory(targetPath);
+
+                foreach (var file in Directory.GetFiles(sourcePath, "*.*"))
+                    File.Copy(file, Path.Combine(targetPath, Path.GetFileName(file)), overwrite);
+
+                foreach (var folder in Directory.GetDirectories(sourcePath))
+                    stack.Push(folder.Substring(length));
+            }
+        }
+
+        /// <summary>
+        /// Moves a folder, overwriting the files at the new location if there are matches.
+        /// </summary>
+        public static void ForceMoveDirectory(String oldPath, String newPath)
+        {
+            var stack = new Stack<String>();
+            stack.Push(string.Empty);
+
+            int length = oldPath.EndsWith(Path.DirectorySeparatorChar.ToString()) ||
+                         oldPath.EndsWith(Path.AltDirectorySeparatorChar.ToString())
+                             ? oldPath.Length : oldPath.Length + 1;
+            while (stack.Count > 0)
+            {
+                var subPath = stack.Pop();
+                var sourcePath = Path.Combine(oldPath, subPath);
+                var targetPath = Path.Combine(newPath, subPath);
+                if (!Directory.Exists(targetPath))
+                    Directory.CreateDirectory(targetPath);
+
+                foreach (var file in Directory.GetFiles(sourcePath, "*.*"))
+                    ForceMove(file, Path.Combine(targetPath, Path.GetFileName(file)));
+
+                foreach (var folder in Directory.GetDirectories(sourcePath))
+                    stack.Push(folder.Substring(length));
+            }
+
+            Directory.Delete(oldPath, true);
+        }
+
+        /// <summary>
         /// If the path already exists, the user is asked to confirm
         /// </summary>
         public static bool ConfirmOverwrite(string path)
@@ -316,6 +373,23 @@ namespace PluginCore.Helpers
                 return result == DialogResult.Yes;
             }
             else return true;
+        }
+
+        /// <summary>
+        /// Checks if a file name matches a search filter mask, eg: filename.jpg matches f*.jpg
+        /// </summary>
+        /// <param name="fileName">The name of the file to check</param>
+        /// <param name="filterMask">The search filter to apply. You can use multiple masks by using ;</param>
+        public static bool FileMatchesSearchFilter(string fileName, string filterMask)
+        {
+            foreach (string mask in filterMask.Split(';'))
+            {
+                String convertedMask = "^" + Regex.Escape(mask).Replace("\\*", ".*").Replace("\\?", ".") + "$";
+                Regex regexMask = new Regex(convertedMask, RegexOptions.IgnoreCase);
+                if (regexMask.IsMatch(fileName)) return true;
+            }
+
+            return false;
         }
 
         public static bool IsHaxeExtension(string extension)

--- a/PluginCore/PluginCore/Managers/DocumentManager.cs
+++ b/PluginCore/PluginCore/Managers/DocumentManager.cs
@@ -65,7 +65,10 @@ namespace PluginCore.Managers
             ITabbedDocument current = PluginBase.MainForm.CurrentDocument;
             foreach (ITabbedDocument document in PluginBase.MainForm.Documents)
             {
-                if (document.IsEditable)
+                /* We need to check for virtual models, another more generic option would be 
+                 *  Path.GetFileName(document.FileName).IndexOfAny(Path.GetInvalidFileNameChars()) == -1
+                 * But this one is used in more places */
+                if (document.IsEditable && !document.Text.StartsWith("[model] "))
                 {
                     String filename = Path.GetFullPath(document.FileName);
                     if (filename.StartsWith(oldPath))

--- a/PluginCore/PluginCore/Resources/de_DE.resX
+++ b/PluginCore/PluginCore/Resources/de_DE.resX
@@ -5314,4 +5314,8 @@ Eigene Sprachumgebungen müssen eine Erweiterung der Standard-Sprachumgebung sei
     <value>Declare protected variable</value>
     <comment>Added after 4.6.4</comment>
   </data>
+  <data name="ProjectManager.Info.ExtensionChangeWarning" xml:space="preserve">
+    <value>If you change a file name extension, the file may become unusable. Are you sure you want to change it?</value>
+    <comment>Added after 4.6.4</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/de_DE.resX
+++ b/PluginCore/PluginCore/Resources/de_DE.resX
@@ -5318,4 +5318,8 @@ Eigene Sprachumgebungen müssen eine Erweiterung der Standard-Sprachumgebung sei
     <value>If you change a file name extension, the file may become unusable. Are you sure you want to change it?</value>
     <comment>Added after 4.6.4</comment>
   </data>
+  <data name="CodeRefactor.Info.MovingOutsideClasspath" xml:space="preserve">
+    <value>You are moving files outside your defined classpaths. Refactoring is not available and your project may stop working. Continue?</value>
+    <comment>Added after 4.6.4</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -5320,4 +5320,8 @@ Custom locales must be an extension of a default locale, e.g. en-US.</value>
     <value>Declare protected variable</value>
     <comment>Added after 4.6.4</comment>
   </data>
+  <data name="ProjectManager.Info.ExtensionChangeWarning" xml:space="preserve">
+    <value>If you change a file name extension, the file may become unusable. Are you sure you want to change it?</value>
+    <comment>Added after 4.6.4</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -5324,4 +5324,8 @@ Custom locales must be an extension of a default locale, e.g. en-US.</value>
     <value>If you change a file name extension, the file may become unusable. Are you sure you want to change it?</value>
     <comment>Added after 4.6.4</comment>
   </data>
+  <data name="CodeRefactor.Info.MovingOutsideClasspath" xml:space="preserve">
+    <value>You are moving files outside your defined classpaths. Refactoring is not available and your project may stop working. Continue?</value>
+    <comment>Added after 4.6.4</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/eu_ES.resX
+++ b/PluginCore/PluginCore/Resources/eu_ES.resX
@@ -5307,4 +5307,8 @@ Lokalizazio pertsonalizatuek lehenetsiaren luzapen bat izan behar dute, adb. en-
     <value>protected aldagaia deklaratu</value>
     <comment>Added after 4.6.4</comment>
   </data>
+  <data name="ProjectManager.Info.ExtensionChangeWarning" xml:space="preserve">
+    <value>If you change a file name extension, the file may become unusable. Are you sure you want to change it?</value>
+    <comment>Added after 4.6.4</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/eu_ES.resX
+++ b/PluginCore/PluginCore/Resources/eu_ES.resX
@@ -5311,4 +5311,8 @@ Lokalizazio pertsonalizatuek lehenetsiaren luzapen bat izan behar dute, adb. en-
     <value>If you change a file name extension, the file may become unusable. Are you sure you want to change it?</value>
     <comment>Added after 4.6.4</comment>
   </data>
+  <data name="CodeRefactor.Info.MovingOutsideClasspath" xml:space="preserve">
+    <value>You are moving files outside your defined classpaths. Refactoring is not available and your project may stop working. Continue?</value>
+    <comment>Added after 4.6.4</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/ja_JP.resX
+++ b/PluginCore/PluginCore/Resources/ja_JP.resX
@@ -5373,4 +5373,8 @@ UseData:"</value>
     <value>protected 変数を作成</value>
     <comment>Added after 4.6.4</comment>
   </data>
+  <data name="ProjectManager.Info.ExtensionChangeWarning" xml:space="preserve">
+    <value>If you change a file name extension, the file may become unusable. Are you sure you want to change it?</value>
+    <comment>Added after 4.6.4</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/ja_JP.resX
+++ b/PluginCore/PluginCore/Resources/ja_JP.resX
@@ -5278,7 +5278,6 @@ UseData:"</value>
   </data>
   <data name="AirProperties.Label.ExitOnSuspend" xml:space="preserve">
     <value>実行を終了</value>
-    <value>Exit On Suspend</value>
     <comment>Added after 4.6.3</comment>
   </data>
   <data name="AirProperties.Label.ExternalSWFs" xml:space="preserve">

--- a/PluginCore/PluginCore/Resources/ja_JP.resX
+++ b/PluginCore/PluginCore/Resources/ja_JP.resX
@@ -5377,4 +5377,8 @@ UseData:"</value>
     <value>If you change a file name extension, the file may become unusable. Are you sure you want to change it?</value>
     <comment>Added after 4.6.4</comment>
   </data>
+  <data name="CodeRefactor.Info.MovingOutsideClasspath" xml:space="preserve">
+    <value>You are moving files outside your defined classpaths. Refactoring is not available and your project may stop working. Continue?</value>
+    <comment>Added after 4.6.4</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/zh_CN.resx
+++ b/PluginCore/PluginCore/Resources/zh_CN.resx
@@ -5320,4 +5320,8 @@
     <value>Declare protected variable</value>
     <comment>Added after 4.6.4</comment>
   </data>
+  <data name="ProjectManager.Info.ExtensionChangeWarning" xml:space="preserve">
+    <value>If you change a file name extension, the file may become unusable. Are you sure you want to change it?</value>
+    <comment>Added after 4.6.4</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/zh_CN.resx
+++ b/PluginCore/PluginCore/Resources/zh_CN.resx
@@ -5324,4 +5324,8 @@
     <value>If you change a file name extension, the file may become unusable. Are you sure you want to change it?</value>
     <comment>Added after 4.6.4</comment>
   </data>
+  <data name="CodeRefactor.Info.MovingOutsideClasspath" xml:space="preserve">
+    <value>You are moving files outside your defined classpaths. Refactoring is not available and your project may stop working. Continue?</value>
+    <comment>Added after 4.6.4</comment>
+  </data>
 </root>


### PR DESCRIPTION
Fixed tons of errors and unsupported cases, mainly in the Move command. Should fix issues #144 #162 #187 #400 #518 and several more issues not reported.
Rename command left modified files unsaved, while Move command saved them, the latter is the common approach taken, and I'd say seeing tons of files with unsaved changes may confuse the user, so made Rename to behave the same.
The Move command tried to keep modified files open, but the code was wrong, I fixed the initial check but left it commented, I think it pollutes the user interfaces when the refactoring affects many files. If this feature is wanted it would require some further changes.
When the Move and Rename commands finish, the affected files that were initially open are kept open, although the position is lost.
Removed calls to RefactoringHelper.GetSearchPatternFromLang and use Project.DefaultSearchExtension instead, that way everything is centralized, this allowed to see the default search filter of Haxe projects was missing the recently added .hxp files (confirmed to be an oversight), and made finding references able to find matches in code sections of MXML files (no extensively tested).
Made folder-package check case-sensitive, as it's the right thing to do.