### PR TITLE
Fixed an inconsistency in the settings filter

### DIFF
--- a/FlashDevelop/Dialogs/SettingDialog.cs
+++ b/FlashDevelop/Dialogs/SettingDialog.cs
@@ -429,7 +429,6 @@ namespace FlashDevelop.Dialogs
         private void FilterPropertySheet()
         {
             if (Win32.IsRunningOnMono()) return;
-            LocalizedDescriptionAttribute lda = null;
             Object settingsObj = this.itemPropertyGrid.SelectedObject;
             String text = this.filterText.Text;
             if (settingsObj != null)
@@ -439,9 +438,7 @@ namespace FlashDevelop.Dialogs
                 PropertyInfo[] props = settingsObj.GetType().GetProperties();
                 foreach (PropertyInfo prop in props)
                 {
-                    var atts = prop.GetCustomAttributes(typeof(LocalizedDescriptionAttribute), true);
-                    if (atts.Length > 0) lda = atts[0] as LocalizedDescriptionAttribute;
-                    if (prop.Name.ToLower().ToLower().Contains(text.ToLower()) || lda != null && lda.Description.ToLower().Contains(text.ToLower()))
+                    if (PropertyMatches(prop, text))
                     {
                         Array.Resize(ref browsables, i + 1);
                         browsables.SetValue(prop.Name, i);
@@ -466,10 +463,19 @@ namespace FlashDevelop.Dialogs
                 PropertyInfo[] props = settingsObj.GetType().GetProperties();
                 foreach (PropertyInfo prop in props)
                 {
-                    if (prop.Name.ToLower().Contains(text.ToLower())) ok = true;
+                    if (PropertyMatches(prop, text)) ok = true;
                 }
             }
             return ok;
+        }
+
+        private Boolean PropertyMatches(PropertyInfo prop, String text)
+        {
+            LocalizedDescriptionAttribute lda = null;
+            var atts = prop.GetCustomAttributes(typeof(LocalizedDescriptionAttribute), true);
+            if (atts.Length > 0) lda = atts[0] as LocalizedDescriptionAttribute;
+            return prop.Name.ToLower().Contains(text.ToLower()) ||
+                   lda != null && lda.Description.ToLower().Contains(text.ToLower());
         }
 
         /// <summary>


### PR DESCRIPTION
The description of a property was only being taken into account when filtering the currently selected plugin's properties, but not when repopulating the plugin list itself.
This led to effects like the CodeFormatter plugin not appearing for the "Trim " filter String, even though it's contained in the Trim trailing spaces property's description.