### PR TITLE
Type Explorer improvements

### DIFF
--- a/External/Plugins/ASCompletion/CustomControls/ModelsExplorer.Designer.cs
+++ b/External/Plugins/ASCompletion/CustomControls/ModelsExplorer.Designer.cs
@@ -29,7 +29,7 @@ namespace ASCompletion
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.outlineTreeView = new System.Windows.Forms.TreeView();
+            this.outlineTreeView = new System.Windows.Forms.FixedTreeView();
             this.outlineContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.exploreToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -73,21 +73,21 @@ namespace ASCompletion
             this.exploreToolStripMenuItem.Name = "exploreToolStripMenuItem";
             this.exploreToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.exploreToolStripMenuItem.Text = "Explore";
-            this.exploreToolStripMenuItem.Click += new System.EventHandler(this.exploreToolStripMenuItem_Click);
+            this.exploreToolStripMenuItem.Click += new System.EventHandler(this.ExploreToolStripMenuItem_Click);
             // 
             // editToolStripMenuItem
             // 
             this.editToolStripMenuItem.Name = "editToolStripMenuItem";
             this.editToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.editToolStripMenuItem.Text = "Edit";
-            this.editToolStripMenuItem.Click += new System.EventHandler(this.editToolStripMenuItem_Click);
+            this.editToolStripMenuItem.Click += new System.EventHandler(this.EditToolStripMenuItem_Click);
             // 
             // convertToolStripMenuItem
             // 
             this.convertToolStripMenuItem.Name = "convertToolStripMenuItem";
             this.convertToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.convertToolStripMenuItem.Text = "Convert To Intrinsic";
-            this.convertToolStripMenuItem.Click += new System.EventHandler(this.convertToolStripMenuItem_Click);
+            this.convertToolStripMenuItem.Click += new System.EventHandler(this.ConvertToolStripMenuItem_Click);
             // 
             // updateTimer
             // 
@@ -135,7 +135,7 @@ namespace ASCompletion
             this.refreshButton.Size = new System.Drawing.Size(23, 19);
             this.refreshButton.Text = "toolStripButton1";
             this.refreshButton.ToolTipText = "Refresh";
-            this.refreshButton.Click += new System.EventHandler(this.refreshButton_Click);
+            this.refreshButton.Click += new System.EventHandler(this.RefreshButton_Click);
             // 
             // rebuildButton
             //
@@ -147,7 +147,7 @@ namespace ASCompletion
             this.rebuildButton.Size = new System.Drawing.Size(23, 19);
             this.rebuildButton.Text = "toolStripButton1";
             this.rebuildButton.ToolTipText = "Rebuild";
-            this.rebuildButton.Click += new System.EventHandler(this.rebuildButton_Click);
+            this.rebuildButton.Click += new System.EventHandler(this.RebuildButton_Click);
             // 
             // searchButton
             //
@@ -159,7 +159,7 @@ namespace ASCompletion
             this.searchButton.Size = new System.Drawing.Size(23, 19);
             this.searchButton.Text = "toolStripButton1";
             this.searchButton.ToolTipText = "Search";
-            this.searchButton.Click += new System.EventHandler(this.searchButton_Click);
+            this.searchButton.Click += new System.EventHandler(this.SearchButton_Click);
             // 
             // ModelsExplorer
             // 
@@ -180,7 +180,7 @@ namespace ASCompletion
 
         #endregion
 
-        private System.Windows.Forms.TreeView outlineTreeView;
+        private System.Windows.Forms.FixedTreeView outlineTreeView;
         private System.Windows.Forms.Timer updateTimer;
         private System.Windows.Forms.ToolStrip toolStrip;
         private System.Windows.Forms.ToolStripLabel filterLabel;

--- a/External/Plugins/ASCompletion/CustomControls/ModelsExplorer.cs
+++ b/External/Plugins/ASCompletion/CustomControls/ModelsExplorer.cs
@@ -509,6 +509,17 @@ namespace ASCompletion
             return false;
         }
 
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (keyData == Keys.Escape)
+            {
+                OnShortcut(keyData);
+                return true;
+            }
+
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
         private void ModelsExplorer_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.KeyCode == Keys.Enter)
@@ -522,17 +533,17 @@ namespace ASCompletion
             else OnShortcut(e.KeyData);
         }
 
-        private void searchButton_Click(object sender, EventArgs e)
+        private void SearchButton_Click(object sender, EventArgs e)
         {
             FindNextMatch(filterTextBox.Text);
         }
 
-        private void refreshButton_Click(object sender, EventArgs e)
+        private void RefreshButton_Click(object sender, EventArgs e)
         {
             UpdateTree();
         }
 
-        private void rebuildButton_Click(object sender, EventArgs e)
+        private void RebuildButton_Click(object sender, EventArgs e)
         {
             outlineTreeView.Nodes.Clear();
             ASContext.RebuildClasspath();
@@ -541,7 +552,7 @@ namespace ASCompletion
 
         #region Context menu
 
-        private void exploreToolStripMenuItem_Click(object sender, EventArgs e)
+        private void ExploreToolStripMenuItem_Click(object sender, EventArgs e)
         {
             TreeNode node = outlineTreeView.SelectedNode;
             if (node == null) return;
@@ -551,14 +562,14 @@ namespace ASCompletion
                 PluginBase.MainForm.CallCommand("RunProcess", String.Format("explorer.exe;/e,\"{0}\"", path));
         }
 
-        private void editToolStripMenuItem_Click(object sender, EventArgs e)
+        private void EditToolStripMenuItem_Click(object sender, EventArgs e)
         {
             TreeNode node = outlineTreeView.SelectedNode;
             if (node == null) return;
             outlineTreeView_Click(null, null);
         }
 
-        private void convertToolStripMenuItem_Click(object sender, EventArgs e)
+        private void ConvertToolStripMenuItem_Click(object sender, EventArgs e)
         {
             TreeNode node = outlineTreeView.SelectedNode;
             if (node == null || current == null || current.Classpath == null) return;


### PR DESCRIPTION
Use FixedTreeView instead of normal TreeView. It solves the flickering seen sometimes.
Capture the Escape key to close the panel as originally intended.