### PR TITLE
Add more themeing

### DIFF
--- a/External/Themes/FullThemes/DefaultTheme/$(BaseDir)/Settings/Themes/Default.fdi
+++ b/External/Themes/FullThemes/DefaultTheme/$(BaseDir)/Settings/Themes/Default.fdi
@@ -24,10 +24,18 @@ DockPanel.ShowAutoHideContentOn=Hover
 #ToolStripItem.ArrowColor=#ff0000
 #ToolStripItem.TextColor=#0000ff
 
+VS2005DockPaneCaption.ActiveForeColor=#333333
+VS2005DockPaneCaption.ActiveImageColor=#333333
+VS2005DockPaneCaption.ImageColor=#333333
 #VS2005DockPaneCaption.BorderColor=#ff0000
+
 #VS2005DockPaneStrip.DocTabActiveBorder=#ff0000
+VS2005DockPaneStrip.DocTabActiveForeColor=#000000
 #VS2005DockPaneStrip.DocTabInactiveBorder=#0000ff
+#VS2005DockPaneStrip.ToolActiveBorderColor=#ff0000
 #VS2005DockPaneStrip.ToolBorderColor=#ff0000
+VS2005DockPaneStrip.ToolActiveForeColor=#333333
+VS2005DockPaneStrip.ImageColor=#000000
 
 #ToolStripMenu.TitleBackColor=#ff00ff
 #ToolStripMenu.TitleBorderColor=#0000ff

--- a/External/Themes/FullThemes/DimGrayTheme/$(BaseDir)/Settings/Themes/DimGray.fdi
+++ b/External/Themes/FullThemes/DimGrayTheme/$(BaseDir)/Settings/Themes/DimGray.fdi
@@ -24,10 +24,18 @@ DockPanel.ShowAutoHideContentOn=Hover
 #ToolStripItem.ArrowColor=#ff0000
 #ToolStripItem.TextColor=#0000ff
 
+VS2005DockPaneCaption.ActiveForeColor=#EEEEEE
+VS2005DockPaneCaption.ActiveImageColor=#EEEEEE
+VS2005DockPaneCaption.ImageColor=#EEEEEE
 #VS2005DockPaneCaption.BorderColor=#ff0000
+
 #VS2005DockPaneStrip.DocTabActiveBorder=#ff0000
+VS2005DockPaneStrip.DocTabActiveForeColor=#222222
 #VS2005DockPaneStrip.DocTabInactiveBorder=#0000ff
+#VS2005DockPaneStrip.ToolActiveBorderColor=#ff0000
 #VS2005DockPaneStrip.ToolBorderColor=#ff0000
+VS2005DockPaneStrip.ToolActiveForeColor=#333333
+VS2005DockPaneStrip.ImageColor=#222222
 
 #ToolStripMenu.TitleBackColor=#ff00ff
 #ToolStripMenu.TitleBorderColor=#0000ff

--- a/External/Themes/FullThemes/ObsidianTheme/$(BaseDir)/Settings/Themes/Obsidian.fdi
+++ b/External/Themes/FullThemes/ObsidianTheme/$(BaseDir)/Settings/Themes/Obsidian.fdi
@@ -24,10 +24,18 @@ ToolStripSeparator.ForeColor=#889299
 ToolStripItem.ArrowColor=#3C4142
 ToolStripItem.TextColor=#3C4142
 
-VS2005DockPaneStrip.DocTabActiveBorder=#6D767C
-VS2005DockPaneStrip.DocTabInactiveBorder=#6D767C
-VS2005DockPaneStrip.ToolBorderColor=#6D767C
+VS2005DockPaneCaption.ActiveForeColor=#D1D1D1
+VS2005DockPaneCaption.ActiveImageColor=#D1D1D1
+VS2005DockPaneCaption.ImageColor=#D1D1D1
 VS2005DockPaneCaption.BorderColor=#6D767C
