### PR TITLE
Changed most uses of MainForm.OpenEditableDocument

### DIFF
--- a/External/Plugins/CodeRefactor/Commands/FindAllReferences.cs
+++ b/External/Plugins/CodeRefactor/Commands/FindAllReferences.cs
@@ -126,8 +126,8 @@ namespace CodeRefactor.Commands
                     if (fileEntries.Value.Count > 0 && System.IO.File.Exists(fileEntries.Key))
                     {
                         SearchMatch entry = fileEntries.Value[0];
-                        PluginBase.MainForm.OpenEditableDocument(fileEntries.Key, false);
-                        RefactoringHelper.SelectMatch(PluginBase.MainForm.CurrentDocument.SciControl, entry);
+                        var doc = (ITabbedDocument)PluginBase.MainForm.OpenEditableDocument(fileEntries.Key, false);
+                        RefactoringHelper.SelectMatch(doc.SciControl, entry);
                         break;
                     }
                 }
@@ -158,7 +158,7 @@ namespace CodeRefactor.Commands
                     // we have to open/reopen the entry's file
                     // there are issues with evaluating the declaration targets with non-open, non-current files
                     // we have to do it each time as the process of checking the declaration source can change the currently open file!
-                    ScintillaControl sci = this.AssociatedDocumentHelper.LoadDocument(currentFileName);
+                    ScintillaControl sci = this.AssociatedDocumentHelper.LoadDocument(currentFileName).SciControl;
                     // if the search result does point to the member source, store it
                     if (RefactoringHelper.DoesMatchPointToTarget(sci, match, target, this.AssociatedDocumentHelper))
                     {

--- a/External/Plugins/CodeRefactor/Commands/Move.cs
+++ b/External/Plugins/CodeRefactor/Commands/Move.cs
@@ -358,7 +358,7 @@ namespace CodeRefactor.Commands
                 oldType = oldType.Trim('.');
                 MessageBar.Locked = true;
                 string newFilePath = currentTarget.NewFilePath;
-                ScintillaControl sci = AssociatedDocumentHelper.LoadDocument(currentTarget.TmpFilePath ?? newFilePath);
+                ScintillaControl sci = AssociatedDocumentHelper.LoadDocument(currentTarget.TmpFilePath ?? newFilePath).SciControl;
                 List<SearchMatch> matches = search.Matches(sci.Text);
                 string packageReplacement = "package";
                 if (currentTarget.NewPackage != "")
@@ -514,14 +514,14 @@ namespace CodeRefactor.Commands
                     // we have to open/reopen the entry's file
                     // there are issues with evaluating the declaration targets with non-open, non-current files
                     // we have to do it each time as the process of checking the declaration source can change the currently open file!
-                    sci = AssociatedDocumentHelper.LoadDocument(file);
+                    sci = AssociatedDocumentHelper.LoadDocument(file).SciControl;
                     // if the search result does point to the member source, store it
                     if (RefactoringHelper.DoesMatchPointToTarget(sci, match, currentTargetResult, this.AssociatedDocumentHelper))
                         actualMatches.Add(match);
                 }
                 if (actualMatches.Count == 0) continue;
                 int currLine = -1;
-                sci = AssociatedDocumentHelper.LoadDocument(file);
+                sci = AssociatedDocumentHelper.LoadDocument(file).SciControl;
                 string directory = Path.GetDirectoryName(file);
                 // Let's check if we need to add the import. Check the considerations at the start of the file
                 // directory != currentTarget.OwnerPath -> renamed owner directory, so both files in the same place

--- a/External/Plugins/CodeRefactor/Commands/Move.cs
+++ b/External/Plugins/CodeRefactor/Commands/Move.cs
@@ -358,7 +358,8 @@ namespace CodeRefactor.Commands
                 oldType = oldType.Trim('.');
                 MessageBar.Locked = true;
                 string newFilePath = currentTarget.NewFilePath;
