### PR TITLE
Fixed isDebuggerSuspended check

### DIFF
--- a/External/Plugins/FlashDebugger/Helpers/MenusHelper.cs
+++ b/External/Plugins/FlashDebugger/Helpers/MenusHelper.cs
@@ -267,7 +267,7 @@ namespace FlashDebugger
             CurrentButton.Enabled = CurrentMenu.Enabled = RunToCursorButton.Enabled = enabled;
             NextButton.Enabled = NextMenu.Enabled = FinishButton.Enabled = FinishMenu.Enabled = enabled;
             RunToCursorMenu.Enabled = StepButton.Enabled = StepMenu.Enabled = enabled;
-            if (state == DebuggerState.Running && !PluginMain.debugManager.FlashInterface.isDebuggerSuspended)
+            if (state == DebuggerState.Running && (!PluginMain.debugManager.FlashInterface.isDebuggerStarted || !PluginMain.debugManager.FlashInterface.isDebuggerSuspended))
 			{
 				PanelsHelper.localsUI.TreeControl.Nodes.Clear();
 				PanelsHelper.stackframeUI.ClearItem();


### PR DESCRIPTION
It could throw a NPE in some exceptional cases when the debugger is stopped.