### PR TITLE
Read only project properties

### DIFF
--- a/External/Plugins/ProjectManager/Controls/PropertiesDialog.cs
+++ b/External/Plugins/ProjectManager/Controls/PropertiesDialog.cs
@@ -955,7 +955,28 @@ namespace ProjectManager.Controls
             classpathControl.Classpaths = project.Classpaths.ToArray();
             classpathControl.Language = project.Language;
             classpathControl.LanguageBox.Visible = false;
+            UpdateClasspaths(project.MovieOptions.Platform);
             classpathsChanged = false;
+        }
+
+        private void UpdateClasspaths(string platform)
+        {
+            LanguagePlatform langPlatform = GetLanguagePlatform(platform);
+            if (langPlatform != null)
+            {
+                string selectedVersion = versionCombo.Text == "" ? "1.0" : versionCombo.Text;
+                PlatformVersion version = langPlatform.GetVersion(selectedVersion);
+                
+                if (version != null && version.Commands != null && version.Commands.ContainsKey("display"))
+                {
+                    classpathControl.Enabled = false;
+                    label2.Text = String.Format(TextHelper.GetString("Info.ProjectClasspathsDisabled"), platform);
+                    return;
+                }
+            }
+
+            classpathControl.Enabled = true;
+            label2.Text = TextHelper.GetString("Info.ProjectClasspaths");
         }
 
         private void InitSDKTab()
@@ -1020,6 +1041,7 @@ namespace ProjectManager.Controls
 
             InitCombo(versionCombo, project.MovieOptions.TargetVersions(this.platformCombo.Text), project.MovieOptions.Version);
             versionCombo.SelectedIndexChanged += new EventHandler(versionCombo_SelectedIndexChanged);
+            UpdateVersionCombo();
 
             InitTestMovieOptions();
             UpdateGeneralPanel();
@@ -1032,6 +1054,19 @@ namespace ProjectManager.Controls
             editCommandButton.Visible = state == TestMovieBehavior.Custom 
                 || state == TestMovieBehavior.OpenDocument
                 || state == TestMovieBehavior.Webserver;
+        }
+
+        private void UpdateVersionCombo()
+        {
+            if (versionCombo.Items.Count > 1)
+            {
+                versionCombo.Enabled = true;
+            }
+            else
+            {
+                versionCombo.Enabled = false;
+                versionCombo.SelectedIndex = -1;
+            }
         }
 
         private void InitTestMovieOptions()
@@ -1090,6 +1125,18 @@ namespace ProjectManager.Controls
         {
             if (testMovieCombo.SelectedIndex < 0) return TestMovieBehavior.Unknown;
             else return (TestMovieBehavior)Enum.Parse(typeof(TestMovieBehavior), (testMovieCombo.SelectedItem as ComboItem).Value.ToString());
+        }
+
+        private LanguagePlatform GetLanguagePlatform(string platform)
+        {
+            LanguagePlatform langPlatform = null;
+            if (PlatformData.SupportedLanguages.ContainsKey(project.Language))
+            {
+                SupportedLanguage lang = PlatformData.SupportedLanguages[project.Language];
+                if (lang.Platforms.ContainsKey(platform))
+                    langPlatform = lang.Platforms[platform];
+            }
+            return langPlatform;
         }
 
 		protected void Modified()
@@ -1219,9 +1266,11 @@ namespace ProjectManager.Controls
             this.versionCombo.SelectedIndex = Math.Max(0, this.versionCombo.Items.IndexOf(
                         project.MovieOptions.DefaultVersion(this.platformCombo.Text)));
 
+            UpdateVersionCombo();
             InitTestMovieOptions();
             UpdateGeneralPanel();
             UpdateEditCommandButton();
+            UpdateClasspaths(platformCombo.Text);
 
             DetectExternalToolchain();
 
@@ -1372,6 +1421,12 @@ namespace ProjectManager.Controls
             bool isGraphical = project.MovieOptions.IsGraphical(GetPlatform());
             widthTextBox.Enabled = heightTextBox.Enabled = fpsTextBox.Enabled
                 = colorTextBox.Enabled = colorLabel.Enabled = isGraphical;
+
+            LanguagePlatform langPlatform = GetLanguagePlatform(platformCombo.Text);
+            if (langPlatform != null && langPlatform.ExternalToolchain != null)
+                exportinLabel.Text = TextHelper.GetString("Label.ConfigurationFile");
+            else
+                exportinLabel.Text = TextHelper.GetString("Label.OutputFile");
         }
 
         private void manageButton_Click(object sender, EventArgs e)

