### PR TITLE
Better string parsing. Fixes Issue #444

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -1297,11 +1297,11 @@ namespace ASCompletion.Completion
             // measure highlighting
             int start = calltipDef.IndexOf('(');
             while ((start >= 0) && (paramIndex-- > 0))
-                start = FindNearSymbolInFunctDef(calltipDef, ",", start + 1);
+                start = FindNearSymbolInFunctDef(calltipDef, ',', start + 1);
 
-            int end = FindNearSymbolInFunctDef(calltipDef, ",", start + 1);
+            int end = FindNearSymbolInFunctDef(calltipDef, ',', start + 1);
             if (end < 0)
-                end = FindNearSymbolInFunctDef(calltipDef, ")", start + 1);
+                end = FindNearSymbolInFunctDef(calltipDef, ')', start + 1);
 
             // get parameter name
             string paramName = "";
@@ -1344,7 +1344,7 @@ namespace ASCompletion.Completion
             else UITools.CallTip.CallTipSetHlt(start + 1, end, true);
         }
 
-        static private int FindNearSymbolInFunctDef(string defBody, string symbol, int startAt)
+        static private int FindNearSymbolInFunctDef(string defBody, char symbol, int startAt)
         {
             string featEnd = null;
 
@@ -1382,18 +1382,8 @@ namespace ASCompletion.Completion
                             featEnd = "\"";
                             break;
                         default:
-                            int ci = i;
-                            int j;
-                            int sl = symbol.Length;
-                            for (j = 0; j < sl && ci < count; j++)
-                            {
-                                if (defBody[ci++] != symbol[j])
-                                    break;
-                            }
-
-                            if (j == sl)
+                            if (c == symbol)
                                 return i;
-
                             break;
                     }
                 }

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -1401,9 +1401,14 @@ namespace ASCompletion.Completion
                 {
                     if (featEnd == "\"" || featEnd == "'")
                     {
-                        if (defBody[i - 1] == '\\')
-                            continue;
+                        // Are we on an escaped ' or ""?
+                        int escNo = 0;
+                        int l = i - 1;
+                        while (l > -1 && defBody[l--] == '\\')
+                            escNo++;
 
+                        if (escNo % 2 != 0)
+                            continue;
                     }
                     else
                     {

--- a/External/Plugins/ASCompletion/Model/ASFileParser.cs
+++ b/External/Plugins/ASCompletion/Model/ASFileParser.cs
@@ -698,12 +698,21 @@ namespace ASCompletion.Model
                                 }
                             }
                         }
-                        // end of string
+                        // end of string?
                         else if (isInString)
                         {
                             if (c1 == 10 || c1 == 13) { if (!haXe) inString = 0; }
-                            else if (c1 == '"') { if (inString == 1 && ba[i - 2] != '\\') inString = 0; }
-                            else if (c1 == '\'') { if (inString == 2 && ba[i - 2] != '\\') inString = 0; }
+                            else if ((c1 == '"' && inString == 1) || (c1 == '\'' && inString == 2))
+                            {
+                                // Are we on an escaped ' or ""?
+                                int escNo = 0;
+                                int l = i - 2;
+                                while (l > -1 && ba[l--] == '\\')
+                                    escNo++;
+
+                                // Even number of escaped \ means we are not on an escaped ' or ""
+                                if (escNo % 2 == 0) inString = 0;
+                            }
 
                             // extract "include" declarations
                             if (inString == 0 && length == 7 && context == 0)

--- a/External/Plugins/ASCompletion/Model/ASFileParser.cs
+++ b/External/Plugins/ASCompletion/Model/ASFileParser.cs
@@ -701,10 +701,9 @@ namespace ASCompletion.Model
                         // end of string
                         else if (isInString)
                         {
-                            if (c1 == '\\') { i++; continue; }
-                            else if (c1 == 10 || c1 == 13) inString = 0;
-                            else if ((inString == 1) && (c1 == '"')) inString = 0;
-                            else if ((inString == 2) && (c1 == '\'')) inString = 0;
+                            if (c1 == 10 || c1 == 13) { if (!haXe) inString = 0; }
+                            else if (c1 == '"') { if (inString == 1 && ba[i - 2] != '\\') inString = 0; }
+                            else if (c1 == '\'') { if (inString == 2 && ba[i - 2] != '\\') inString = 0; }
 
                             // extract "include" declarations
                             if (inString == 0 && length == 7 && context == 0)

--- a/External/Plugins/ASCompletion/PluginMain.cs
+++ b/External/Plugins/ASCompletion/PluginMain.cs
@@ -906,7 +906,8 @@ namespace ASCompletion
             if (ASComplete.HasCalltip())
             {
                 int pos = sci.CurrentPos - 1;
-                if (sci.CharAt(pos) == ',' && sci.BaseStyleAt(pos) == 0)
+                char c = (char)sci.CharAt(pos);
+                if ((c == ',' || c == '(') && sci.BaseStyleAt(pos) == 0)
                     sci.Colourise(0, -1);
                 ASComplete.HandleFunctionCompletion(sci, false, true);
             }

--- a/External/Plugins/ASCompletion/PluginMain.cs
+++ b/External/Plugins/ASCompletion/PluginMain.cs
@@ -904,7 +904,12 @@ namespace ASCompletion
         private void OnUpdateCallTip(ScintillaNet.ScintillaControl sci, int position)
         {
             if (ASComplete.HasCalltip())
+            {
+                int pos = sci.CurrentPos - 1;
+                if (sci.CharAt(pos) == ',' && sci.BaseStyleAt(pos) == 0)
+                    sci.Colourise(0, -1);
                 ASComplete.HandleFunctionCompletion(sci, false, true);
+            }
         }
 
         private void OnUpdateSimpleTip(ScintillaNet.ScintillaControl sci, Point mousePosition)


### PR DESCRIPTION
Do not skip \ and the next character when parsing strings. All IDEs I've tried leave them in hints, and when there are escaped Unicode or ASCII characters it results in strange output. Also, skipping it could result in other wrong results, for example some bad formed include statement.

ASComplete.FindNearSymbolInFunctDef has been rewritten to better detect parameters. The new function is larger, but is faster, more inline with file parsing, and I find it to be easier to get what the function actually does than the previous one, but the latter may be just something subjective. Are ({[ really possible? I left them, but sincerely, I don't know when they can appear (aside from trying to use objects and arrays in default values, which is wrong).

This adds multi line string support in Haxe in the native parser as well. Having multiline strings as default value to optional arguments could result in several issues, for example incomplete models and some completion issues. It also fixes some completion issues inside functions if there are multiline strings.

Last, this fixes pressing , inside a string as a parameter of a function when the call tip is visible.

BTW, some FB versions also hint parameters incorrectly if there are commas inside a string used as the default value.

EDIT: Forgot to comment that pressing , inside a string with the call tip visible does not work with Haxe if we are inside some secondary line in a multiline string. But this is because Scintilla styling fails as you know.