### PR TITLE
Copy Tree command and combine inherited (#4)

### DIFF
--- a/External/Plugins/FlashDebugger/Controls/DataTree/ValueNode.cs
+++ b/External/Plugins/FlashDebugger/Controls/DataTree/ValueNode.cs
@@ -11,30 +11,15 @@ namespace FlashDebugger.Controls.DataTree
             get { return m_ChildrenShowLimit; }
             set { m_ChildrenShowLimit = value; }
         }
+		public static bool m_ShowFullClasspaths = true;
+		public static bool m_ShowObjectIDs = true;
 
         protected Value m_Value;
         private bool m_bEditing = false;
 
-		public string ID
-		{
-			get
-			{
-				if (m_Value != null)
-				{
-					int type = m_Value.getType();
-					if (type == VariableType_.MOVIECLIP || type == VariableType_.OBJECT)
-					{
-						return m_Value.getTypeName().replaceAll("::", ".").replaceAll("@", " - ").ToString();
-					}
-					else if (type == VariableType_.FUNCTION)
-					{
-						return "Function - " + m_Value.ToString();
-					}
-				}
-				return "";
-			}
-		}
-
+		/// <summary>
+		/// Get the display value based on user's preferences
+		/// </summary>
         public override string Value
         {
             get
@@ -47,16 +32,41 @@ namespace FlashDebugger.Controls.DataTree
                 string temp = null;
                 if (type == VariableType_.MOVIECLIP || type == VariableType_.OBJECT)
                 {
-					// return class type without classpath
-					string typeStr = Strings.AfterLast(m_Value.getTypeName().ToString(), "::", true);
-					string shortStr = Strings.Before(typeStr, "@");
-					if (shortStr == "[]")
+					string typeStr = "";
+					if (m_ShowFullClasspaths)
 					{
-						return "Array";
+						// return class type with classpath
+						typeStr = m_Value.getTypeName().replaceAll("::", ".").ToString();
+						
+					}else
+					{
+						// return class type without classpath
+						typeStr = Strings.AfterLast(m_Value.getTypeName().ToString(), "::", true);
 					}
-					return typeStr;
+					
+					// show / hide IDs
+					if (m_ShowObjectIDs)
+					{
+						typeStr = typeStr.Replace("@", " @");
+					}else
+					{
+						typeStr = Strings.Before(typeStr, "@");
+					}
 
-                    //return m_Value.getTypeName();
+					// rename array
+					if (typeStr.StartsWith("[]"))
+					{
+						typeStr = typeStr.Replace("[]", "Array");
+					}
+
+					// rename vector
+					else if (typeStr.StartsWith("__AS3__.vec.Vector.<"))
+					{
+						typeStr = typeStr.Replace("__AS3__.vec.Vector.<", "Vector.<");
+					}
+
+					return typeStr;
+					
                 }
                 else if (type == VariableType_.NUMBER)
                 {
@@ -94,7 +104,7 @@ namespace FlashDebugger.Controls.DataTree
                 }
                 else if (type == VariableType_.FUNCTION)
                 {
-                    return "Function";
+                    return "Function @" + m_Value.ToString();
                 }
                 temp = m_Value.ToString();
                 if (!m_bEditing)
@@ -109,6 +119,110 @@ namespace FlashDebugger.Controls.DataTree
             }
         }
 