--- a/External/Plugins/ProjectManager/Projects/Haxe/HaxeProjectReader.cs
+++ b/External/Plugins/ProjectManager/Projects/Haxe/HaxeProjectReader.cs
@@ -107,7 +107,7 @@ namespace ProjectManager.Projects.Haxe
             }
         }
 
-        // process HaXe-specific stuff
+        // process Haxe-specific stuff
         protected override void ProcessNode(string name)
         {
             switch (name)

--- a/FlashDevelop/Bin/Debug/Settings/Platforms/Haxe/flambe.xml
+++ b/FlashDevelop/Bin/Debug/Settings/Platforms/Haxe/flambe.xml
@@ -1,5 +1,5 @@
-<platform name="Flambe" targets="html,flash,android,ios,firefox" debugger="flash" 
-	external="cmd" external-capture="html,flash,android,ios,firefox" default-project="flambe.yaml">
+<platform name="Flambe" targets="html,flash,android,ios,firefox" debugger="flash"
+  external="cmd" external-capture="html,flash,android,ios,firefox" default-project="flambe.yaml">
   <versions>
     <version value="4.0">
       <command name="display" value="flambe haxe-flags $(TargetBuild)"/>

--- a/FlashDevelop/Bin/Debug/Settings/Platforms/Haxe/lime.xml
+++ b/FlashDevelop/Bin/Debug/Settings/Platforms/Haxe/lime.xml
@@ -1,5 +1,5 @@
 <platform name="Lime" targets="html5,flash,windows,neko,android,tizen,blackberry,webos" debugger="flash" 
-	external="haxelib" external-capture="windows,neko,android,tizen,blackberry,webos" default-project="project.xml,application.xml">
+  external="haxelib" external-capture="windows,neko,android,tizen,blackberry,webos" default-project="project.xml,application.xml">
   <versions>
     <version value="1.0">
       <command name="display" value="lime display &quot;$(OutputFile)&quot; $(TargetBuild) -$(BuildConfig)"/>

--- a/FlashDevelop/Bin/Debug/Settings/Platforms/Haxe/nme.xml
+++ b/FlashDevelop/Bin/Debug/Settings/Platforms/Haxe/nme.xml
@@ -1,5 +1,5 @@
-<platform name="Nme" targets="flash,windows,android" debugger="flash" 
-	external="haxelib" external-capture="windows,android" default-project="project.nmml,application.nmml">
+<platform name="NME" targets="flash,windows,android" debugger="flash" external="haxelib"
+  external-capture="windows,android" default-project="project.nmml,application.nmml">
   <versions>
     <version value="1.0">
       <command name="display" value="nme display &quot;$(OutputFile)&quot; $(TargetBuild) -$(BuildConfig)"/>

--- a/PluginCore/PluginCore/PlatformData.cs
+++ b/PluginCore/PluginCore/PlatformData.cs
@@ -265,6 +265,5 @@ namespace PluginCore
         public string Value;
         public XmlNode RawData;
     }
-
 }
 

--- a/PluginCore/PluginCore/Resources/de_DE.resX
+++ b/PluginCore/PluginCore/Resources/de_DE.resX
@@ -1771,7 +1771,7 @@ Ansonsten kann Adobe Flash Professional auch zum Überprüfen der Syntax verwend
     <value>Der ausgewählte Pfad steht in einem Konflikt mit einem bereits existierenden Klassenpfad {0}. Möchten Sie ihn dennoch hinzufüen?</value>
   </data>
   <data name="ProjectManager.Info.Platform" xml:space="preserve">
-    <value>Platform</value>
+    <value>Plattform</value>
   </data>
   <data name="ProjectManager.Info.Popup" xml:space="preserve">
     <value>In Popup ausführen</value>
@@ -1784,6 +1784,10 @@ Ansonsten kann Adobe Flash Professional auch zum Überprüfen der Syntax verwend
   </data>
   <data name="ProjectManager.Info.ProjectClasspaths" xml:space="preserve">
     <value>Projekt-Klassenpfade sind relativ zum Projektverzeichnis.</value>
+  </data>
+  <data name="ProjectManager.Info.ProjectClasspathsDisabled" xml:space="preserve">
+    <value>Klassenpfade von {0}-Projekten werden von der Ausgabedatei bestimmt.</value>
+    <comment>Added after 4.7.0</comment>
   </data>
   <data name="ProjectManager.Info.ProjectDirectory" xml:space="preserve">
     <value>&lt;Projektverzeichnis&gt;</value>
