### PR TITLE
Lock redrawing completely 

### DIFF
--- a/External/Plugins/ASCompletion/CustomControls/StateSavingTreeView.cs
+++ b/External/Plugins/ASCompletion/CustomControls/StateSavingTreeView.cs
@@ -19,12 +19,12 @@ namespace System.Windows.Forms
         }
     }
 
-	/// <summary>
-	/// Exposes methods to save and restore TreeView state (such as scroll position
-	/// and expanded nodes) when rebuilding.
-	/// </summary>
-	public class StateSavingTreeView : TreeView
-	{
+    /// <summary>
+    /// Exposes methods to save and restore TreeView state (such as scroll position
+    /// and expanded nodes) when rebuilding.
+    /// </summary>
+    public class StateSavingTreeView : TreeView
+    {
         public TreeState State = new TreeState();
 
         public void BeginStatefulUpdate(TreeState withState)
@@ -33,12 +33,12 @@ namespace System.Windows.Forms
             BeginStatefulUpdate();
         }
 
-		public void BeginStatefulUpdate()
-		{
-			BeginUpdate();
-			SaveExpandedState();
-			SaveScrollState();
-		}
+        public void BeginStatefulUpdate()
+        {
+            BeginUpdate();
+            SaveExpandedState();
+            SaveScrollState();
+        }
 
         public void EndStatefulUpdate(TreeState withState)
         {
@@ -46,12 +46,12 @@ namespace System.Windows.Forms
             EndStatefulUpdate();
         }
 
-		public void EndStatefulUpdate()
-		{
-			RestoreExpandedState();
-			EndUpdate();
-			RestoreScrollState();
-		}
+        public void EndStatefulUpdate()
+        {
+            RestoreExpandedState();
+            EndUpdate();
+            RestoreScrollState();
+        }
 
         new public void BeginUpdate()
         {
@@ -66,81 +66,81 @@ namespace System.Windows.Forms
             Refresh();
         }
 
-		#region Expanded State Saving
+        #region Expanded State Saving
 
-		public void SaveExpandedState()
-		{
-			State.ExpandedPaths.Clear();
-			AddExpandedPaths(base.Nodes);
-		}
+        public void SaveExpandedState()
+        {
+            State.ExpandedPaths.Clear();
+            AddExpandedPaths(base.Nodes);
+        }
 
-		public void RestoreExpandedState()
-		{
-			foreach (string path in State.ExpandedPaths)
-			{
-				TreeNode node = FindClosestPath(path);
-				if (node != null)
-					node.Expand();
-			}
-		}
+        public void RestoreExpandedState()
+        {
+            foreach (string path in State.ExpandedPaths)
+            {
+                TreeNode node = FindClosestPath(path);
+                if (node != null)
+                    node.Expand();
+            }
+        }
 
-		void AddExpandedPaths(TreeNodeCollection nodes)
-		{
-			foreach (TreeNode node in nodes)
-			{
+        void AddExpandedPaths(TreeNodeCollection nodes)
+        {
+            foreach (TreeNode node in nodes)
+            {
                 if (node.IsExpanded) State.ExpandedPaths.Add(node.FullPath);
-				if (node.Nodes.Count > 0) AddExpandedPaths(node.Nodes);
-			}
-		}
+                if (node.Nodes.Count > 0) AddExpandedPaths(node.Nodes);
+            }
+        }
 
-		#endregion
+        #endregion
 
-		#region Scroll Position Saving
+        #region Scroll Position Saving
 
-		public TreeNode BottomNode
-		{
-			get
-			{
-				TreeNode bottomNode = null;
-				FindBottom(base.Nodes,ref bottomNode);
-				return bottomNode;
-			}
-		}
+        public TreeNode BottomNode
+        {
+            get
+            {
+                TreeNode bottomNode = null;
+                FindBottom(base.Nodes,ref bottomNode);
+                return bottomNode;
+            }
+        }
 
-		private void FindBottom(TreeNodeCollection nodes, ref TreeNode bottomNode)
-		{
-			foreach (TreeNode node in nodes)
-			{
-				if (node.IsVisible)
-					bottomNode = node;
+        private void FindBottom(TreeNodeCollection nodes, ref TreeNode bottomNode)
+        {
+            foreach (TreeNode node in nodes)
+            {
+                if (node.IsVisible)
+                    bottomNode = node;
 
-				else if (bottomNode != null)
-					return; // this node is the first invisible node after finding visible ones
+                else if (bottomNode != null)
+                    return; // this node is the first invisible node after finding visible ones
 
-				if (node.IsExpanded && node.Nodes.Count > 0)
-					FindBottom(node.Nodes,ref bottomNode);
-			}
-		}
+                if (node.IsExpanded && node.Nodes.Count > 0)
+                    FindBottom(node.Nodes,ref bottomNode);
+            }
+        }
 
-		public void SaveScrollState()
-		{
-			if (base.Nodes.Count < 1) return;
+        public void SaveScrollState()
+        {
+            if (base.Nodes.Count < 1) return;
 
-			// store what nodes were at the top and bottom so we can try and preserve scroll
-			// use the tag instead of node reference because you're most likely rebuilding
-			// the tree
-			TreeNode node = base.TopNode;
+            // store what nodes were at the top and bottom so we can try and preserve scroll
+            // use the tag instead of node reference because you're most likely rebuilding
+            // the tree
+            TreeNode node = base.TopNode;
             if (node != null) State.TopPath = node.FullPath;
             else State.TopPath = null;
-			//
-			node = this.BottomNode;
+            //
+            node = this.BottomNode;
             if (node != null) State.BottomPath = node.FullPath;
             else State.BottomPath = null;
-		}
+        }
 
-		public void RestoreScrollState()
-		{
-			if (base.Nodes.Count < 1) return;
+        public void RestoreScrollState()
+        {
+            if (base.Nodes.Count < 1) return;
 
             TreeNode bottomNode = FindClosestPath(State.BottomPath);
             TreeNode topNode = FindClosestPath(State.TopPath);
@@ -151,63 +151,63 @@ namespace System.Windows.Forms
             if (topNode != null)
                 topNode.EnsureVisible();
 
-			// manually scroll all the way to the left
-			Scrolling.scrollToLeft(this);
-		}
+            // manually scroll all the way to the left
+            Scrolling.scrollToLeft(this);
+        }
 
-		public TreeNode FindClosestPath(string path)
-		{
-			if (path == null || path.Length < 1) return null;
-			Queue queue = new Queue(path.Split('\\'));
-			return FindClosestPath(base.Nodes,queue);
-		}
+        public TreeNode FindClosestPath(string path)
+        {
+            if (path == null || path.Length < 1) return null;
+            Queue queue = new Queue(path.Split('\\'));
+            return FindClosestPath(base.Nodes,queue);
+        }
 
-		private TreeNode FindClosestPath(TreeNodeCollection nodes, Queue queue)
-		{
-			string nextChunk = queue.Dequeue() as string;
+        private TreeNode FindClosestPath(TreeNodeCollection nodes, Queue queue)
+        {
+            string nextChunk = queue.Dequeue() as string;
 
-			foreach (TreeNode node in nodes)
-			{
-				if (node.Text == nextChunk)
-				{
-					if (queue.Count > 0 && node.Nodes.Count > 0)
-						return FindClosestPath(node.Nodes,queue);
-					else
-						return node; // as close as we'll get
-				}
-			}
-			return null;
-		}
+            foreach (TreeNode node in nodes)
+            {
+                if (node.Text == nextChunk)
+                {
+                    if (queue.Count > 0 && node.Nodes.Count > 0)
+                        return FindClosestPath(node.Nodes,queue);
+                    else
+                        return node; // as close as we'll get
+                }
+            }
+            return null;
+        }
 
-		/*private void HScroll(System.IntPtr direction)
-		{
-			//Set  direction to 0 to scroll left 1 char
-			//Set  direction to 1 to scroll right 1 char
-			//Set  direction to 2 to scroll 1 page left
-			//Set  direction to 3 to scroll 1 page right
-			System.Windows.Forms.Message hScrollMessage = new Message();
+        /*private void HScroll(System.IntPtr direction)
+        {
+            //Set  direction to 0 to scroll left 1 char
+            //Set  direction to 1 to scroll right 1 char
+            //Set  direction to 2 to scroll 1 page left
+            //Set  direction to 3 to scroll 1 page right
+            System.Windows.Forms.Message hScrollMessage = new Message();
 
-			hScrollMessage.HWnd   = Handle;
-			hScrollMessage.Msg    = 0x0114;  // // #define WM_HSCROLL 0x0114
-			hScrollMessage.WParam = direction;
-			this.DefWndProc( ref hScrollMessage );
-		}*/
+            hScrollMessage.HWnd   = Handle;
+            hScrollMessage.Msg    = 0x0114;  // // #define WM_HSCROLL 0x0114
+            hScrollMessage.WParam = direction;
+            this.DefWndProc( ref hScrollMessage );
+        }*/
 