+
+VS2005DockPaneStrip.DocTabActiveBorder=#6D767C
+VS2005DockPaneStrip.DocTabActiveForeColor=#3A4345
+VS2005DockPaneStrip.DocTabInactiveBorder=#6D767C
+VS2005DockPaneStrip.ToolActiveBorderColor=#6D767C
+VS2005DockPaneStrip.ToolBorderColor=#6D767C
+VS2005DockPaneStrip.ToolActiveForeColor=#3A4345
+VS2005DockPaneStrip.ImageColor=#3A4345
 
 ToolStripMenu.TitleBackColor=#D2D5D3
 ToolStripMenu.TitleBorderColor=#75828A

--- a/External/Themes/FullThemes/ThyleusTheme/$(BaseDir)/Settings/Themes/Thyleus.fdi
+++ b/External/Themes/FullThemes/ThyleusTheme/$(BaseDir)/Settings/Themes/Thyleus.fdi
@@ -24,10 +24,18 @@ ToolStripSeparator.ForeColor=#9D9895
 ToolStripItem.ArrowColor=#474443
 ToolStripItem.TextColor=#363330
 
-VS2005DockPaneStrip.DocTabActiveBorder=#696463
-VS2005DockPaneStrip.DocTabInactiveBorder=#696463
-VS2005DockPaneStrip.ToolBorderColor=#696463
+VS2005DockPaneCaption.ActiveForeColor=#D1D1D1
+VS2005DockPaneCaption.ActiveImageColor=#D1D1D1
+VS2005DockPaneCaption.ImageColor=#D1D1D1
 VS2005DockPaneCaption.BorderColor=#696463
+
+VS2005DockPaneStrip.DocTabActiveBorder=#696463
+VS2005DockPaneStrip.DocTabActiveForeColor=#222222
+VS2005DockPaneStrip.DocTabInactiveBorder=#696463
+VS2005DockPaneStrip.ToolActiveBorderColor=#696463
+VS2005DockPaneStrip.ToolBorderColor=#696463
+VS2005DockPaneStrip.ToolActiveForeColor=#222222
+VS2005DockPaneStrip.ImageColor=#222222
 
 ToolStripMenu.TitleBackColor=#CBC8C5
 ToolStripMenu.TitleBorderColor=#696463

--- a/FlashDevelop/Bin/Debug/Settings/Themes/Default.fdi
+++ b/FlashDevelop/Bin/Debug/Settings/Themes/Default.fdi
@@ -24,10 +24,18 @@ DockPanel.ShowAutoHideContentOn=Hover
 #ToolStripItem.ArrowColor=#ff0000
 #ToolStripItem.TextColor=#0000ff
 
+VS2005DockPaneCaption.ActiveForeColor=#333333
+VS2005DockPaneCaption.ActiveImageColor=#333333
+VS2005DockPaneCaption.ImageColor=#333333
 #VS2005DockPaneCaption.BorderColor=#ff0000
+
 #VS2005DockPaneStrip.DocTabActiveBorder=#ff0000
+VS2005DockPaneStrip.DocTabActiveForeColor=#000000
 #VS2005DockPaneStrip.DocTabInactiveBorder=#0000ff
+#VS2005DockPaneStrip.ToolActiveBorderColor=#ff0000
 #VS2005DockPaneStrip.ToolBorderColor=#ff0000
+VS2005DockPaneStrip.ToolActiveForeColor=#333333
+VS2005DockPaneStrip.ImageColor=#000000
 
 #ToolStripMenu.TitleBackColor=#ff00ff
 #ToolStripMenu.TitleBorderColor=#0000ff

--- a/FlashDevelop/Bin/Debug/Settings/Themes/DimGray.fdi
+++ b/FlashDevelop/Bin/Debug/Settings/Themes/DimGray.fdi
@@ -24,10 +24,18 @@ DockPanel.ShowAutoHideContentOn=Hover
 #ToolStripItem.ArrowColor=#ff0000
 #ToolStripItem.TextColor=#0000ff
 
+VS2005DockPaneCaption.ActiveForeColor=#EEEEEE
+VS2005DockPaneCaption.ActiveImageColor=#EEEEEE
+VS2005DockPaneCaption.ImageColor=#EEEEEE
 #VS2005DockPaneCaption.BorderColor=#ff0000