@@ -2014,6 +2018,10 @@ Ansonsten kann Adobe Flash Professional auch zum Überprüfen der Syntax verwend
   </data>
   <data name="ProjectManager.Label.OutputFile" xml:space="preserve">
     <value>&amp;Ausgabedatei:</value>
+  </data>
+  <data name="ProjectManager.Label.ConfigurationFile" xml:space="preserve">
+    <value>&amp;Konfigurationsdatei:</value>
+    <comment>Added after 4.7.0</comment>
   </data>
   <data name="ProjectManager.Label.Paste" xml:space="preserve">
     <value>&amp;Einfügen</value>
@@ -4192,7 +4200,7 @@ Bitte bedenken Sie, dass Sie viele Projektoptionen nicht mehr nutzen können, so
     <comment>Added after 3.3.1</comment>
   </data>
   <data name="AirProperties.Label.NonWindowedPlatforms" xml:space="preserve">
-    <value>Fensterlose Platformen</value>
+    <value>Fensterlose Plattformen</value>
     <comment>Added after 3.3.1</comment>
   </data>
   <data name="AirProperties.Label.Ok" xml:space="preserve">
@@ -4268,7 +4276,7 @@ Bitte bedenken Sie, dass Sie viele Projektoptionen nicht mehr nutzen können, so
     <comment>Added after 3.3.1</comment>
   </data>
   <data name="AirProperties.Label.WindowedPlatforms" xml:space="preserve">
-    <value>Platformen mit Fenstern</value>
+    <value>Plattformen mit Fenstern</value>
     <comment>Added after 3.3.1</comment>
   </data>
   <data name="AirProperties.Locale.ChineseSimplified" xml:space="preserve">

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -1768,6 +1768,10 @@ Alternatively, Adobe Flash Professional can also be used for syntax checking - p
   <data name="ProjectManager.Info.ProjectClasspaths" xml:space="preserve">
     <value>Project classpaths are relative to the project location.</value>
   </data>
+  <data name="ProjectManager.Info.ProjectClasspathsDisabled" xml:space="preserve">
+    <value>Classpaths of {0} projects are determined by the output file.</value>
+    <comment>Added after 4.7.0</comment>
+  </data>
   <data name="ProjectManager.Info.ProjectDirectory" xml:space="preserve">
     <value>&lt;Project Directory&gt;</value>
   </data>
@@ -2001,6 +2005,10 @@ Alternatively, Adobe Flash Professional can also be used for syntax checking - p
   </data>
   <data name="ProjectManager.Label.OutputFile" xml:space="preserve">
     <value>&amp;Output file:</value>
+  </data>
+  <data name="ProjectManager.Label.ConfigurationFile" xml:space="preserve">
+    <value>&amp;Configuration file:</value>
+    <comment>Added after 4.7.0</comment>
   </data>
   <data name="ProjectManager.Label.Paste" xml:space="preserve">
     <value>&amp;Paste</value>

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -1769,7 +1769,7 @@ Alternatively, Adobe Flash Professional can also be used for syntax checking - p
     <value>Project classpaths are relative to the project location.</value>
   </data>
   <data name="ProjectManager.Info.ProjectClasspathsDisabled" xml:space="preserve">
-    <value>Classpaths of {0} projects are determined by the output file.</value>
+    <value>Classpaths of {0} projects are determined by the Configuration file.</value>
     <comment>Added after 4.7.0</comment>
   </data>
   <data name="ProjectManager.Info.ProjectDirectory" xml:space="preserve">

--- a/PluginCore/PluginCore/Resources/eu_ES.resX
+++ b/PluginCore/PluginCore/Resources/eu_ES.resX
@@ -1767,6 +1767,10 @@ Alternatiba gisa, Adobe Flash Professional ere sintaxi egiaztapenerako erabil da
   <data name="ProjectManager.Info.ProjectClasspaths" xml:space="preserve">
     <value>Proiektuaren bide-izenak proiektuaren kokapenari erlatiboak dira.</value>
   </data>
+  <data name="ProjectManager.Info.ProjectClasspathsDisabled" xml:space="preserve">
+    <value>Classpaths of {0} projects are determined by the output file.</value>
+    <comment>Added after 4.7.0</comment>
+  </data>
   <data name="ProjectManager.Info.ProjectDirectory" xml:space="preserve">
     <value>&lt;Proiektuaren direktorioa&gt;</value>
   </data>
@@ -1999,6 +2003,10 @@ Alternatiba gisa, Adobe Flash Professional ere sintaxi egiaztapenerako erabil da
   </data>
   <data name="ProjectManager.Label.OutputFile" xml:space="preserve">
     <value>&amp;Irteera fitxategia:</value>