-		#endregion
+        #endregion
 
-	    protected static class NativeMethods
-	    {
+        protected static class NativeMethods
+        {
             public const int WM_SETREDRAW = 0xB;
             public const int WM_PRINTCLIENT = 0x0318;
-	        public const int PRF_CLIENT = 0x00000004;
+            public const int PRF_CLIENT = 0x00000004;
 
-	        private const int TV_FIRST = 0x1100;
-	        public const int TVM_SETEXTENDEDSTYLE = TV_FIRST + 44;
-	        public const int TVS_EX_DOUBLEBUFFER = 0x0004;
+            private const int TV_FIRST = 0x1100;
+            public const int TVM_SETEXTENDEDSTYLE = TV_FIRST + 44;
+            public const int TVS_EX_DOUBLEBUFFER = 0x0004;
 
-	        [DllImport("user32.dll")]
-	        public static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+            [DllImport("user32.dll")]
+            public static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
 
-	    }
-	}
+        }
+    }
 }

--- a/External/Plugins/ASCompletion/Win32/FixedTreeView.cs
+++ b/External/Plugins/ASCompletion/Win32/FixedTreeView.cs
@@ -75,7 +75,7 @@ namespace System.Windows.Forms
                 string text = currentNode.Text;
                 if ((prev == text) && (px == e.X) && (py == e.Y))
                     return;
