### PR TITLE
Prevent overloads to show up

### DIFF
--- a/External/Plugins/HaXeContext/Completion/HaxeComplete.cs
+++ b/External/Plugins/HaXeContext/Completion/HaxeComplete.cs
@@ -232,10 +232,16 @@ namespace HaXeContext
                     case "t":
                         if (member == null) continue;
                         ExtractType(reader, member);
-                        Members.Add(member);
+                        if (!IsOverload(member))
+                            Members.Add(member);
                         break;
                 }
             }
+        }
+
+        bool IsOverload(MemberModel member)
+        {
+            return Members.Count > 0 && Members[Members.Count - 1].FullName == member.FullName;
         }
 
         MemberModel ExtractMember(XmlTextReader reader)


### PR DESCRIPTION
This doesn't provide overload completion but at least prevents overloaded functions to appear multiple times in completion list.
Adresses https://github.com/HaxeFoundation/haxe/issues/560