+  </data>
+  <data name="ProjectManager.Label.ConfigurationFile" xml:space="preserve">
+    <value>&amp;Configuration file:</value>
+    <comment>Added after 4.7.0</comment>
   </data>
   <data name="ProjectManager.Label.Paste" xml:space="preserve">
     <value>&amp;Itsatsi</value>

--- a/PluginCore/PluginCore/Resources/eu_ES.resX
+++ b/PluginCore/PluginCore/Resources/eu_ES.resX
@@ -1768,7 +1768,7 @@ Alternatiba gisa, Adobe Flash Professional ere sintaxi egiaztapenerako erabil da
     <value>Proiektuaren bide-izenak proiektuaren kokapenari erlatiboak dira.</value>
   </data>
   <data name="ProjectManager.Info.ProjectClasspathsDisabled" xml:space="preserve">
-    <value>Classpaths of {0} projects are determined by the output file.</value>
+    <value>Classpaths of {0} projects are determined by the Configuration file.</value>
     <comment>Added after 4.7.0</comment>
   </data>
   <data name="ProjectManager.Info.ProjectDirectory" xml:space="preserve">

--- a/PluginCore/PluginCore/Resources/ja_JP.resX
+++ b/PluginCore/PluginCore/Resources/ja_JP.resX
@@ -1770,6 +1770,10 @@
   <data name="ProjectManager.Info.ProjectClasspaths" xml:space="preserve">
     <value>クラスパスはプロジェクトファイルとの相対パスで指定します。</value>
   </data>
+  <data name="ProjectManager.Info.ProjectClasspathsDisabled" xml:space="preserve">
+    <value>Classpaths of {0} projects are determined by the output file.</value>
+    <comment>Added after 4.7.0</comment>
+  </data>
   <data name="ProjectManager.Info.ProjectDirectory" xml:space="preserve">
     <value>&lt;プロジェクト ディレクトリ&gt;</value>
   </data>
@@ -2005,6 +2009,10 @@
   </data>
   <data name="ProjectManager.Label.OutputFile" xml:space="preserve">
     <value>書き出し先(&amp;O):</value>
+  </data>
+  <data name="ProjectManager.Label.ConfigurationFile" xml:space="preserve">
+    <value>&amp;Configuration file:</value>
+    <comment>Added after 4.7.0</comment>
   </data>
   <data name="ProjectManager.Label.Paste" xml:space="preserve">
     <value>貼り付け(&amp;P)</value>

--- a/PluginCore/PluginCore/Resources/ja_JP.resX
+++ b/PluginCore/PluginCore/Resources/ja_JP.resX
@@ -1771,7 +1771,7 @@
     <value>クラスパスはプロジェクトファイルとの相対パスで指定します。</value>
   </data>
   <data name="ProjectManager.Info.ProjectClasspathsDisabled" xml:space="preserve">
-    <value>Classpaths of {0} projects are determined by the output file.</value>
+    <value>Classpaths of {0} projects are determined by the Configuration file.</value>
     <comment>Added after 4.7.0</comment>
   </data>
   <data name="ProjectManager.Info.ProjectDirectory" xml:space="preserve">

--- a/PluginCore/PluginCore/Resources/zh_CN.resx
+++ b/PluginCore/PluginCore/Resources/zh_CN.resx
@@ -1768,6 +1768,10 @@
   <data name="ProjectManager.Info.ProjectClasspaths" xml:space="preserve">
     <value>项目类路径是相对于项目位置.</value>
   </data>
+  <data name="ProjectManager.Info.ProjectClasspathsDisabled" xml:space="preserve">
+    <value>Classpaths of {0} projects are determined by the output file.</value>
+    <comment>Added after 4.7.0</comment>
+  </data>
   <data name="ProjectManager.Info.ProjectDirectory" xml:space="preserve">
     <value>&lt;项目文件夹&gt;</value>
   </data>
@@ -2001,6 +2005,10 @@
   </data>
   <data name="ProjectManager.Label.OutputFile" xml:space="preserve">
     <value>输出文件(&amp;O):</value>
+  </data>
+  <data name="ProjectManager.Label.ConfigurationFile" xml:space="preserve">
+    <value>&amp;Configuration file:</value>
+    <comment>Added after 4.7.0</comment>
   </data>
   <data name="ProjectManager.Label.Paste" xml:space="preserve">
     <value>粘贴(&amp;P)</value>


### PR DESCRIPTION
Little refactor of PropertiesDialog and made the Compiler Options grid read only for OpenFL/etc. projects