-				
+                
                 // text dimensions
                 int offset = 25 - Win32.Scrolling.GetScrollPos(this.Handle, Win32.Scrolling.SB_HORZ);
                 while (currentNode.Parent != null)

--- a/External/Plugins/ASCompletion/Win32/FixedTreeView.cs
+++ b/External/Plugins/ASCompletion/Win32/FixedTreeView.cs
@@ -5,8 +5,6 @@
  * - extends StateSavingTreeView
  */
 
-using System.Runtime.InteropServices;
-
 namespace System.Windows.Forms
 {
     public class FixedTreeView : StateSavingTreeView
@@ -131,20 +129,6 @@ namespace System.Windows.Forms
                 e.Graphics.ReleaseHdc(m.WParam);
             }
             base.OnPaint(e);
-        }
-
-        private static class NativeMethods
-        {
-            public const int WM_PRINTCLIENT = 0x0318;
-            public const int PRF_CLIENT = 0x00000004;
-
-            private const int TV_FIRST = 0x1100;
-            public const int TVM_SETEXTENDEDSTYLE = TV_FIRST + 44;
-            public const int TVS_EX_DOUBLEBUFFER = 0x0004;
-
-            [DllImport("user32.dll")]
-            public static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
-
         }
     }
 }


### PR DESCRIPTION
With latest modifications treeview flickering was solved for some operations, with these ones the treeview drawing is locked while removing and adding new nodes (BeginUpdate() and EndUpdate() isn't 100% working for TreeView).

On all the machines I've tested I now see 0 flickering. The only case where the user may think there is flickering is when writing incomplete code before other functions as they'll be lost, and once the parse is able to get again the following functions they'll reappear.

I don't see the need of Begin/EndUpdate in PluginUI.HighlightAllMachingDeclaration and highlightTimer_Tick, I tried removing the calls, and did not notice any flickering, but left them just in case...