### PR TITLE
Fix localization name of HighlightMatchingWordsDelay

### DIFF
--- a/PluginCore/PluginCore/Resources/de_DE.resX
+++ b/PluginCore/PluginCore/Resources/de_DE.resX
@@ -5900,7 +5900,7 @@ Eigene Sprachumgebungen müssen eine Erweiterung der Standard-Sprachumgebung sei
     <value>Disables the move refactoring of files and folders.</value>
     <comment>Added after 4.7.2</comment>
   </data>
-  <data name="HighlightMatchingWordsDelay" xml:space="preserve">
+  <data name="FlashDevelop.Description.HighlightMatchingWordsDelay" xml:space="preserve">
     <value>The delay in milliseconds after the word match highlight should be shown.</value>
     <comment>Added after 4.7.2</comment>
   </data>

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -5913,7 +5913,7 @@ Custom locales must be an extension of a default locale, e.g. en-US.</value>
     <value>Disables the move refactoring of files and folders.</value>
     <comment>Added after 4.7.2</comment>
   </data>
-  <data name="HighlightMatchingWordsDelay" xml:space="preserve">
+  <data name="FlashDevelop.Description.HighlightMatchingWordsDelay" xml:space="preserve">
     <value>The delay in milliseconds after the word match highlight should be shown.</value>
     <comment>Added after 4.7.2</comment>
   </data>

--- a/PluginCore/PluginCore/Resources/eu_ES.resX
+++ b/PluginCore/PluginCore/Resources/eu_ES.resX
@@ -5897,7 +5897,7 @@ Lokalizazio pertsonalizatuek lehenetsiaren luzapen bat izan behar dute, adb. en-
     <value>Disables the move refactoring of files and folders.</value>
     <comment>Added after 4.7.2</comment>
   </data>
-  <data name="HighlightMatchingWordsDelay" xml:space="preserve">
+  <data name="FlashDevelop.Description.HighlightMatchingWordsDelay" xml:space="preserve">
     <value>The delay in milliseconds after the word match highlight should be shown.</value>
     <comment>Added after 4.7.2</comment>
   </data>

--- a/PluginCore/PluginCore/Resources/ja_JP.resX
+++ b/PluginCore/PluginCore/Resources/ja_JP.resX
@@ -5962,7 +5962,7 @@ UseData:"</value>
     <value>Disables the move refactoring of files and folders.</value>
     <comment>Added after 4.7.2</comment>
   </data>
-  <data name="HighlightMatchingWordsDelay" xml:space="preserve">
+  <data name="FlashDevelop.Description.HighlightMatchingWordsDelay" xml:space="preserve">
     <value>The delay in milliseconds after the word match highlight should be shown.</value>
     <comment>Added after 4.7.2</comment>
   </data>

--- a/PluginCore/PluginCore/Resources/zh_CN.resx
+++ b/PluginCore/PluginCore/Resources/zh_CN.resx
@@ -5910,7 +5910,7 @@
     <value>Disables the move refactoring of files and folders.</value>
     <comment>Added after 4.7.2</comment>
   </data>
-  <data name="HighlightMatchingWordsDelay" xml:space="preserve">
+  <data name="FlashDevelop.Description.HighlightMatchingWordsDelay" xml:space="preserve">
     <value>The delay in milliseconds after the word match highlight should be shown.</value>
     <comment>Added after 4.7.2</comment>
   </data>


### PR DESCRIPTION
The description wouldn't show up / produce an error in the output panel.