+
 #VS2005DockPaneStrip.DocTabActiveBorder=#ff0000
+VS2005DockPaneStrip.DocTabActiveForeColor=#222222
 #VS2005DockPaneStrip.DocTabInactiveBorder=#0000ff
+#VS2005DockPaneStrip.ToolActiveBorderColor=#ff0000
 #VS2005DockPaneStrip.ToolBorderColor=#ff0000
+VS2005DockPaneStrip.ToolActiveForeColor=#333333
+VS2005DockPaneStrip.ImageColor=#222222
 
 #ToolStripMenu.TitleBackColor=#ff00ff
 #ToolStripMenu.TitleBorderColor=#0000ff

--- a/FlashDevelop/Bin/Debug/Settings/Themes/Obsidian.fdi
+++ b/FlashDevelop/Bin/Debug/Settings/Themes/Obsidian.fdi
@@ -24,10 +24,18 @@ ToolStripSeparator.ForeColor=#889299
 ToolStripItem.ArrowColor=#3C4142
 ToolStripItem.TextColor=#3C4142
 
-VS2005DockPaneStrip.DocTabActiveBorder=#6D767C
-VS2005DockPaneStrip.DocTabInactiveBorder=#6D767C
-VS2005DockPaneStrip.ToolBorderColor=#6D767C
+VS2005DockPaneCaption.ActiveForeColor=#D1D1D1
+VS2005DockPaneCaption.ActiveImageColor=#D1D1D1
+VS2005DockPaneCaption.ImageColor=#D1D1D1
 VS2005DockPaneCaption.BorderColor=#6D767C
+
+VS2005DockPaneStrip.DocTabActiveBorder=#6D767C
+VS2005DockPaneStrip.DocTabActiveForeColor=#3A4345
+VS2005DockPaneStrip.DocTabInactiveBorder=#6D767C
+VS2005DockPaneStrip.ToolActiveBorderColor=#6D767C
+VS2005DockPaneStrip.ToolBorderColor=#6D767C
+VS2005DockPaneStrip.ToolActiveForeColor=#3A4345
+VS2005DockPaneStrip.ImageColor=#3A4345
 
 ToolStripMenu.TitleBackColor=#D2D5D3
 ToolStripMenu.TitleBorderColor=#75828A

--- a/FlashDevelop/Bin/Debug/Settings/Themes/Thyleus.fdi
+++ b/FlashDevelop/Bin/Debug/Settings/Themes/Thyleus.fdi
@@ -24,10 +24,18 @@ ToolStripSeparator.ForeColor=#9D9895
 ToolStripItem.ArrowColor=#474443
 ToolStripItem.TextColor=#363330
 
-VS2005DockPaneStrip.DocTabActiveBorder=#696463
-VS2005DockPaneStrip.DocTabInactiveBorder=#696463
-VS2005DockPaneStrip.ToolBorderColor=#696463
+VS2005DockPaneCaption.ActiveForeColor=#D1D1D1
+VS2005DockPaneCaption.ActiveImageColor=#D1D1D1
+VS2005DockPaneCaption.ImageColor=#D1D1D1
 VS2005DockPaneCaption.BorderColor=#696463
+
+VS2005DockPaneStrip.DocTabActiveBorder=#696463
+VS2005DockPaneStrip.DocTabActiveForeColor=#222222
+VS2005DockPaneStrip.DocTabInactiveBorder=#696463
+VS2005DockPaneStrip.ToolActiveBorderColor=#696463
+VS2005DockPaneStrip.ToolBorderColor=#696463
+VS2005DockPaneStrip.ToolActiveForeColor=#222222
+VS2005DockPaneStrip.ImageColor=#222222
 
 ToolStripMenu.TitleBackColor=#CBC8C5
 ToolStripMenu.TitleBorderColor=#696463

