### PR TITLE
Copy Tree command and combine inherited (#3)

### DIFF
--- a/External/Plugins/FlashDebugger/Controls/DataNode.cs
+++ b/External/Plugins/FlashDebugger/Controls/DataNode.cs
@@ -48,14 +48,20 @@ namespace FlashDebugger.Controls
 			}
 			return m_Value.getName().length()>0 && m_Value.getName().startsWith("_") ? 1 : -1;
 		}
-		
-		public string ID {
-			get {
-				if (m_Value != null) {
+
+		public string ID
+		{
+			get
+			{
+				if (m_Value != null)
+				{
 					int type = m_Value.getValue().getType();
-					if (type == VariableType_.MOVIECLIP || type == VariableType_.OBJECT) {
+					if (type == VariableType_.MOVIECLIP || type == VariableType_.OBJECT)
+					{
 						return m_Value.getValue().getTypeName().replaceAll("::", ".").replaceAll("@", " - ").ToString();
-					} else if (type == VariableType_.FUNCTION) {
+					}
+					else if (type == VariableType_.FUNCTION)
+					{
 						return "Function - " + m_Value.getValue().ToString();
 					}
 				}
@@ -64,27 +70,28 @@ namespace FlashDebugger.Controls
 		}
 
 		public string Value
-        {
-            get
+		{
+			get
 			{
 				if (m_Value == null)
 				{
 					return string.Empty;
 				}
-                int type = m_Value.getValue().getType();
-                string temp = null;
+				int type = m_Value.getValue().getType();
+				string temp = null;
 				if (type == VariableType_.MOVIECLIP || type == VariableType_.OBJECT)
 				{
-				
+
 					// return class type without classpath
 					string typeStr = Strings.AfterLast(m_Value.getValue().getTypeName().ToString(), "::", true);
 					string shortStr = Strings.Before(typeStr, "@");
-					if (shortStr == "[]") {
+					if (shortStr == "[]")
+					{
 						return "Array";
 					}
 					return typeStr;
-					
-                    //return m_Value.getValue().getTypeName();
+
+					//return m_Value.getValue().getTypeName();
 				}
 				else if (type == VariableType_.NUMBER)
 				{
@@ -115,13 +122,13 @@ namespace FlashDebugger.Controls
 					{
 						if (!m_bEditing)
 						{
-                            temp = "\"" + escape(m_Value.ToString()) + "\"";
+							temp = "\"" + escape(m_Value.ToString()) + "\"";
 						}
 						else
 						{
-                            temp = m_Value.ToString();
+							temp = m_Value.ToString();
 						}
-                        return temp;
+						return temp;
 					}
 				}
 				else if (type == VariableType_.NULL)
@@ -131,15 +138,15 @@ namespace FlashDebugger.Controls
 				else if (type == VariableType_.FUNCTION)
 				{
 					return "Function";
-                    //m_Value.ToString();
+					//m_Value.ToString();
 					//return "<setter>";
 				}
-                if (temp == null) temp = m_Value.ToString();
-                if (!m_bEditing)
-                {
-                    temp = escape(temp);
-                }
-                return temp;
+				if (temp == null) temp = m_Value.ToString();
+				if (!m_bEditing)
+				{
+					temp = escape(temp);
+				}
+				return temp;
 			}
 			set
 			{
@@ -147,7 +154,7 @@ namespace FlashDebugger.Controls
 				{
 					return;
 				}
-                throw new NotImplementedException();
+				throw new NotImplementedException();
 #if false
 				int type = m_Value.getValue().getType();
 				if (type == VariableType_.NUMBER)
@@ -164,7 +171,7 @@ namespace FlashDebugger.Controls
 				}
 #endif
 			}
-        }
+		}
 
         private string escape(string text)
         {

--- a/External/Plugins/FlashDebugger/Controls/DataNode.cs
+++ b/External/Plugins/FlashDebugger/Controls/DataNode.cs
@@ -48,6 +48,20 @@ namespace FlashDebugger.Controls
 			}
 			return m_Value.getName().length()>0 && m_Value.getName().startsWith("_") ? 1 : -1;
 		}
+		
+		public string ID {
+			get {
+				if (m_Value != null) {
+					int type = m_Value.getValue().getType();
+					if (type == VariableType_.MOVIECLIP || type == VariableType_.OBJECT) {
+						return m_Value.getValue().getTypeName().replaceAll("::", ".").replaceAll("@", " - ").ToString();
+					} else if (type == VariableType_.FUNCTION) {
+						return "Function - " + m_Value.getValue().ToString();
+					}
+				}
+				return "";
+			}
+		}
 
 		public string Value
         {
@@ -61,7 +75,16 @@ namespace FlashDebugger.Controls
                 string temp = null;
 				if (type == VariableType_.MOVIECLIP || type == VariableType_.OBJECT)
 				{
-                    return m_Value.getValue().getTypeName();
+				
+					// return class type without classpath
+					string typeStr = Strings.AfterLast(m_Value.getValue().getTypeName().ToString(), "::", true);
+					string shortStr = Strings.Before(typeStr, "@");
+					if (shortStr == "[]") {
+						return "Array";
+					}
+					return typeStr;
+					
+                    //return m_Value.getValue().getTypeName();
 				}
 				else if (type == VariableType_.NUMBER)
 				{
@@ -107,7 +130,8 @@ namespace FlashDebugger.Controls
 				}
 				else if (type == VariableType_.FUNCTION)
 				{
-                    m_Value.ToString();
+					return "Function";
+                    //m_Value.ToString();
 					//return "<setter>";
 				}
                 if (temp == null) temp = m_Value.ToString();

--- a/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
+++ b/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
@@ -284,7 +284,8 @@ namespace FlashDebugger.Controls
 				if (inherited.Count > 0)
 				{
 					// list inherited alongside main class members
-					foreach (DataNode item in inherited) {
+					foreach (DataNode item in inherited)
+					{
 						node.Nodes.Add(item);
 					}
 
@@ -459,8 +460,10 @@ namespace FlashDebugger.Controls
 		// ADDED
 		#region Copy ID & Tree
 
-		private void CopyItemIDClick(Object sender, System.EventArgs e) {
-			if (Tree.SelectedNode != null) {
+		private void CopyItemIDClick(Object sender, System.EventArgs e)
+		{
+			if (Tree.SelectedNode != null)
+			{
 
 				DataNode node = Tree.SelectedNode.Tag as DataNode;
 				Clipboard.SetText(node.ID);
@@ -468,12 +471,15 @@ namespace FlashDebugger.Controls
 			}
 		}
 
-		private void CopyItemTreeClick(Object sender, System.EventArgs e) {
+		private void CopyItemTreeClick(Object sender, System.EventArgs e)
+		{
 			CopyTreeInternal(0);
 		}
 
-		private void CopyTreeInternal(int levelLimit) {
-			if (Tree.SelectedNode != null) {
+		private void CopyTreeInternal(int levelLimit)
+		{
+			if (Tree.SelectedNode != null)
+			{
 
 				DataNode node = Tree.SelectedNode.Tag as DataNode;
 				Clipboard.SetText(CopyTreeHelper.GetTreeAsText(Tree.SelectedNode, node, "\t", this, levelLimit));

--- a/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
+++ b/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
@@ -279,16 +279,27 @@ namespace FlashDebugger.Controls
 						nodes.Add(memberNode);
 					}
 				}
+
+				// inherited vars
 				if (inherited.Count > 0)
 				{
-					DataNode inheritedNode = new DataNode("[inherited]");
+					// list inherited alongside main class members
+					foreach (DataNode item in inherited) {
+						node.Nodes.Add(item);
+					}
+
+					// list inherited in a [inherited] group
+					/*DataNode inheritedNode = new DataNode("[inherited]");
 					inherited.Sort();
 					foreach (DataNode item in inherited)
 					{
 						inheritedNode.Nodes.Add(item);
 					}
-					node.Nodes.Add(inheritedNode);
+					node.Nodes.Add(inheritedNode);*/
+
 				}
+
+				// static vars
 				if (statics.Count > 0)
 				{
 					DataNode staticNode = new DataNode("[static]");
@@ -299,6 +310,7 @@ namespace FlashDebugger.Controls
 					}
 					node.Nodes.Add(staticNode);
 				}
+
 				//test children
 				foreach (String ch in node.Variable.getValue().getClassHierarchy(false))
 				{

--- a/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
+++ b/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
@@ -20,6 +20,8 @@ namespace FlashDebugger.Controls
         private ToolStripMenuItem copyMenuItem, viewerMenuItem, watchMenuItem;
 		private List<String> expandedList = new List<String>();
 		private bool watchMode;
+		private ToolStripMenuItem copyIDMenuItem;
+		private ToolStripMenuItem copyTreeMenuItem;
 
         public Collection<Node> Nodes
         {
@@ -77,8 +79,10 @@ namespace FlashDebugger.Controls
             this.NameTreeColumn.Header = TextHelper.GetString("Label.Name");
             this.ValueTreeColumn.Header = TextHelper.GetString("Label.Value");
             copyMenuItem = new ToolStripMenuItem(TextHelper.GetString("Label.Copy"), null, new EventHandler(this.CopyItemClick));
-            viewerMenuItem = new ToolStripMenuItem(TextHelper.GetString("Label.Viewer"), null, new EventHandler(this.ViewerItemClick));
-            _contextMenuStrip.Items.AddRange(new ToolStripMenuItem[] { copyMenuItem, viewerMenuItem});
+            copyIDMenuItem = new ToolStripMenuItem("Copy ID", null, new EventHandler(this.CopyItemIDClick));
+			copyTreeMenuItem = new ToolStripMenuItem("Copy Tree", null, new EventHandler(this.CopyItemTreeClick));
+			viewerMenuItem = new ToolStripMenuItem(TextHelper.GetString("Label.Viewer"), null, new EventHandler(this.ViewerItemClick));
+            _contextMenuStrip.Items.AddRange(new ToolStripMenuItem[] { copyMenuItem, copyIDMenuItem, copyTreeMenuItem, viewerMenuItem});
 			if (watchMode)
 			{
 				watchMenuItem = new ToolStripMenuItem(TextHelper.GetString("Label.Unwatch"), null, new EventHandler(this.WatchItemClick));
@@ -243,120 +247,129 @@ namespace FlashDebugger.Controls
         {
             if (e.Node.Index >= 0)
             {
-                DataNode node = e.Node.Tag as DataNode;
-				if (node.Nodes.Count == 0 && node.Variable != null)
-                {
-					FlashInterface flashInterface = PluginMain.debugManager.FlashInterface;
-					List<DataNode> nodes = new List<DataNode>();
-					List<DataNode> inherited = new List<DataNode>();
-					List<DataNode> statics = new List<DataNode>();
-					int tmpLimit = node.ChildrenShowLimit;
-					foreach (Variable member in node.Variable.getValue().getMembers(flashInterface.Session))
-					{
-						DataNode memberNode = new DataNode(member);
-                        
-						if (member.isAttributeSet(VariableAttribute_.IS_STATIC))
-						{
-							statics.Add(memberNode);
-						}
-						else if (member.getLevel() > 0)
-						{
-							inherited.Add(memberNode);
-						}
-						else
-						{
-							nodes.Add(memberNode);
-						}
-					}
-					if (inherited.Count > 0)
-					{
-						DataNode inheritedNode = new DataNode("[inherited]");
-						inherited.Sort();
-						foreach (DataNode item in inherited)
-						{
-							inheritedNode.Nodes.Add(item);
-						}
-						node.Nodes.Add(inheritedNode);
-					}
-					if (statics.Count > 0)
-					{
-						DataNode staticNode = new DataNode("[static]");
-						statics.Sort();
-						foreach (DataNode item in statics)
-						{
-							staticNode.Nodes.Add(item);
-						}
-						node.Nodes.Add(staticNode);
-					}
-					//test children
-					foreach (String ch in node.Variable.getValue().getClassHierarchy(false))
-					{
-						if (ch.Equals("flash.display::DisplayObjectContainer"))
-						{
-							double numChildren = ((java.lang.Double)node.Variable.getValue().getMemberNamed(flashInterface.Session, "numChildren").getValue().getValueAsObject()).doubleValue();
-							DataNode childrenNode = new DataNode("[children]");
-							for (int i = 0; i < numChildren; i++)
-							{
-								try
-								{
-                                    IASTBuilder b = new ASTBuilder(false);
-                                    string cmd = GetVariablePath(node) + ".getChildAt(" + i + ")";
-                                    ValueExp exp = b.parse(new java.io.StringReader(cmd));
-                                    var ctx = new ExpressionContext(flashInterface.Session, flashInterface.GetFrames()[PluginMain.debugManager.CurrentFrame]);
-                                    var obj = exp.evaluate(ctx);
-                                    if (obj is flash.tools.debugger.concrete.DValue) obj = new flash.tools.debugger.concrete.DVariable("getChildAt(" + i + ")", (flash.tools.debugger.concrete.DValue)obj, ((flash.tools.debugger.concrete.DValue)obj).getIsolateId());
-                                    DataNode childNode = new DataNode((Variable)obj);
-                                    childNode.Text = "child_" + i;
-									childrenNode.Nodes.Add(childNode);
-								}
-                                catch (Exception) { }
-							}
-							node.Nodes.Add(childrenNode);
-						}
-                        else if (ch.Equals("flash.events::EventDispatcher"))
-                        {
-                            Variable list = node.Variable.getValue().getMemberNamed(flashInterface.Session, "listeners");
-                            var omg = list.getName();
-                            /*
-                            double numChildren = ((java.lang.Double)node.Variable.getValue().getMemberNamed(flashInterface.Session, "numChildren").getValue().getValueAsObject()).doubleValue();
-                            DataNode childrenNode = new DataNode("[children]");
-                            for (int i = 0; i < numChildren; i++)
-                            {
-                                try
-                                {
-
-                                    IASTBuilder b = new ASTBuilder(false);
-                                    string cmd = GetVariablePath(node) + ".getChildAt(" + i + ")";
-                                    ValueExp exp = b.parse(new java.io.StringReader(cmd));
-                                    var ctx = new ExpressionContext(flashInterface.Session, flashInterface.Session.getFrames()[PluginMain.debugManager.CurrentFrame]);
-                                    var obj = exp.evaluate(ctx);
-                                    if (obj is flash.tools.debugger.concrete.DValue) obj = new flash.tools.debugger.concrete.DVariable("child_" + i, (flash.tools.debugger.concrete.DValue)obj);
-                                    DataNode childNode = new DataNode((Variable)obj);
-                                    childrenNode.Nodes.Add(childNode);
-                                }
-                                catch (Exception) { }
-                            }
-                            node.Nodes.Add(childrenNode);
-                             * */
-                        }
-					}
-					//test children
-					nodes.Sort();
-					_tree.BeginUpdate();
-					foreach (DataNode item in nodes)
-					{
-						if (0 == tmpLimit--) break;
-						node.Nodes.Add(item);
-					}
-					if (tmpLimit == -1)
-					{
-						DataNode moreNode = new DataNode("...");
-						node.Nodes.Add(moreNode);
-					}
-					_tree.EndUpdate();
-                }
+                ListChildItems(e.Node);
             }
         }
+		
+		public void ListChildItems(TreeNodeAdv treeNode) {
+		
+			DataNode node = treeNode.Tag as DataNode;
+			
+			if (node.Nodes.Count == 0 && node.Variable != null)
+			{
+				FlashInterface flashInterface = PluginMain.debugManager.FlashInterface;
+				List<DataNode> nodes = new List<DataNode>();
+				List<DataNode> inherited = new List<DataNode>();
+				List<DataNode> statics = new List<DataNode>();
+				int tmpLimit = node.ChildrenShowLimit;
+				foreach (Variable member in node.Variable.getValue().getMembers(flashInterface.Session))
+				{
+					DataNode memberNode = new DataNode(member);
+					
+					if (member.isAttributeSet(VariableAttribute_.IS_STATIC))
+					{
+						statics.Add(memberNode);
+					}
+					else if (member.getLevel() > 0)
+					{
+						inherited.Add(memberNode);
+					}
+					else
+					{
+						nodes.Add(memberNode);
+					}
+				}
+				if (inherited.Count > 0)
+				{
+					DataNode inheritedNode = new DataNode("[inherited]");
+					inherited.Sort();
+					foreach (DataNode item in inherited)
+					{
+						inheritedNode.Nodes.Add(item);
+					}
+					node.Nodes.Add(inheritedNode);
+				}
+				if (statics.Count > 0)
+				{
+					DataNode staticNode = new DataNode("[static]");
+					statics.Sort();
+					foreach (DataNode item in statics)
+					{
+						staticNode.Nodes.Add(item);
+					}
+					node.Nodes.Add(staticNode);
+				}
+				//test children
+				foreach (String ch in node.Variable.getValue().getClassHierarchy(false))
+				{
+					if (ch.Equals("flash.display::DisplayObjectContainer"))
+					{
+						double numChildren = ((java.lang.Double)node.Variable.getValue().getMemberNamed(flashInterface.Session, "numChildren").getValue().getValueAsObject()).doubleValue();
+						DataNode childrenNode = new DataNode("[children]");
+						for (int i = 0; i < numChildren; i++)
+						{
+							try
+							{
+								IASTBuilder b = new ASTBuilder(false);
+								string cmd = GetVariablePath(node) + ".getChildAt(" + i + ")";
+								ValueExp exp = b.parse(new java.io.StringReader(cmd));
+								var ctx = new ExpressionContext(flashInterface.Session, flashInterface.GetFrames()[PluginMain.debugManager.CurrentFrame]);
+								var obj = exp.evaluate(ctx);
+								if (obj is flash.tools.debugger.concrete.DValue) obj = new flash.tools.debugger.concrete.DVariable("getChildAt(" + i + ")", (flash.tools.debugger.concrete.DValue)obj, ((flash.tools.debugger.concrete.DValue)obj).getIsolateId());
+								DataNode childNode = new DataNode((Variable)obj);
+								childNode.Text = "child_" + i;
+								childrenNode.Nodes.Add(childNode);
+							}
+							catch (Exception) { }
+						}
+						node.Nodes.Add(childrenNode);
+					}
+					else if (ch.Equals("flash.events::EventDispatcher"))
+					{
+						Variable list = node.Variable.getValue().getMemberNamed(flashInterface.Session, "listeners");
+						var omg = list.getName();
+						/*
+						double numChildren = ((java.lang.Double)node.Variable.getValue().getMemberNamed(flashInterface.Session, "numChildren").getValue().getValueAsObject()).doubleValue();
+						DataNode childrenNode = new DataNode("[children]");
+						for (int i = 0; i < numChildren; i++)
+						{
+							try
+							{
+
+								IASTBuilder b = new ASTBuilder(false);
+								string cmd = GetVariablePath(node) + ".getChildAt(" + i + ")";
+								ValueExp exp = b.parse(new java.io.StringReader(cmd));
+								var ctx = new ExpressionContext(flashInterface.Session, flashInterface.Session.getFrames()[PluginMain.debugManager.CurrentFrame]);
+								var obj = exp.evaluate(ctx);
+								if (obj is flash.tools.debugger.concrete.DValue) obj = new flash.tools.debugger.concrete.DVariable("child_" + i, (flash.tools.debugger.concrete.DValue)obj);
+								DataNode childNode = new DataNode((Variable)obj);
+								childrenNode.Nodes.Add(childNode);
+							}
+							catch (Exception) { }
+						}
+						node.Nodes.Add(childrenNode);
+						 * */
+					}
+				}
+				
+				//test children
+				nodes.Sort();
+
+				// add child items
+				_tree.BeginUpdate();
+				foreach (DataNode item in nodes)
+				{
+					if (0 == tmpLimit--) break;
+					node.Nodes.Add(item);
+				}
+				if (tmpLimit == -1)
+				{
+					DataNode moreNode = new DataNode("...");
+					node.Nodes.Add(moreNode);
+				}
+				_tree.EndUpdate();
+			}
+		}
 
 		void _tree_NodeMouseDoubleClick(object sender, TreeNodeAdvMouseEventArgs e)
 		{
@@ -429,6 +442,36 @@ namespace FlashDebugger.Controls
         }
 
         #endregion
+		
+		
+		// ADDED
+		#region Copy ID & Tree
+
+		private void CopyItemIDClick(Object sender, System.EventArgs e) {
+			if (Tree.SelectedNode != null) {
+
+				DataNode node = Tree.SelectedNode.Tag as DataNode;
+				Clipboard.SetText(node.ID);
+
+			}
+		}
+
+		private void CopyItemTreeClick(Object sender, System.EventArgs e) {
+			CopyTreeInternal(0);
+		}
+
+		private void CopyTreeInternal(int levelLimit) {
+			if (Tree.SelectedNode != null) {
+
+				DataNode node = Tree.SelectedNode.Tag as DataNode;
+				Clipboard.SetText(CopyTreeHelper.GetTreeAsText(Tree.SelectedNode, node, "\t", this, levelLimit));
+
+			}
+		}
+
+
+		#endregion
+
     }
 
 }

--- a/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
+++ b/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
@@ -17,11 +17,10 @@ namespace FlashDebugger.Controls
         private DataTreeModel _model;
         private static ViewerForm viewerForm = null;
         private ContextMenuStrip _contextMenuStrip;
-        private ToolStripMenuItem copyMenuItem, viewerMenuItem, watchMenuItem;
+        private ToolStripMenuItem copyMenuItem, viewerMenuItem, watchMenuItem, copyIDMenuItem, copyTreeMenuItem;
 		private List<String> expandedList = new List<String>();
 		private bool watchMode;
-		private ToolStripMenuItem copyIDMenuItem;
-		private ToolStripMenuItem copyTreeMenuItem;
+		private static bool combineInherited = false;
 
         public Collection<Node> Nodes
         {
@@ -280,25 +279,33 @@ namespace FlashDebugger.Controls
 					}
 				}
 
+
 				// inherited vars
 				if (inherited.Count > 0)
 				{
-					// list inherited alongside main class members
-					foreach (DataNode item in inherited)
+					if (combineInherited)
 					{
-						node.Nodes.Add(item);
-					}
+						// list inherited alongside main class members
+						foreach (DataNode item in inherited)
+						{
+							node.Nodes.Add(item);
+						}
 
-					// list inherited in a [inherited] group
-					/*DataNode inheritedNode = new DataNode("[inherited]");
-					inherited.Sort();
-					foreach (DataNode item in inherited)
+					}
+					else
 					{
-						inheritedNode.Nodes.Add(item);
-					}
-					node.Nodes.Add(inheritedNode);*/
+						// list inherited in a [inherited] group
+						DataNode inheritedNode = new DataNode("[inherited]");
+						inherited.Sort();
+						foreach (DataNode item in inherited)
+						{
+							inheritedNode.Nodes.Add(item);
+						}
+						node.Nodes.Add(inheritedNode);
 
+					}
 				}
+
 
 				// static vars
 				if (statics.Count > 0)
@@ -440,6 +447,12 @@ namespace FlashDebugger.Controls
 		}
 
 
+		public static bool CombineInherited
+		{
+			get { return DataTreeControl.combineInherited; }
+			set { DataTreeControl.combineInherited = value; }
+		}
+
         #region IToolTipProvider Members
 
         public string GetToolTip(TreeNodeAdv node, NodeControl nodeControl)
@@ -456,8 +469,6 @@ namespace FlashDebugger.Controls
 
         #endregion
 		
-		
-		// ADDED
 		#region Copy ID & Tree
 
 		private void CopyItemIDClick(Object sender, System.EventArgs e)

--- a/External/Plugins/FlashDebugger/FlashDebugger.csproj
+++ b/External/Plugins/FlashDebugger/FlashDebugger.csproj
@@ -138,8 +138,10 @@
     <Compile Include="Debugger\ExpressionContext.cs" />
     <Compile Include="Debugger\FlashInterface.cs" />
     <Compile Include="Debugger\VariableFacade.cs" />
+    <Compile Include="Helpers\CopyAsTree.cs" />
     <Compile Include="Helpers\MenusHelper.cs" />
     <Compile Include="Helpers\PanelsHelper.cs" />
+    <Compile Include="Helpers\StringsHelper.cs" />
     <Compile Include="Helpers\ScintillaHelper.cs" />
     <Compile Include="PluginUI.cs">
       <SubType>UserControl</SubType>

--- a/External/Plugins/FlashDebugger/Helpers/CopyAsTree.cs
+++ b/External/Plugins/FlashDebugger/Helpers/CopyAsTree.cs
@@ -5,8 +5,10 @@ using System.Text;
 using Aga.Controls.Tree;
 using FlashDebugger.Controls;
 
-namespace FlashDebugger {
-	public class CopyTreeHelper {
+namespace FlashDebugger
+{
+	public class CopyTreeHelper
+	{
 
 		public const int CopyTreeMaxRecursion = 10;
 		public const int CopyTreeMaxChars = 1000000;
@@ -14,7 +16,8 @@ namespace FlashDebugger {
 		private static Dictionary<string, int> CopiedObjects;
 
 
-		public static string GetTreeAsText(TreeNodeAdv treeNode, DataNode dataNode, string levelSep, DataTreeControl control, int levelLimit) {
+		public static string GetTreeAsText(TreeNodeAdv treeNode, DataNode dataNode, string levelSep, DataTreeControl control, int levelLimit)
+		{
 			StringBuilder sb = new StringBuilder();
 
 			// ensure expanded
@@ -27,17 +30,20 @@ namespace FlashDebugger {
 			return sb.ToString() ?? "";
 		}
 
-		private static void GetTreeItemsAsText(IList treeNodes, IList dataNodes, string levelSep, int level, StringBuilder sb, DataTreeControl control, int levelLimit) {
+		private static void GetTreeItemsAsText(IList treeNodes, IList dataNodes, string levelSep, int level, StringBuilder sb, DataTreeControl control, int levelLimit)
+		{
 
 			// per node
 			int len = dataNodes.Count;
-			for (int c = 0; c < len; c++) {
+			for (int c = 0; c < len; c++)
+			{
 				DataNode child = (DataNode)dataNodes[c];
 				TreeNodeAdv childTree = (TreeNodeAdv)treeNodes[c];
 
 
 				// skip if unwanted item
-				if (!IsWantedChild(child)) {
+				if (!IsWantedChild(child))
+				{
 					continue;
 				}
 
@@ -50,7 +56,8 @@ namespace FlashDebugger {
 				sb.Append(child.Text + " : " + child.Value);
 
 				// recurse for children .. but skip if unwanted items
-				if (child.Nodes.Count > 0 && IsWantedParent(child)) {
+				if (child.Nodes.Count > 0 && IsWantedParent(child))
+				{
 
 					// opening brace
 					sb.AppendLine("{");
@@ -58,31 +65,39 @@ namespace FlashDebugger {
 					string childID = child.ID;
 
 					// add error if too many levels of recursion
-					if (level <= levelLimit || levelLimit == 0) {
+					if (level <= levelLimit || levelLimit == 0)
+					{
 
 						// check if encountered before
 						bool isNew = !CopiedObjects.ContainsKey(childID);
-						if (!isNew) {
+						if (!isNew)
+						{
 
 							// error
 							AppendTimes(sb, levelSep, level + 1);
 							sb.AppendLine("[Already listed before]");
 
-						} else if (level > CopyTreeMaxRecursion) {
+						}
+						else if (level > CopyTreeMaxRecursion)
+						{
 
 							// error
 							AppendTimes(sb, levelSep, level + 1);
 							sb.AppendLine("[Recursion too deep, increase CopyTreeMaxRecursion in FlashDebugger settings]");
 
-						} else {
+						}
+						else
+						{
 
 							// add to list
 							CopiedObjects.Add(childID, 1);
 
 							// children
-							try {
+							try
+							{
 								GetTreeItemsAsText(childTree.Children, child.Nodes, levelSep, level + 1, sb, control, levelLimit);
-							} catch (System.Exception ex) { }
+							}
+							catch (System.Exception ex) { }
 
 						}
 					}
@@ -92,13 +107,16 @@ namespace FlashDebugger {
 					AppendTimes(sb, levelSep, level);
 					sb.AppendLine("}");
 
-				} else {
+				}
+				else
+				{
 					sb.AppendLine();
 				}
 
 
 				// stop recursion if too long
-				if (sb.Length > CopyTreeMaxChars) {
+				if (sb.Length > CopyTreeMaxChars)
+				{
 					sb.Append("......");
 					return;
 				}
@@ -107,15 +125,20 @@ namespace FlashDebugger {
 			}
 		}
 
-		private static bool IsWantedParent(DataNode parent) {
-			try {
+		private static bool IsWantedParent(DataNode parent)
+		{
+			try
+			{
 
 				// if is an empty array []
 				// then skip it from opening and closing { } the output
-				if (parent.Nodes.Count == 1 || parent.Nodes.Count == 2) {
-					if (parent.Value.StartsWith("Array")) {
+				if (parent.Nodes.Count == 1 || parent.Nodes.Count == 2)
+				{
+					if (parent.Value.StartsWith("Array"))
+					{
 						DataNode child1 = (DataNode)parent.Nodes[0];
-						if (child1.Text == "[static]" || child1.Text == "length") {
+						if (child1.Text == "[static]" || child1.Text == "length")
+						{
 							return false;
 						}
 					}
@@ -123,37 +146,47 @@ namespace FlashDebugger {
 
 				// catch "cannot cast Aga.TreeNode to DataNode" 
 				// TODO : fix this instead of just catching it
-			} catch (Exception ex) { }
+			}
+			catch (Exception ex) { }
 			return true;
 		}
 
 		private static string[] as3DisabledProps = new string[] { "stage", "parent", "root", "loaderInfo", "_nativeWindow", "nativeWindow" };
 
-		private static bool IsWantedChild(DataNode child) {
-			try {
-				if (child.Parent != null) {
+		private static bool IsWantedChild(DataNode child)
+		{
+			try
+			{
+				if (child.Parent != null)
+				{
 					DataNode parent = ((DataNode)child.Parent);
 
 					// if is an array []
 					// skip [static] and "length" properties
-					if (parent.Value.StartsWith("Array")) {
-						if (child.Text == "[static]" || child.Text == "length") {
+					if (parent.Value.StartsWith("Array"))
+					{
+						if (child.Text == "[static]" || child.Text == "length")
+						{
 							return false;
 						}
 					}
 
 					// if is an AS3 display object,
 					// don't go upward (stage, parent)
-					if (parent.Value.StartsWith("flash.display.") || parent.Value == "Main") {
-						if (Array.IndexOf(as3DisabledProps, child.Text) > -1) {
+					if (parent.Value.StartsWith("flash.display.") || parent.Value == "Main")
+					{
+						if (Array.IndexOf(as3DisabledProps, child.Text) > -1)
+						{
 							return false;
 						}
 					}
 
 					// if is an AS2 display object,
 					// don't go upward (_parent)
-					if (parent.Value == "MovieClip" || parent.Value == "Video") {
-						if (child.Text == "_parent") {
+					if (parent.Value == "MovieClip" || parent.Value == "Video")
+					{
+						if (child.Text == "_parent")
+						{
 							return false;
 						}
 					}
@@ -162,12 +195,15 @@ namespace FlashDebugger {
 
 				// catch "cannot cast Aga.TreeNode to DataNode" 
 				// TODO : fix this instead of just catching it
-			} catch (Exception ex) { }
+			}
+			catch (Exception ex) { }
 			return true;
 		}
 
-		private static void AppendTimes(StringBuilder sb, string append, int times) {
-			for (int t = 0; t < times; t++) {
+		private static void AppendTimes(StringBuilder sb, string append, int times)
+		{
+			for (int t = 0; t < times; t++)
+			{
 				sb.Append(append);
 			}
 		}

--- a/External/Plugins/FlashDebugger/Helpers/CopyAsTree.cs
+++ b/External/Plugins/FlashDebugger/Helpers/CopyAsTree.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using Aga.Controls.Tree;
+using FlashDebugger.Controls;
+
+namespace FlashDebugger {
+	public class CopyTreeHelper {
+
+		public const int CopyTreeMaxRecursion = 10;
+		public const int CopyTreeMaxChars = 1000000;
+
+		private static Dictionary<string, int> CopiedObjects;
+
+
+		public static string GetTreeAsText(TreeNodeAdv treeNode, DataNode dataNode, string levelSep, DataTreeControl control, int levelLimit) {
+			StringBuilder sb = new StringBuilder();
+
+			// ensure expanded
+			control.ListChildItems(treeNode);
+
+			// add children nodes
+			CopiedObjects = new Dictionary<string, int>();
+			GetTreeItemsAsText(new List<TreeNodeAdv> { treeNode }, new List<DataNode> { dataNode }, levelSep, 0, sb, control, levelLimit);
+
+			return sb.ToString() ?? "";
+		}
+
+		private static void GetTreeItemsAsText(IList treeNodes, IList dataNodes, string levelSep, int level, StringBuilder sb, DataTreeControl control, int levelLimit) {
+
+			// per node
+			int len = dataNodes.Count;
+			for (int c = 0; c < len; c++) {
+				DataNode child = (DataNode)dataNodes[c];
+				TreeNodeAdv childTree = (TreeNodeAdv)treeNodes[c];
+
+
+				// skip if unwanted item
+				if (!IsWantedChild(child)) {
+					continue;
+				}
+
+
+				// ensure expanded
+				control.ListChildItems(childTree);
+
+				// add node
+				AppendTimes(sb, levelSep, level);
+				sb.Append(child.Text + " : " + child.Value);
+
+				// recurse for children .. but skip if unwanted items
+				if (child.Nodes.Count > 0 && IsWantedParent(child)) {
+
+					// opening brace
+					sb.AppendLine("{");
+
+					string childID = child.ID;
+
+					// add error if too many levels of recursion
+					if (level <= levelLimit || levelLimit == 0) {
+
+						// check if encountered before
+						bool isNew = !CopiedObjects.ContainsKey(childID);
+						if (!isNew) {
+
+							// error
+							AppendTimes(sb, levelSep, level + 1);
+							sb.AppendLine("[Already listed before]");
+
+						} else if (level > CopyTreeMaxRecursion) {
+
+							// error
+							AppendTimes(sb, levelSep, level + 1);
+							sb.AppendLine("[Recursion too deep, increase CopyTreeMaxRecursion in FlashDebugger settings]");
+
+						} else {
+
+							// add to list
+							CopiedObjects.Add(childID, 1);
+
+							// children
+							try {
+								GetTreeItemsAsText(childTree.Children, child.Nodes, levelSep, level + 1, sb, control, levelLimit);
+							} catch (System.Exception ex) { }
+
+						}
+					}
+
+
+					// closing brace
+					AppendTimes(sb, levelSep, level);
+					sb.AppendLine("}");
+
+				} else {
+					sb.AppendLine();
+				}
+
+
+				// stop recursion if too long
+				if (sb.Length > CopyTreeMaxChars) {
+					sb.Append("......");
+					return;
+				}
+
+
+			}
+		}
+
+		private static bool IsWantedParent(DataNode parent) {
+			try {
+
+				// if is an empty array []
+				// then skip it from opening and closing { } the output
+				if (parent.Nodes.Count == 1 || parent.Nodes.Count == 2) {
+					if (parent.Value.StartsWith("Array")) {
+						DataNode child1 = (DataNode)parent.Nodes[0];
+						if (child1.Text == "[static]" || child1.Text == "length") {
+							return false;
+						}
+					}
+				}
+
+				// catch "cannot cast Aga.TreeNode to DataNode" 
+				// TODO : fix this instead of just catching it
+			} catch (Exception ex) { }
+			return true;
+		}
+
+		private static string[] as3DisabledProps = new string[] { "stage", "parent", "root", "loaderInfo", "_nativeWindow", "nativeWindow" };
+
+		private static bool IsWantedChild(DataNode child) {
+			try {
+				if (child.Parent != null) {
+					DataNode parent = ((DataNode)child.Parent);
+
+					// if is an array []
+					// skip [static] and "length" properties
+					if (parent.Value.StartsWith("Array")) {
+						if (child.Text == "[static]" || child.Text == "length") {
+							return false;
+						}
+					}
+
+					// if is an AS3 display object,
+					// don't go upward (stage, parent)
+					if (parent.Value.StartsWith("flash.display.") || parent.Value == "Main") {
+						if (Array.IndexOf(as3DisabledProps, child.Text) > -1) {
+							return false;
+						}
+					}
+
+					// if is an AS2 display object,
+					// don't go upward (_parent)
+					if (parent.Value == "MovieClip" || parent.Value == "Video") {
+						if (child.Text == "_parent") {
+							return false;
+						}
+					}
+
+				}
+
+				// catch "cannot cast Aga.TreeNode to DataNode" 
+				// TODO : fix this instead of just catching it
+			} catch (Exception ex) { }
+			return true;
+		}
+
+		private static void AppendTimes(StringBuilder sb, string append, int times) {
+			for (int t = 0; t < times; t++) {
+				sb.Append(append);
+			}
+		}
+
+	}
+}

--- a/External/Plugins/FlashDebugger/Helpers/StringsHelper.cs
+++ b/External/Plugins/FlashDebugger/Helpers/StringsHelper.cs
@@ -2,37 +2,75 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace FlashDebugger {
-	public static class Strings {
+namespace FlashDebugger
+{
+	public static class Strings
+	{
 
-
-		public static string Before(string text, string find, int startAt = 0, bool returnAll = false, bool forward = true) {
+		/// <summary>
+		/// Get the substring before the specified search term (find). 
+		/// </summary>
+		/// <param name="text">Main string</param>
+		/// <param name="find">Search term</param>
+		/// <param name="startAt">Starts searching for term at specified char indexed.</param>
+		/// <param name="returnAll">If search term not found, return entire string? (true) or return "" (false)</param>
+		/// <param name="forward">Search forward from startAt, or backward from it</param>
+		/// <returns>Substring before the specified search term</returns>
+		public static string Before(string text, string find, int startAt = 0, bool returnAll = false, bool forward = true)
+		{
 			if (text == null) { return returnAll ? text : ""; }
 			int idx;
-			if (forward) {
+			if (forward)
+			{
 				idx = text.IndexOf(find, startAt, StringComparison.Ordinal);
-			} else {
+			}
+			else
+			{
 				idx = text.LastIndexOf(find, text.Length - startAt, StringComparison.Ordinal);
 			}
 			if (idx == -1) { return returnAll ? text : ""; }
 			return text.Substring(0, idx);
 
 		}
-		public static string After(string text, string find, int startAt = 0, bool returnAll = false, bool forward = true) {
+
+		/// <summary>
+		/// Get the substring after the specified search term (find). 
+		/// </summary>
+		/// <param name="text">Main string</param>
+		/// <param name="find">Search term</param>
+		/// <param name="startAt">Starts searching for term at specified char indexed.</param>
+		/// <param name="returnAll">If search term not found, return entire string? (true) or return "" (false)</param>
+		/// <param name="forward">Search forward from startAt, or backward from it</param>
+		/// <returns>Substring after the specified search term</returns>
+		public static string After(string text, string find, int startAt = 0, bool returnAll = false, bool forward = true)
+		{
 			if (text == null) { return returnAll ? text : ""; }
 			int idx;
-			if (!forward) {
+			if (!forward)
+			{
 				idx = text.LastIndexOf(find, text.Length - startAt, StringComparison.Ordinal);
-			} else {
+			}
+			else
+			{
 				idx = text.IndexOf(find, startAt, StringComparison.Ordinal);
 			}
 			if (idx == -1) { return returnAll ? text : ""; }
 			idx += find.Length;
 			return text.Substring(idx);
 		}
-		public static string AfterLast(string text, string find, bool returnAll = false) {
+
+		/// <summary>
+		/// Get the substring after the last instance of the search term (find). 
+		/// </summary>
+		/// <param name="text">Main string</param>
+		/// <param name="find">Search term</param>
+		/// <param name="returnAll">If search term not found, return entire string? (true) or return "" (false)</param>
+		/// <returns>Substring after the last instance of search term</returns>
+		public static string AfterLast(string text, string find, bool returnAll = false)
+		{
 			int idx = text.LastIndexOf(find, StringComparison.Ordinal);
-			if (idx == -1) {
+			if (idx == -1)
+			{
 				return returnAll ? text : "";
 			}
 			idx += find.Length;

--- a/External/Plugins/FlashDebugger/Helpers/StringsHelper.cs
+++ b/External/Plugins/FlashDebugger/Helpers/StringsHelper.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FlashDebugger {
+	public static class Strings {
+
+
+		public static string Before(string text, string find, int startAt = 0, bool returnAll = false, bool forward = true) {
+			if (text == null) { return returnAll ? text : ""; }
+			int idx;
+			if (forward) {
+				idx = text.IndexOf(find, startAt, StringComparison.Ordinal);
+			} else {
+				idx = text.LastIndexOf(find, text.Length - startAt, StringComparison.Ordinal);
+			}
+			if (idx == -1) { return returnAll ? text : ""; }
+			return text.Substring(0, idx);
+
+		}
+		public static string After(string text, string find, int startAt = 0, bool returnAll = false, bool forward = true) {
+			if (text == null) { return returnAll ? text : ""; }
+			int idx;
+			if (!forward) {
+				idx = text.LastIndexOf(find, text.Length - startAt, StringComparison.Ordinal);
+			} else {
+				idx = text.IndexOf(find, startAt, StringComparison.Ordinal);
+			}
+			if (idx == -1) { return returnAll ? text : ""; }
+			idx += find.Length;
+			return text.Substring(idx);
+		}
+		public static string AfterLast(string text, string find, bool returnAll = false) {
+			int idx = text.LastIndexOf(find, StringComparison.Ordinal);
+			if (idx == -1) {
+				return returnAll ? text : "";
+			}
+			idx += find.Length;
+			return text.Substring(idx);
+		}
+
+	}
+}

--- a/appman.xml
+++ b/appman.xml
@@ -167,7 +167,7 @@
 		</Urls>
 	</Entry>
 	<Entry>
-		<Id>torgit</Id>
+		<Id>torgit64</Id>
 		<Name>TortoiseGit (x64)</Name>
 		<Version>1.8.13</Version>
 		<Build>1</Build>
@@ -215,7 +215,7 @@
 		</Urls>
 	</Entry>
 	<Entry>
-		<Id>torsvn</Id>
+		<Id>torsvn64</Id>
 		<Name>TortoiseSVN (x64)</Name>
 		<Version>1.8.10</Version>
 		<Build>1</Build>


### PR DESCRIPTION
1. Add "Copy Tree" and "Copy ID" commands to DataTreeControl
2. Hide full class paths ("flash.display.MovieClip" shows as "MovieClip")
3. List inherited vars alongside main vars of a class instance
4. Add property in DataTreeControl to toggle this behavior
5. Use FD4 code styling (braces on new lines)
6. Add comments for String utilis (StringsHelper)