-                ScintillaControl sci = AssociatedDocumentHelper.LoadDocument(currentTarget.TmpFilePath ?? newFilePath).SciControl;
+                var doc = AssociatedDocumentHelper.LoadDocument(currentTarget.TmpFilePath ?? newFilePath);
+                ScintillaControl sci = doc.SciControl;
                 List<SearchMatch> matches = search.Matches(sci.Text);
                 string packageReplacement = "package";
                 if (currentTarget.NewPackage != "")
@@ -383,7 +384,7 @@ namespace CodeRefactor.Commands
                 }
                 //Do we want to open modified files?
                 //if (sci.IsModify) AssociatedDocumentHelper.MarkDocumentToKeep(file);
-                PluginBase.MainForm.CurrentDocument.Save();
+                doc.Save();
                 MessageBar.Locked = false;
                 UserInterfaceManager.ProgressDialog.Show();
                 UserInterfaceManager.ProgressDialog.SetTitle(TextHelper.GetString("Info.FindingReferences"));
@@ -507,6 +508,7 @@ namespace CodeRefactor.Commands
                     entry.Key == currentTarget.NewFilePath) continue;
                 string file = entry.Key;
                 UserInterfaceManager.ProgressDialog.UpdateStatusMessage(TextHelper.GetString("Info.Updating") + " \"" + file + "\"");
+                ITabbedDocument doc;
                 ScintillaControl sci;
                 var actualMatches = new List<SearchMatch>();
                 foreach (SearchMatch match in entry.Value)
@@ -521,7 +523,8 @@ namespace CodeRefactor.Commands
                 }
                 if (actualMatches.Count == 0) continue;
                 int currLine = -1;
-                sci = AssociatedDocumentHelper.LoadDocument(file).SciControl;
+                doc = AssociatedDocumentHelper.LoadDocument(file);
+                sci = doc.SciControl;
                 string directory = Path.GetDirectoryName(file);
                 // Let's check if we need to add the import. Check the considerations at the start of the file
                 // directory != currentTarget.OwnerPath -> renamed owner directory, so both files in the same place
@@ -579,7 +582,7 @@ namespace CodeRefactor.Commands
                 Results[file].AddRange(actualMatches);
                 //Do we want to open modified files?
                 //if (sci.IsModify) AssociatedDocumentHelper.MarkDocumentToKeep(file);
-                PluginBase.MainForm.CurrentDocument.Save();
+                doc.Save();
             }
 
             currentTargetIndex++;

