### PR TITLE
Recovered watcher disable/enable calls

### DIFF
--- a/External/Plugins/ProjectManager/Actions/FileActions.cs
+++ b/External/Plugins/ProjectManager/Actions/FileActions.cs
@@ -27,6 +27,8 @@ namespace ProjectManager.Actions
         public const string FileCopy = "ProjectManager.FileActions.Copy";
         public const string FileCut = "ProjectManager.FileActions.Cut";
         public const string FilePaste = "ProjectManager.FileActions.Paste";
+        public const string FileEnableWatchers = "ProjectManager.FileActions.EnableWatchers";
+        public const string FileDisableWatchers = "ProjectManager.FileActions.DisableWatchers";
     }
 
     /// <summary>
@@ -341,11 +343,13 @@ namespace ProjectManager.Actions
 
                 if (result == DialogResult.OK)
                 {
+                    DisableWatchers();
                     if (!FileHelper.Recycle(path))
                     {
                         String error = TextHelper.GetString("FlashDevelop.Info.CouldNotBeRecycled");
                         throw new Exception(error + " " + path);
                     }
+
                     OnFileDeleted(path);
                 }
             }
@@ -353,7 +357,11 @@ namespace ProjectManager.Actions
             {
                 ErrorManager.ShowError(exception);
             }
-            finally { PopCurrentDirectory(); }
+            finally
+            {
+                EnableWatchers();
+                PopCurrentDirectory();
+            }
         }
 
         public void Delete(string[] paths)
@@ -377,6 +385,8 @@ namespace ProjectManager.Actions
 
                     if (result == DialogResult.OK)
                     {
+                        DisableWatchers();
+
                         foreach (string path in paths)
                         {
                             if (!FileHelper.Recycle(path))
@@ -392,7 +402,11 @@ namespace ProjectManager.Actions
                 {
                     ErrorManager.ShowError(exception);
                 }
-                finally { PopCurrentDirectory(); }
+                finally
+                {
+                    EnableWatchers();
+                    PopCurrentDirectory();
+                }
             }
         }
 
@@ -424,6 +438,7 @@ namespace ProjectManager.Actions
 
             try
             {
+                DisableWatchers();
                 PushCurrentDirectory();
 
                 string oldDir = Path.GetDirectoryName(oldPath);
@@ -473,7 +488,11 @@ namespace ProjectManager.Actions
                 ErrorManager.ShowError(exception);
                 return false;
             }
-            finally { PopCurrentDirectory(); }
+            finally
+            {
+                EnableWatchers();
+                PopCurrentDirectory();
+            }
             return true;
         }
 
@@ -483,6 +502,7 @@ namespace ProjectManager.Actions
 
             try
             {
+                DisableWatchers();
                 PushCurrentDirectory();
 
                 // try to fix toPath if it's a filename
@@ -514,7 +534,11 @@ namespace ProjectManager.Actions
             {
                 ErrorManager.ShowError(exception);
             }
-            finally { PopCurrentDirectory(); }
+            finally
+            {
+                EnableWatchers();
+                PopCurrentDirectory();
+            }
         }
 
         public void Copy(string fromPath, string toPath)
@@ -601,6 +625,18 @@ namespace ProjectManager.Actions
             }
             File.Copy(file, filePath, true);
             return filePath;
+        }
+
+        private void DisableWatchers()
+        {
+            DataEvent disableWatchers = new DataEvent(EventType.Command, ProjectFileActionsEvents.FileDisableWatchers, null);
+            EventManager.DispatchEvent(this, disableWatchers);
+        }
+
+        private void EnableWatchers()
+        {
+            DataEvent enableWatchers = new DataEvent(EventType.Command, ProjectFileActionsEvents.FileEnableWatchers, null);
+            EventManager.DispatchEvent(this, enableWatchers);
         }
 
         #endregion


### PR DESCRIPTION
The old MoveDirectory method had watcher calls, but Move, the only function that was calling it, is already wrapped in watcher calls.

EDIT: BTW, I'll commit more improvements to the Move and Rename commands during this week.