### PR TITLE
Ensure inserting import on Move is always added to a correct location

### DIFF
--- a/External/Plugins/CodeRefactor/Commands/Move.cs
+++ b/External/Plugins/CodeRefactor/Commands/Move.cs
@@ -537,6 +537,7 @@ namespace CodeRefactor.Commands
                 for (int i = actualMatches.Count - 1; i >= 0; i--)
                 {
                     var sm = actualMatches[i];
+                    if (currLine == -1) currLine = sm.Line - 1;
                     if (sm.LineText.Contains(oldType))
                     {
                         sm.Index -= sci.MBSafeTextLength(oldType) - sci.MBSafeTextLength(targetName);
@@ -550,7 +551,6 @@ namespace CodeRefactor.Commands
                     }
                     else
                     {
-                        if (currLine == -1) currLine = sm.Line - 1;
                         actualMatches.RemoveAt(i);
                     }
                 }


### PR DESCRIPTION
NOTE: This exposes some other limitations, eg: highlighting is wrong on some cases where the import is inserted. I'm aware, it will be handled on the upcoming rewrite of the class. More important generating code that compiles, than these other problems.