+		/// <summary>
+		/// Get the full classpath of the value, eg: "flash.display.MovieClip"
+		/// </summary>
+		public string ClassPath
+		{
+			get
+			{
+
+				//return m_Value.getClassHierarchy(false).replaceAll("::", ".");
+
+				if (m_Value == null)
+				{
+					return null;
+				}
+				int type = m_Value.getType();
+				if (type == VariableType_.MOVIECLIP || type == VariableType_.OBJECT)
+				{
+					string typeStr = Strings.Before(m_Value.getTypeName().replaceAll("::", "."), "@");
+
+					if (typeStr == "[]")
+					{
+						return "Array";
+					}
+					return typeStr;
+
+				}
+				else if (type == VariableType_.NUMBER)
+				{
+					return "Number";
+				}
+				else if (type == VariableType_.BOOLEAN)
+				{
+					return "Boolean";
+				}
+				else if (type == VariableType_.STRING)
+				{
+					return "String";
+				}
+				else if (type == VariableType_.NULL)
+				{
+					return "null";
+				}
+				else if (type == VariableType_.FUNCTION)
+				{
+					return "Function";
+				}
+				return null;
+			}
+			set
+			{
+				throw new NotSupportedException();
+			}
+
+		}
+
+		/// <summary>
+		/// Get the object ID with the class name
+		/// </summary>
+		public string ID
+		{
+			get
+			{
+				if (m_Value != null)
+				{
+					int type = m_Value.getType();
+					if (type == VariableType_.MOVIECLIP || type == VariableType_.OBJECT)
+					{
+						return m_Value.getTypeName().replaceAll("::", ".").replaceAll("@", " - ").ToString();
+					}
+					else if (type == VariableType_.FUNCTION)
+					{
+						return "Function - " + m_Value.ToString();
+					}
+				}
+				return "";
+			}
+		}
+
+		/// <summary>
+		/// Check if the value is a primitive type (int, Number, String, Boolean)
+		/// </summary>
+		public bool IsPrimitive
+        {
+            get
+            {
+				if (m_Value == null)
+                {
+                    return false;
+                }
+                int type = m_Value.getType();
+                if (type == VariableType_.NUMBER || type == VariableType_.BOOLEAN ||
+					type == VariableType_.STRING || type == VariableType_.NULL)
+                {
+                    return true;
+                }
+                return false;
+            }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+		
         private string escape(string text)
         {
             text = text.Replace("\\", "\\\\");

--- a/External/Plugins/FlashDebugger/Controls/DataTree/ValueNode.cs
+++ b/External/Plugins/FlashDebugger/Controls/DataTree/ValueNode.cs
@@ -15,6 +15,26 @@ namespace FlashDebugger.Controls.DataTree
         protected Value m_Value;
         private bool m_bEditing = false;
 
+		public string ID
+		{
+			get
+			{
+				if (m_Value != null)
+				{
+					int type = m_Value.getType();
+					if (type == VariableType_.MOVIECLIP || type == VariableType_.OBJECT)
+					{
+						return m_Value.getTypeName().replaceAll("::", ".").replaceAll("@", " - ").ToString();
+					}
+					else if (type == VariableType_.FUNCTION)
+					{
+						return "Function - " + m_Value.ToString();
+					}
+				}
+				return "";
+			}
+		}
+
         public override string Value
         {
             get
@@ -27,7 +47,16 @@ namespace FlashDebugger.Controls.DataTree
                 string temp = null;
                 if (type == VariableType_.MOVIECLIP || type == VariableType_.OBJECT)
                 {
-                    return m_Value.getTypeName();
+					// return class type without classpath
+					string typeStr = Strings.AfterLast(m_Value.getTypeName().ToString(), "::", true);
+					string shortStr = Strings.Before(typeStr, "@");
+					if (shortStr == "[]")
+					{
+						return "Array";
+					}
+					return typeStr;
+
+                    //return m_Value.getTypeName();
                 }
                 else if (type == VariableType_.NUMBER)
                 {
@@ -63,11 +92,10 @@ namespace FlashDebugger.Controls.DataTree
                 {
                     return "null";
                 }
-                /*else if (type == VariableType_.FUNCTION)
+                else if (type == VariableType_.FUNCTION)
                 {
-                    m_Value.ToString();
-                    //return "<setter>";
-                }*/
+                    return "Function";
+                }
                 temp = m_Value.ToString();
                 if (!m_bEditing)
                 {

--- a/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
+++ b/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
@@ -21,11 +21,12 @@ namespace FlashDebugger.Controls
         private DataTreeModel _model;
         private static ViewerForm viewerForm;
         private ContextMenuStrip _contextMenuStrip;
-		private ToolStripMenuItem copyMenuItem, viewerMenuItem, watchMenuItem, copyIDMenuItem, copyTreeMenuItem;
+		private ToolStripMenuItem copyMenuItem, viewerMenuItem, watchMenuItem, copyValueMenuItem, copyIDMenuItem, copyTreeMenuItem;
         private DataTreeState state;
         private bool watchMode;
         private bool addingNewExpression;
-		private static bool combineInherited = false;
+		private static bool m_combineInherited = false;
+		private static bool m_showStaticInObjects = true;
 
         public Collection<Node> Nodes
         {
@@ -99,10 +100,11 @@ namespace FlashDebugger.Controls
             this.NameTreeColumn.Header = TextHelper.GetString("Label.Name");
             this.ValueTreeColumn.Header = TextHelper.GetString("Label.Value");
             copyMenuItem = new ToolStripMenuItem(TextHelper.GetString("Label.Copy"), null, new EventHandler(this.CopyItemClick));
-            copyIDMenuItem = new ToolStripMenuItem("Copy ID", null, new EventHandler(this.CopyItemIDClick));
+			copyValueMenuItem = new ToolStripMenuItem("Copy Value", null, new EventHandler(this.CopyItemValueClick));
+			copyIDMenuItem = new ToolStripMenuItem("Copy ID", null, new EventHandler(this.CopyItemIDClick));
 			copyTreeMenuItem = new ToolStripMenuItem("Copy Tree", null, new EventHandler(this.CopyItemTreeClick));
             viewerMenuItem = new ToolStripMenuItem(TextHelper.GetString("Label.Viewer"), null, new EventHandler(this.ViewerItemClick));
-            _contextMenuStrip.Items.AddRange(new ToolStripMenuItem[] { copyMenuItem, copyIDMenuItem, copyTreeMenuItem, viewerMenuItem});
+			_contextMenuStrip.Items.AddRange(new ToolStripMenuItem[] { copyMenuItem, copyIDMenuItem, copyValueMenuItem, copyTreeMenuItem, viewerMenuItem });
             if (watchMode)
                 watchMenuItem = new ToolStripMenuItem(TextHelper.GetString("Label.Unwatch"), null, new EventHandler(this.WatchItemClick));
             else
@@ -389,10 +391,11 @@ namespace FlashDebugger.Controls
 						nodes.Add(memberNode);
 					}
 				}
+
 				// inherited vars
 				if (inherited.Count > 0)
 				{
-					if (combineInherited)
+					if (m_combineInherited)
 					{
 						// list inherited alongside main class members
 						foreach (DataNode item in inherited)
@@ -416,7 +419,7 @@ namespace FlashDebugger.Controls
 				}
 
 				// static vars
-				if (statics.Count > 0)
+				if (m_showStaticInObjects && statics.Count > 0)
 				{
 					DataNode staticNode = new ValueNode("[static]");
 					statics.Sort();
@@ -426,6 +429,7 @@ namespace FlashDebugger.Controls
 					}
 					node.Nodes.Add(staticNode);
 				}
+
 				// test children
 				foreach (String ch in node.PlayerValue.getClassHierarchy(false))
 				{
@@ -590,12 +594,6 @@ namespace FlashDebugger.Controls
                 if (topNode != null) Tree.EnsureVisible(topNode);
             }
         }
-		
-		public static bool CombineInherited
-		{
-			get { return DataTreeControl.combineInherited; }
-			set { DataTreeControl.combineInherited = value; }
-		}
 
         #region IToolTipProvider Members
 
@@ -633,8 +631,18 @@ namespace FlashDebugger.Controls
 
         #endregion
 		
-		
-		#region Copy ID & Tree
+		#region Copy Value, ID, Tree
+
+		private void CopyItemValueClick(Object sender, System.EventArgs e)
+		{
+			if (Tree.SelectedNode != null)
+			{
+
+				ValueNode node = Tree.SelectedNode.Tag as ValueNode;
+				Clipboard.SetText(node.Value);
+
+			}
+		}
 
 		private void CopyItemIDClick(Object sender, System.EventArgs e)
 		{
@@ -662,9 +670,47 @@ namespace FlashDebugger.Controls
 
 			}
 		}
-
-
+		
 		#endregion
+
+        #region Settings
+
+		public int CopyTreeMaxChars
+		{
+			get { return CopyTreeHelper._CopyTreeMaxChars; }
+			set { CopyTreeHelper._CopyTreeMaxChars = value; }
+		}
+        public int CopyTreeMaxRecursion
+        {
+			get { return CopyTreeHelper._CopyTreeMaxRecursion; }
+			set { CopyTreeHelper._CopyTreeMaxRecursion = value; }
+        }
+		
+		public static bool CombineInherited
+		{
+			get { return DataTreeControl.m_combineInherited; }
+			set { DataTreeControl.m_combineInherited = value; }
+		}
+
+		public static bool ShowStaticInObjects
+		{
+			get { return DataTreeControl.m_showStaticInObjects; }
+			set { DataTreeControl.m_showStaticInObjects = value; }
+		}
+		
+		public static bool ShowFullClasspaths
+		{
+			get { return ValueNode.m_ShowFullClasspaths; }
+			set { ValueNode.m_ShowFullClasspaths = value; }
+		}
+
+		public static bool ShowObjectIDs
+		{
+			get { return ValueNode.m_ShowObjectIDs; }
+			set { ValueNode.m_ShowObjectIDs = value; }
+		}
+
+        #endregion
 		
     }
 