--- a/External/Plugins/CodeRefactor/Commands/Rename.cs
+++ b/External/Plugins/CodeRefactor/Commands/Rename.cs
@@ -242,7 +242,7 @@ namespace CodeRefactor.Commands
             {
                 UserInterfaceManager.ProgressDialog.UpdateStatusMessage(TextHelper.GetString("Info.Updating") + " \"" + entry.Key + "\"");
                 // re-open the document and replace all the text
-                var sci = AssociatedDocumentHelper.LoadDocument(entry.Key);
+                var sci = AssociatedDocumentHelper.LoadDocument(entry.Key).SciControl;
                 // replace matches in the current file with the new name
                 RefactoringHelper.ReplaceMatches(entry.Value, sci, this.newName);
                 //Uncomment if we want to keep modified files

--- a/External/Plugins/CodeRefactor/Commands/Rename.cs
+++ b/External/Plugins/CodeRefactor/Commands/Rename.cs
@@ -242,12 +242,13 @@ namespace CodeRefactor.Commands
             {
                 UserInterfaceManager.ProgressDialog.UpdateStatusMessage(TextHelper.GetString("Info.Updating") + " \"" + entry.Key + "\"");
                 // re-open the document and replace all the text
-                var sci = AssociatedDocumentHelper.LoadDocument(entry.Key).SciControl;
+                var doc = AssociatedDocumentHelper.LoadDocument(entry.Key);
+                var sci = doc.SciControl;
                 // replace matches in the current file with the new name
                 RefactoringHelper.ReplaceMatches(entry.Value, sci, this.newName);
                 //Uncomment if we want to keep modified files
                 //if (sci.IsModify) AssociatedDocumentHelper.MarkDocumentToKeep(entry.Key);
-                PluginBase.MainForm.CurrentDocument.Save();
+                doc.Save();
             }
             if (newFileName != null) RenameFile(eventArgs.Results);
             this.Results = eventArgs.Results;

--- a/External/Plugins/CodeRefactor/Provider/DocumentHelper.cs
+++ b/External/Plugins/CodeRefactor/Provider/DocumentHelper.cs
@@ -130,11 +130,11 @@ namespace CodeRefactor.Provider
         /// If the document was not already previously opened, this will flag 
         /// it as a temporary file.
         /// </summary>
-        public ScintillaControl LoadDocument(String fileName)
+        public ITabbedDocument LoadDocument(String fileName)
         {
             ITabbedDocument newDocument = (ITabbedDocument)PluginBase.MainForm.OpenEditableDocument(fileName);
             this.RegisterLoadedDocument(newDocument);
-            return ASContext.CurSciControl;
+            return newDocument;
         }
 
         /// <summary>

--- a/External/Plugins/CodeRefactor/Provider/RefactoringHelper.cs
+++ b/External/Plugins/CodeRefactor/Provider/RefactoringHelper.cs
@@ -107,7 +107,8 @@ namespace CodeRefactor.Provider
         {
             String fileName = Path.GetFileNameWithoutExtension(path);
             Int32 line = 0;
-            ScintillaControl sci = associatedDocumentHelper.LoadDocument(path);
+            var doc = associatedDocumentHelper.LoadDocument(path);
+            ScintillaControl sci = doc != null ? doc.SciControl : null;
             if (sci == null) return null; // Should not happen...
             List<ClassModel> classes = ASContext.Context.CurrentModel.Classes;
             if (classes.Count > 0)

--- a/External/Plugins/FlashDebugger/Helpers/ScintillaHelper.cs
+++ b/External/Plugins/FlashDebugger/Helpers/ScintillaHelper.cs
@@ -332,9 +332,9 @@ namespace FlashDebugger
 
         static public ScintillaControl ActivateDocument(string filefullpath, int line, Boolean bSelectLine)
         {
-            PluginBase.MainForm.OpenEditableDocument(filefullpath, false);
-            if (PluginBase.MainForm.CurrentDocument.FileName != filefullpath) return null;
-            ScintillaControl sci = PluginBase.MainForm.CurrentDocument.SciControl;
+            var doc = PluginBase.MainForm.OpenEditableDocument(filefullpath, false) as ITabbedDocument;
+            if (doc == null || doc.FileName != filefullpath) return null;
+            ScintillaControl sci = doc.SciControl;
             if (line >= 0)
             {
                 sci.EnsureVisible(line);

--- a/FlashDevelop/Dialogs/FRInFilesDialog.cs
+++ b/FlashDevelop/Dialogs/FRInFilesDialog.cs
@@ -631,10 +631,10 @@ namespace FlashDevelop.Dialogs
             if (File.Exists(data.Key))
             {
                 Globals.MainForm.Activate();
-                Globals.MainForm.OpenEditableDocument(data.Key, false);
-                if (Globals.CurrentDocument.IsEditable)
+                var doc = Globals.MainForm.OpenEditableDocument(data.Key, false) as ITabbedDocument;
+                if (doc != null && doc.IsEditable)
                 {
-                    ScintillaControl sci = Globals.CurrentDocument.SciControl;
+                    ScintillaControl sci = doc.SciControl;
                     if (this.resultsView.Columns.Count == 4)
                     {
                         Int32 column = sci.MBSafeTextLength(data.Value.LineText.Substring(0, data.Value.Column));


### PR DESCRIPTION
Instead use the returned ITabbedDocument.

Under some rare circumstances (I guess only on some multithreading scenarios?) the MainForm.CurrentDocument was not immediately updated to reflect the newly opened document. When this happened it caused the refactoring commands to lose some of the changes made to files, finding references to lose some results, the debugger to not open files when expected on errors or breakpoints...