### PR TITLE
GetLine is now fixed to match Scintilla and return all EOLs, we need to fix and review all usage

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -3162,10 +3162,8 @@ namespace ASCompletion.Completion
                 minPos = Sci.PositionFromLine(expression.ContextMember.LineFrom);
                 StringBuilder sbBody = new StringBuilder();
                 for (int i = expression.ContextMember.LineFrom; i <= expression.ContextMember.LineTo; i++)
-                    sbBody.Append(Sci.GetLine(i)).Append('\n');
+                    sbBody.Append(Sci.GetLine(i));
                 body = sbBody.ToString();
-                //int tokPos = body.IndexOf(expression.ContextMember.Name);
-                //if (tokPos >= 0) minPos += tokPos + expression.ContextMember.Name.Length;
 
                 var hasBody = FlagType.Function | FlagType.Constructor;
                 if (!haXe) hasBody |= FlagType.Getter | FlagType.Setter;

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -1036,7 +1036,7 @@ namespace ASCompletion.Completion
         private static void ReformatLine(ScintillaControl Sci, int position)
         {
             int line = Sci.LineFromPosition(position);
-            string txt = Sci.GetLine(line);
+            string txt = Sci.GetLine(line).TrimEnd(new char[] { '\r', '\n' });
             int curPos = Sci.CurrentPos;
             int startPos = Sci.PositionFromLine(line);
             int offset = Sci.MBSafeLengthFromBytes(txt, position - startPos);

--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -271,8 +271,9 @@ namespace ASCompletion.Completion
 
                 // "assign var to statement" suggestion
                 int curLine = Sci.CurrentLine;
-                string ln = Sci.GetLine(curLine);
-                if (ln.Trim().Length > 0 && ln.TrimEnd().Length <= Sci.CurrentPos - Sci.PositionFromLine(curLine) && ln.IndexOf("=") == -1)
+                string ln = Sci.GetLine(curLine).TrimEnd();
+                if (ln.Length > 0 && ln.IndexOf("=") == -1 
+                    && ln.Length <= Sci.CurrentPos - Sci.PositionFromLine(curLine)) // cursor at end of line
                 {
                     ShowAssignStatementToVarList(found);
                     return;
@@ -4362,8 +4363,7 @@ namespace ASCompletion.Completion
             sci.LineScroll(0, firstLine - sci.FirstVisibleLine + 1);
 
             ASContext.Context.RefreshContextCache(fullPath);
-            if (sci.EOLMode == 2) return sci.GetLine(line).Length + nl.Length;
-            else return sci.GetLine(line).Length + nl.Length - 1;
+            return sci.GetLine(line).Length;
         }
         #endregion
 

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -3380,8 +3380,7 @@ namespace FlashDevelop
         public void SortLines(Object sender, System.EventArgs e)
         {
             ScintillaControl sci = Globals.SciControl;
-            Int32 position = sci.CurrentPos;
-            Int32 curLine = sci.LineFromPosition(position);
+            Int32 curLine = sci.LineFromPosition(sci.SelectionStart);
             Int32 endLine = sci.LineFromPosition(sci.SelectionEnd);
             List<String> lines = new List<String>();
             for (Int32 line = curLine; line < endLine + 1; ++line)
@@ -3390,14 +3389,12 @@ namespace FlashDevelop
             }
             lines.Sort(CompareLines);
             StringBuilder result = new StringBuilder();
-            string end = lines[lines.Count - 1];
-            foreach (String s in lines )
+            foreach (String s in lines)
             {
                 result.Append(s);
-                if (s != end) result.Append("\n");
             }
             Int32 selStart = sci.PositionFromLine(curLine);
-            Int32 selEnd = sci.PositionFromLine(endLine) + sci.GetLine(endLine).Length;
+            Int32 selEnd = sci.PositionFromLine(endLine) + sci.MBSafeTextLength(sci.GetLine(endLine));
             sci.SetSel(selStart, selEnd);
             sci.ReplaceSel(result.ToString());
         }
@@ -3408,8 +3405,7 @@ namespace FlashDevelop
         public void SortLineGroups(Object sender, System.EventArgs e)
         {
             ScintillaControl sci = Globals.SciControl;
-            Int32 position = sci.CurrentPos;
-            Int32 curLine = sci.LineFromPosition(position);
+            Int32 curLine = sci.LineFromPosition(sci.SelectionStart);
             Int32 endLine = sci.LineFromPosition(sci.SelectionEnd);
             List<List<String>> lineLists = new List<List<String>>();
             List<String> curList = new List<String>();
@@ -3417,9 +3413,10 @@ namespace FlashDevelop
             for (Int32 line = curLine; line < endLine + 1; ++line)
             {
                 String lineText = sci.GetLine(line);
-                if (CompareLines(lineText, "\r") == 0)
+                if (lineText.Trim() == "")
                 {
                     curList.Sort(CompareLines);
+                    curList.Add(lineText);
                     curList = new List<String>();
                     lineLists.Add(curList);
                     continue;
@@ -3428,17 +3425,15 @@ namespace FlashDevelop
             }
             curList.Sort(CompareLines);
             StringBuilder result = new StringBuilder();
-            List<String> end = lineLists[lineLists.Count - 1];
             foreach (List<String> l in lineLists)
             {
                 foreach (String s in l)
                 {
                     result.Append(s);
                 }
-                if (l != end) result.Append("\r");
             }
             Int32 selStart = sci.PositionFromLine(curLine);
-            Int32 selEnd = sci.PositionFromLine(endLine) + sci.GetLine(endLine).Length;
+            Int32 selEnd = sci.PositionFromLine(endLine) + sci.MBSafeTextLength(sci.GetLine(endLine));
             sci.SetSel(selStart, selEnd);
             sci.ReplaceSel(result.ToString());
         }

--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -3214,7 +3214,6 @@ namespace ScintillaNet
 			byte[] buffer = new byte[sz + 1];
 			fixed (byte* b = buffer) SPerform(2153, (uint)line, (uint)b);
             if (sz == 0) return ""; // Empty last line
-            if (buffer[sz - 1] == 10) sz--;
 			return Encoding.GetEncoding(this.CodePage).GetString(buffer, 0, sz);
 		}
 

--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -6674,8 +6674,7 @@ namespace ScintillaNet
         public int GetStartLine(int line)
         {
             string str = GetLine(line);
-            char marker;
-            marker = (ConfigurationLanguage == "xml" || ConfigurationLanguage == "html" || ConfigurationLanguage == "css") ? '>' : ')';
+            char marker = (ConfigurationLanguage == "xml" || ConfigurationLanguage == "html" || ConfigurationLanguage == "css") ? '>' : ')';
             int pos = str.LastIndexOf(marker);
             if (pos >= 0)
             {


### PR DESCRIPTION
Previous returned only \r. This also matches other line related methods. Push here fixes-