--- a/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
+++ b/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
@@ -675,12 +675,13 @@ namespace FlashDebugger.Controls
 
         #region Settings
 
-		public int CopyTreeMaxChars
+		public static int CopyTreeMaxChars
 		{
 			get { return CopyTreeHelper._CopyTreeMaxChars; }
 			set { CopyTreeHelper._CopyTreeMaxChars = value; }
 		}
-        public int CopyTreeMaxRecursion
+		
+		public static int CopyTreeMaxRecursion
         {
 			get { return CopyTreeHelper._CopyTreeMaxRecursion; }
 			set { CopyTreeHelper._CopyTreeMaxRecursion = value; }

--- a/External/Plugins/FlashDebugger/FlashDebugger.csproj
+++ b/External/Plugins/FlashDebugger/FlashDebugger.csproj
@@ -148,8 +148,10 @@
     <Compile Include="Debugger\ExpressionContext.cs" />
     <Compile Include="Debugger\FlashInterface.cs" />
     <Compile Include="Debugger\VariableFacade.cs" />
+    <Compile Include="Helpers\CopyAsTree.cs" />
     <Compile Include="Helpers\MenusHelper.cs" />
     <Compile Include="Helpers\PanelsHelper.cs" />
+    <Compile Include="Helpers\StringsHelper.cs" />
     <Compile Include="Helpers\ScintillaHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PluginMain.cs" />

--- a/External/Plugins/FlashDebugger/Helpers/CopyAsTree.cs
+++ b/External/Plugins/FlashDebugger/Helpers/CopyAsTree.cs
@@ -1,0 +1,212 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using Aga.Controls.Tree;
+using FlashDebugger.Controls;
+using FlashDebugger.Controls.DataTree;
+
+namespace FlashDebugger
+{
+	public class CopyTreeHelper
+	{
+
+		public const int CopyTreeMaxRecursion = 10;
+		public const int CopyTreeMaxChars = 1000000;
+
+		private static Dictionary<string, int> CopiedObjects;
+
+
+		public static string GetTreeAsText(TreeNodeAdv treeNode, ValueNode dataNode, string levelSep, DataTreeControl control, int levelLimit)
+		{
+			StringBuilder sb = new StringBuilder();
+
+			// ensure expanded
+			control.ListChildItems(dataNode);
+
+			// add children nodes
+			CopiedObjects = new Dictionary<string, int>();
+			GetTreeItemsAsText(new List<ValueNode> { dataNode }, levelSep, 0, sb, control, levelLimit);
+
+			return sb.ToString() ?? "";
+		}
+
+		private static void GetTreeItemsAsText(IList dataNodes, string levelSep, int level, StringBuilder sb, DataTreeControl control, int levelLimit)
+		{
+
+			// per node
+			int len = dataNodes.Count;
+			for (int c = 0; c < len; c++)
+			{
+				ValueNode child = (ValueNode)dataNodes[c];
+
+
+				// skip if unwanted item
+				if (!IsWantedChild(child))
+				{
+					continue;
+				}
+
+
+				// ensure expanded
+				control.ListChildItems(child);
+
+				// add node
+				AppendTimes(sb, levelSep, level);
+				sb.Append(child.Text + " : " + child.Value);
+
+				// recurse for children .. but skip if unwanted items
+				if (child.Nodes.Count > 0 && IsWantedParent(child))
+				{
+
+					// opening brace
+					sb.AppendLine("{");
+
+					string childID = child.ID;
+
+					// add error if too many levels of recursion
+					if (level <= levelLimit || levelLimit == 0)
+					{
+
+						// check if encountered before
+						bool isNew = !CopiedObjects.ContainsKey(childID);
+						if (!isNew)
+						{
+
+							// error
+							AppendTimes(sb, levelSep, level + 1);
+							sb.AppendLine("[Already listed before]");
+
+						}
+						else if (level > CopyTreeMaxRecursion)
+						{
+
+							// error
+							AppendTimes(sb, levelSep, level + 1);
+							sb.AppendLine("[Recursion too deep, increase CopyTreeMaxRecursion in FlashDebugger settings]");
+
+						}
+						else
+						{
+
+							// add to list
+							CopiedObjects.Add(childID, 1);
+
+							// children
+							try
+							{
+								GetTreeItemsAsText(child.Nodes, levelSep, level + 1, sb, control, levelLimit);
+							}
+							catch (System.Exception ex) { }
+
+						}
+					}
+
+
+					// closing brace
+					AppendTimes(sb, levelSep, level);
+					sb.AppendLine("}");
+
+				}
+				else
+				{
+					sb.AppendLine();
+				}
+
+
+				// stop recursion if too long
+				if (sb.Length > CopyTreeMaxChars)
+				{
+					sb.Append("......");
+					return;
+				}
+
+
+			}
+		}
+
+		private static bool IsWantedParent(DataNode parent)
+		{
+			try
+			{
+
+				// if is an empty array []
+				// then skip it from opening and closing { } the output
+				if (parent.Nodes.Count == 1 || parent.Nodes.Count == 2)
+				{
+					if (parent.Value.StartsWith("Array"))
+					{
+						DataNode child1 = (DataNode)parent.Nodes[0];
+						if (child1.Text == "[static]" || child1.Text == "length")
+						{
+							return false;
+						}
+					}
+				}
+
+				// catch "cannot cast Aga.TreeNode to DataNode" 
+				// TODO : fix this instead of just catching it
+			}
+			catch (Exception ex) { }
+			return true;
+		}
+
+		private static string[] as3DisabledProps = new string[] { "stage", "parent", "root", "loaderInfo", "_nativeWindow", "nativeWindow" };
+
+		private static bool IsWantedChild(DataNode child)
+		{
+			try
+			{
+				if (child.Parent != null)
+				{
+					DataNode parent = ((DataNode)child.Parent);
+
+					// if is an array []
+					// skip [static] and "length" properties
+					if (parent.Value.StartsWith("Array"))
+					{
+						if (child.Text == "[static]" || child.Text == "length")
+						{
+							return false;
+						}
+					}
+
+					// if is an AS3 display object,
+					// don't go upward (stage, parent)
+					if (parent.Value.StartsWith("flash.display.") || parent.Value == "Main")
+					{
+						if (Array.IndexOf(as3DisabledProps, child.Text) > -1)
+						{
+							return false;
+						}
+					}
+
+					// if is an AS2 display object,
+					// don't go upward (_parent)
+					if (parent.Value == "MovieClip" || parent.Value == "Video")
+					{
+						if (child.Text == "_parent")
+						{
+							return false;
+						}
+					}
+
+				}
+
+				// catch "cannot cast Aga.TreeNode to DataNode" 
+				// TODO : fix this instead of just catching it
+			}
+			catch (Exception ex) { }
+			return true;
+		}
+
+		private static void AppendTimes(StringBuilder sb, string append, int times)
+		{
+			for (int t = 0; t < times; t++)
+			{
+				sb.Append(append);
+			}
+		}
+
+	}
+}

--- a/External/Plugins/FlashDebugger/Helpers/StringsHelper.cs
+++ b/External/Plugins/FlashDebugger/Helpers/StringsHelper.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FlashDebugger
+{
+	public static class Strings
+	{
+
+		/// <summary>
+		/// Get the substring before the specified search term (find). 
+		/// </summary>
+		/// <param name="text">Main string</param>
+		/// <param name="find">Search term</param>
+		/// <param name="startAt">Starts searching for term at specified char indexed.</param>
+		/// <param name="returnAll">If search term not found, return entire string? (true) or return "" (false)</param>
+		/// <param name="forward">Search forward from startAt, or backward from it</param>
+		/// <returns>Substring before the specified search term</returns>
+		public static string Before(string text, string find, int startAt = 0, bool returnAll = false, bool forward = true)
+		{
+			if (text == null) { return returnAll ? text : ""; }
+			int idx;
+			if (forward)
+			{
+				idx = text.IndexOf(find, startAt, StringComparison.Ordinal);
+			}
+			else
+			{
+				idx = text.LastIndexOf(find, text.Length - startAt, StringComparison.Ordinal);
+			}
+			if (idx == -1) { return returnAll ? text : ""; }
+			return text.Substring(0, idx);
+
+		}
+
+		/// <summary>
+		/// Get the substring after the specified search term (find). 
+		/// </summary>
+		/// <param name="text">Main string</param>
+		/// <param name="find">Search term</param>
+		/// <param name="startAt">Starts searching for term at specified char indexed.</param>
+		/// <param name="returnAll">If search term not found, return entire string? (true) or return "" (false)</param>
+		/// <param name="forward">Search forward from startAt, or backward from it</param>
+		/// <returns>Substring after the specified search term</returns>
+		public static string After(string text, string find, int startAt = 0, bool returnAll = false, bool forward = true)
+		{
+			if (text == null) { return returnAll ? text : ""; }
+			int idx;
+			if (!forward)
+			{
+				idx = text.LastIndexOf(find, text.Length - startAt, StringComparison.Ordinal);
+			}
+			else
+			{
+				idx = text.IndexOf(find, startAt, StringComparison.Ordinal);
+			}
+			if (idx == -1) { return returnAll ? text : ""; }
+			idx += find.Length;
+			return text.Substring(idx);
+		}
+
+		/// <summary>
+		/// Get the substring after the last instance of the search term (find). 
+		/// </summary>
+		/// <param name="text">Main string</param>
+		/// <param name="find">Search term</param>
+		/// <param name="returnAll">If search term not found, return entire string? (true) or return "" (false)</param>
+		/// <returns>Substring after the last instance of search term</returns>
+		public static string AfterLast(string text, string find, bool returnAll = false)
+		{
+			int idx = text.LastIndexOf(find, StringComparison.Ordinal);
+			if (idx == -1)
+			{
+				return returnAll ? text : "";
+			}
+			idx += find.Length;
+			return text.Substring(idx);
+		}
+
+	}
+}


### PR DESCRIPTION
@Neverbirth : All your points have been taken into consideration, static settings bool's have been added for each change in behavior, and the original behavior has been restored by default. Dictionary has been freed at end of CopyTree. String issues have been fixed using full classpaths. 

@Meychi : I didn't create an issue yet, because I corrected every issue brought up. And yes, I rewrote and re-tested everything with the code from `fd5` branch.

1. Add "Copy Tree", "Copy Value" "Copy ID" commands to `DataTreeControl`
2. Add the following setting bools to `DataTreeControl`
  - CopyTreeMaxChars - default : 1000000
  - CopyTreeMaxRecursion  - default : 10
  - CombineInherited - default : false
  - ShowStaticInObjects - default : true
  - ShowFullClasspaths - default : true
  - ShowObjectIDs - default : true
3. Add string utils (`StringsHelper`)
4. Add getters in `ValueNode` for:
  - IsPrimitive
  - ClassPath
  - ID
5. Arrays show as "Array" instead of "[]"
6. Vectors show as "Vector.<*>" instead of "AS3.vec.Vector.<*>"
7. Add the following optional features to the debug data tree
  - Hide object IDs ("@abc123")
  - Hide full class paths ("flash.display.MovieClip" shows as "MovieClip")
  - List inherited vars alongside main vars of a class instance
  - `[static]` does not show in dynamic objects

**Preview**
This is what it looks like by default. No major changes compared to FD4.

![fd_copyastree_v4](https://cloud.githubusercontent.com/assets/6797866/6499635/fe1c6660-c324-11e4-97a0-4afd61abb167.png)
