### PR TITLE
Scale the SplitterSize for DockPanels

### DIFF
--- a/PluginCore/DockPanelSuite/Docking/Measures.cs
+++ b/PluginCore/DockPanelSuite/Docking/Measures.cs
@@ -4,7 +4,7 @@ namespace WeifenLuo.WinFormsUI.Docking
 {
     internal static class Measures
     {
-        public const int SplitterSize = 4;
+        public static readonly int SplitterSize = ScaleHelper.Scale(4);
     }
 
     internal static class MeasurePane


### PR DESCRIPTION
Splitters were not being scaled with DPI so the target area was very thin.