### PR TITLE
Fix for crash in some incorrectly defined metadata tags

### DIFF
--- a/External/Plugins/ASCompletion/Model/FileModel.cs
+++ b/External/Plugins/ASCompletion/Model/FileModel.cs
@@ -55,7 +55,7 @@ namespace ASCompletion.Model
                 if (mParams.Count > 0)
                 {
                     for (int i = 0, c = mParams.Count; i < c; i++)
-                        Params.Add(mParams[i].Groups[1].Value, mParams[i].Groups[2].Value);
+                        Params[mParams[i].Groups[1].Value] = mParams[i].Groups[2].Value;
                 }
                 else if (Kind == ASMetaKind.Event || Kind == ASMetaKind.Style) // invalid Event
                     Kind = ASMetaKind.Unknown;


### PR DESCRIPTION
Wouldn't have committed this to the development branch if it were not because it fixes some possible nasty crashes, and FD 4.7 is not released yet.

EDIT: For example the ones fixed here: https://github.com/apache/flex-flexunit/commit/1cf55d524f47affdb0c4e0e60d511d39e3d6e8b2

BTW, I was the one to add this crash while fixing other wrong cases and add some unsupported ones.