### PR TITLE
Move the caret / selection in SelectionDuplicate

### DIFF
--- a/FlashDevelop/Bin/Debug/Settings/MainMenu.xml
+++ b/FlashDevelop/Bin/Debug/Settings/MainMenu.xml
@@ -85,7 +85,7 @@
 		<button label="Label.MoveLineUp" click="ScintillaCommand" tag="MoveLineUp" shortcut="Control|Alt|Up" flags="Enable:IsEditable" />
 		<button label="Label.MoveLineDown" click="ScintillaCommand" tag="MoveLineDown" shortcut="Control|Alt|Down" flags="Enable:IsEditable" />
 		<button label="Label.TransposeLines" click="ScintillaCommand" tag="LineTranspose" shortcut="Control|T" flags="Enable:IsEditable" />
-		<button label="Label.DuplicateSelection" click="ScintillaCommand" tag="SelectionDuplicate" shortcut="Control|D" flags="Enable:IsEditable" />
+		<button label="Label.DuplicateSelection" click="ScintillaCommand" tag="SmartSelectionDuplicate" shortcut="Control|D" flags="Enable:IsEditable" />
 		<button label="Label.SortLineGroups" click="SortLineGroups" flags="Enable:IsEditable|Enable:HasSelection" />
 		<button label="Label.SortLines" click="SortLines" flags="Enable:IsEditable|Enable:HasSelection" />
 		<separator />

--- a/FlashDevelop/Bin/Debug/Settings/ScintillaMenu.xml
+++ b/FlashDevelop/Bin/Debug/Settings/ScintillaMenu.xml
@@ -7,7 +7,7 @@
 		<button label="Label.MoveLineUp" click="ScintillaCommand" tag="MoveLineUp" />
 		<button label="Label.MoveLineDown" click="ScintillaCommand" tag="MoveLineDown" />
 		<button label="Label.TransposeLines" click="ScintillaCommand" tag="LineTranspose" />
-		<button label="Label.DuplicateSelection" click="ScintillaCommand" tag="SelectionDuplicate" />
+		<button label="Label.DuplicateSelection" click="ScintillaCommand" tag="SmartSelectionDuplicate" />
 		<button label="Label.SortLineGroups" click="SortLineGroups" flags="Enable:Enable:HasSelection" />
 		<button label="Label.SortLines" click="SortLines" flags="Enable:Enable:HasSelection" />
 		<separator />

--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -2298,9 +2298,18 @@ namespace ScintillaNet
         /// </summary>
         public void SelectionDuplicate()
         {
+            SPerform(2469, 0, 0);
+        }
+
+        /// <summary>
+        /// Calls SelectionDuplicate and moves the selection
+        /// to a convenient position afterwards.
+        /// </summary>
+        public void SmartSelectionDuplicate()
+        {
             bool wholeLine = SelectionStart == SelectionEnd;
             int selectionLength = SelectionEnd - SelectionStart;
-            SPerform(2469, 0, 0);
+            SelectionDuplicate();
             if (wholeLine)
                 LineDown();
             else

--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -2298,7 +2298,16 @@ namespace ScintillaNet
         /// </summary>
         public void SelectionDuplicate()
         {
+            bool wholeLine = SelectionStart == SelectionEnd;
+            int selectionLength = SelectionEnd - SelectionStart;
             SPerform(2469, 0, 0);
+            if (wholeLine)
+                LineDown();
+            else
+            {
+                SelectionStart += selectionLength;
+                SelectionEnd += selectionLength;
+            }
         }
         
         /// <summary>


### PR DESCRIPTION
Like FD, IntelliJ IDEA also has a Ctrl+D shortcut to duplicate the current selection (or line if the selection is empty), but it also
- moves the caret down one line if a line is duplicated
- moves the selection to the duplicated text if the selection is duplicated

I think this is convenient, so I implemented the same behavior here.

It does seem a little counter-intuitive when you undo the duplication, because the selection doesn't go back to what it was before. I tried `Begin` / `EndUndoAction()`, but Scintilla doesn't care about selection changes in the undo history.
The [docs](http://www.scintilla.org/ScintillaDoc.html) say:

>Scintilla saves actions that change the document. Scintilla does not save caret and selection movements, view scrolling and the like.

I'm not sure how this behavior could be emulated either, there are undo / redo event listeners, but I don't know how you would be able to tell that what's being undone / redone is a SelectionDuplicate action.