--- a/PluginCore/DockPanelSuite/Customization/DockPanelStripRenderer.cs
+++ b/PluginCore/DockPanelSuite/Customization/DockPanelStripRenderer.cs
@@ -465,7 +465,11 @@ namespace System.Windows.Forms
         {
             if (renderer is ToolStripProfessionalRenderer) 
             {
-                Color text = PluginBase.MainForm.GetThemeColor("ToolStripItem.TextColor");
+                Color text;
+                if (e.ToolStrip is StatusStrip)
+                    text = PluginBase.MainForm.GetThemeColor("StatusStrip.ForeColor");
+                else
+                    text = PluginBase.MainForm.GetThemeColor("ToolStripItem.TextColor");
                 if (text != Color.Empty) e.TextColor = text;
             }
             renderer.DrawItemText(e);

--- a/PluginCore/DockPanelSuite/Customization/VS2005DockPaneCaption.cs
+++ b/PluginCore/DockPanelSuite/Customization/VS2005DockPaneCaption.cs
@@ -41,9 +41,9 @@ namespace WeifenLuo.WinFormsUI.Docking
 
             protected override void OnRefreshChanges()
             {
-                if (DockPaneCaption.TextColor != ForeColor)
+                if (DockPaneCaption.ImageColor != ForeColor)
                 {
-                    ForeColor = DockPaneCaption.TextColor;
+                    ForeColor = DockPaneCaption.ImageColor;
                     Invalidate();
                 }
             }
@@ -348,11 +348,31 @@ namespace WeifenLuo.WinFormsUI.Docking
 
         private Color TextColor
         {
-            get 
+            get
             {
-                Color color = PluginCore.PluginBase.MainForm.GetThemeColor("VS2005DockPaneCaption.ForeColor");
+                Color color;
+                if (DockPane.IsActivated)
+                    color = PluginCore.PluginBase.MainForm.GetThemeColor("VS2005DockPaneCaption.ActiveForeColor");
+                else
+                    color = PluginCore.PluginBase.MainForm.GetThemeColor("VS2005DockPaneCaption.ForeColor");
+
                 if (color != Color.Empty) return color;
-                else return DockPane.IsActivated ? ActiveTextColor : InactiveTextColor; 
+                else return DockPane.IsActivated ? ActiveTextColor : InactiveTextColor;
+            }
+        }
+
+        private Color ImageColor
+        {
+            get
+            {
+                Color color;
+                if (DockPane.IsActivated)
+                    color = PluginCore.PluginBase.MainForm.GetThemeColor("VS2005DockPaneCaption.ActiveImageColor");
+                else
+                    color = PluginCore.PluginBase.MainForm.GetThemeColor("VS2005DockPaneCaption.ImageColor");
+
+                if (color != Color.Empty) return color;
+                else return DockPane.IsActivated ? ActiveTextColor : InactiveTextColor;
             }
         }
 

--- a/PluginCore/DockPanelSuite/Customization/VS2005DockPaneStrip.cs
+++ b/PluginCore/DockPanelSuite/Customization/VS2005DockPaneStrip.cs
@@ -85,9 +85,9 @@ namespace WeifenLuo.WinFormsUI.Docking
 
             protected override void OnRefreshChanges()
             {
-                if (VS2005DockPaneStrip.ColorDocumentActiveText != ForeColor)
+                if (VS2005DockPaneStrip.ImageColor != ForeColor)
                 {
-                    ForeColor = VS2005DockPaneStrip.ColorDocumentActiveText;
+                    ForeColor = VS2005DockPaneStrip.ImageColor;
                     Invalidate();
                 }
             }
@@ -422,7 +422,17 @@ namespace WeifenLuo.WinFormsUI.Docking
             get { return ScaleHelper.Scale(_DocumentTextGapRight); }
         }
 
-        private static Pen PenToolWindowTabBorder
+        private static Pen PenToolWindowTabActiveBorder
+        {
+            get
+            {
+                Color color = PluginCore.PluginBase.MainForm.GetThemeColor("VS2005DockPaneStrip.ToolActiveBorderColor");
+                if (color != Color.Empty) return new Pen(color);
+                else return SystemPens.ControlDark;
+            }
+        }
+
+        private static Pen PenToolWindowTabInactiveBorder
         {
             get 
             {
@@ -493,7 +503,7 @@ namespace WeifenLuo.WinFormsUI.Docking
         {
             get 
             {
-                Color color = PluginCore.PluginBase.MainForm.GetThemeColor("VS2005DockPaneStrip.ForeColor");
+                Color color = PluginCore.PluginBase.MainForm.GetThemeColor("VS2005DockPaneStrip.ToolActiveForeColor");
                 if (color != Color.Empty) return color;
                 else return SystemColors.ControlText; 
             }
@@ -503,7 +513,7 @@ namespace WeifenLuo.WinFormsUI.Docking
         {
             get 
             {
-                Color color = PluginCore.PluginBase.MainForm.GetThemeColor("VS2005DockPaneStrip.TabForeColor");
+                Color color = PluginCore.PluginBase.MainForm.GetThemeColor("VS2005DockPaneStrip.DocTabActiveForeColor");
                 if (color != Color.Empty) return color;
                 else return SystemColors.ControlText; 
             }
@@ -526,6 +536,16 @@ namespace WeifenLuo.WinFormsUI.Docking
                 Color color = PluginCore.PluginBase.MainForm.GetThemeColor("VS2005DockPaneStrip.TabForeColor");
                 if (color != Color.Empty) return color;
                 else return SystemColors.ControlText; 
+            }
+        }
+
+        private static Color ImageColor
+        {
+            get
+            {
+                Color color = PluginCore.PluginBase.MainForm.GetThemeColor("VS2005DockPaneStrip.ImageColor");
+                if (color != Color.Empty) return color;
+                else return SystemColors.ControlText;
             }
         }
 
@@ -1023,7 +1043,7 @@ namespace WeifenLuo.WinFormsUI.Docking
         {
             Rectangle rectTabStrip = TabStripRectangle;
 
-            g.DrawLine(PenToolWindowTabBorder, rectTabStrip.Left, rectTabStrip.Top,
+            g.DrawLine(PenToolWindowTabActiveBorder, rectTabStrip.Left, rectTabStrip.Top,
                 rectTabStrip.Right, rectTabStrip.Top);
 
             for (int i=0; i<Tabs.Count; i++)
@@ -1183,12 +1203,12 @@ namespace WeifenLuo.WinFormsUI.Docking
             if (DockPane.ActiveContent == tab.Content)
             {
                 g.FillPath(BrushToolWindowActiveBackground, path);
-                g.DrawPath(PenToolWindowTabBorder, path);
+                g.DrawPath(PenToolWindowTabActiveBorder, path);
 
                 // NICK: eliminate line between tab and content
-                RectangleF r = path.GetBounds();
-                using (Pen pen = new Pen(Color.FromArgb(240, 239, 243)))
-                    g.DrawLine(pen, r.Left + 1, r.Top, r.Right - 1, r.Top);
+                //RectangleF r = path.GetBounds();
+                //using (Pen pen = new Pen(BackColor))
+                //   g.DrawLine(pen, r.Left + 1, r.Top, r.Right - 1, r.Top);
 
                 TextRenderer.DrawText(g, tab.Content.DockHandler.TabText, Font, rectText, ColorToolWindowActiveText, ToolWindowTextFormat);
             }


### PR DESCRIPTION
Added more settings for differentiating between Active and Inactive tabs. Also, updated the included themes.

StatusStrip.ForeColor is respected

Added VS2005DockPaneCaption.ActiveForeColor
Added VS2005DockPaneCaption.ImageColor
Added VS2005DockPaneCaption.ActiveImageColor

Added VS2005DockPaneStrip.ToolActiveBorderColor
Added VS2005DockPaneStrip.ToolActiveForeColor
Added VS2005DockPaneStrip.DocTabActiveForeColor
Added VS2005DockPaneStrip.ImageColor

Put it all together and it makes for some nice themes.
![image](https://cloud.githubusercontent.com/assets/611219/6993087/f1e86eb2-dab6-11e4-85a3-df647613af17.png)
