### PR TITLE
Improved regex handling.

### DIFF
--- a/External/Plugins/ASCompletion/Model/ASFileParser.cs
+++ b/External/Plugins/ASCompletion/Model/ASFileParser.cs
@@ -927,7 +927,7 @@ namespace ASCompletion.Model
                 {
                     if (c1 == '/')
                     {
-                        LookupRegex(ref ba, ref i);
+                        LookupRegex(ba, ref i);
                     }
                     else if (c1 == '}')
                     {
@@ -1013,7 +1013,7 @@ namespace ASCompletion.Model
                     else if (c1 == '/')
                     {
                         int i0 = i;
-                        if (LookupRegex(ref ba, ref i) && valueLength < VALUE_BUFFER - 3)
+                        if (LookupRegex(ba, ref i) && valueLength < VALUE_BUFFER - 3)
                         {
                             valueBuffer[valueLength++] = '/';
                             for (; i0 < i; i0++)
@@ -1611,7 +1611,7 @@ namespace ASCompletion.Model
                         // literal regex
                         else if (c1 == '/' && version == 3)
                         {
-                            if (LookupRegex(ref ba, ref i))
+                            if (LookupRegex(ba, ref i))
                                 continue;
                         }
                 }
@@ -1640,16 +1640,26 @@ namespace ASCompletion.Model
             //  Debug.WriteLine("out model: " + model.GenerateIntrinsic(false));
         }
 
-        private bool LookupRegex(ref string ba, ref int i)
+        private bool LookupRegex(string ba, ref int i)
         {
             int len = ba.Length;
-            int i0 = i - 2;
+            int i0;
             char c;
             // regex in valid context
+
+            if (!haXe)
+                i0 = i - 2;
+            else
+            {
+                if (ba[i - 2] != '~')
+                    return false;
+                i0 = i - 3;
+            }
+
             while (i0 > 0)
             {
                 c = ba[i0--];
-                if ("=(,[{;".IndexOf(c) >= 0) break; // ok
+                if ("=(,[{;:".IndexOf(c) >= 0) break; // ok
                 if (" \t".IndexOf(c) >= 0) continue;
                 return false; // anything else isn't expected before a regex
             }

--- a/External/Plugins/ASCompletion/Model/ASFileParser.cs
+++ b/External/Plugins/ASCompletion/Model/ASFileParser.cs
@@ -1671,6 +1671,15 @@ namespace ASCompletion.Model
                 if (c == '/') break; // end of regex
                 if ("\r\n".IndexOf(c) >= 0) return false;
             }
+            while (i0 < len)
+            {
+                c = ba[i0++];
+                if (!char.IsLetter(c))
+                {
+                    i--;
+                    break;
+                }
+            }
             i = i0; // ok, skip this regex
             return true;
         }

--- a/External/Plugins/BookmarkPanel/PluginUI.cs
+++ b/External/Plugins/BookmarkPanel/PluginUI.cs
@@ -405,6 +405,7 @@ namespace BookmarkPanel
                 search.NoCase = true;
                 search.IsRegex = true;
                 search.Filter = SearchFilter.None;
+                search.SourceFile = sci.FileName;
                 return search.Matches(sci.Text);
             }
             return null;

--- a/External/Plugins/CodeRefactor/Commands/Move.cs
+++ b/External/Plugins/CodeRefactor/Commands/Move.cs
@@ -360,6 +360,7 @@ namespace CodeRefactor.Commands
                 string newFilePath = currentTarget.NewFilePath;
                 var doc = AssociatedDocumentHelper.LoadDocument(currentTarget.TmpFilePath ?? newFilePath);
                 ScintillaControl sci = doc.SciControl;
+                search.SourceFile = sci.FileName;
                 List<SearchMatch> matches = search.Matches(sci.Text);
                 string packageReplacement = "package";
                 if (currentTarget.NewPackage != "")

--- a/External/Plugins/CodeRefactor/Commands/OrganizeImports.cs
+++ b/External/Plugins/CodeRefactor/Commands/OrganizeImports.cs
@@ -152,7 +152,7 @@ namespace CodeRefactor.Commands
             imports.Sort(comparerType);
             sci.GotoLine(line);
             Int32 curLine = 0;
-            List<String> uniques = this.GetUniqueImports(imports, searchInText);
+            List<String> uniques = this.GetUniqueImports(imports, searchInText, sci.FileName);
             // correct position compensation for private imports
             DeletedImportsCompensation = imports.Count - uniques.Count;
             String prevPackage = null;
@@ -181,12 +181,12 @@ namespace CodeRefactor.Commands
         /// <summary>
         /// Gets the unique string list of imports
         /// </summary>
-        private List<String> GetUniqueImports(List<MemberModel> imports, String searchInText)
+        private List<String> GetUniqueImports(List<MemberModel> imports, String searchInText, String sourceFile)
         {
             List<String> results = new List<String>();
             foreach (MemberModel import in imports)
             {
-                if (!results.Contains(import.Type) && MemberTypeImported(import.Name, searchInText))
+                if (!results.Contains(import.Type) && MemberTypeImported(import.Name, searchInText, sourceFile))
                 {
                     results.Add(import.Type);
                 }
@@ -197,13 +197,14 @@ namespace CodeRefactor.Commands
         /// <summary>
         /// Checks if the member type is imported
         /// </summary>
-        private Boolean MemberTypeImported(String type, String searchInText)
+        private Boolean MemberTypeImported(String type, String searchInText, String sourceFile)
         {
             if (type == "*") return true;
             FRSearch search = new FRSearch(type);
             search.Filter = SearchFilter.OutsideCodeComments | SearchFilter.OutsideStringLiterals;
             search.NoCase = false;
             search.WholeWord = true;
+            search.SourceFile = sourceFile;
             return search.Match(searchInText) != null;
         }
 

--- a/FlashDevelop/Controls/QuickFind.cs
+++ b/FlashDevelop/Controls/QuickFind.cs
@@ -581,6 +581,7 @@ namespace FlashDevelop.Controls
             search.Filter = SearchFilter.None;
             search.NoCase = !this.matchCaseCheckBox.Checked;
             search.WholeWord = this.wholeWordCheckBox.Checked;
+            search.SourceFile = sci.FileName;
             return search.Matches(sci.Text);
         }
 

--- a/FlashDevelop/Dialogs/FRInDocDialog.cs
+++ b/FlashDevelop/Dialogs/FRInDocDialog.cs
@@ -660,6 +660,7 @@ namespace FlashDevelop.Dialogs
                 FRSearch search = new FRSearch(pattern);
                 search.NoCase = !this.matchCaseCheckBox.Checked;
                 search.Filter = SearchFilter.None;
+                search.SourceFile = sci.FileName;
                 if (!simple)
                 {
                     search.IsRegex = this.useRegexCheckBox.Checked;

--- a/PluginCore/PluginCore/FRService/FRRunner.cs
+++ b/PluginCore/PluginCore/FRService/FRRunner.cs
@@ -61,6 +61,7 @@ namespace PluginCore.FRService
                 foreach (String file in files)
                 {
                     String src = configuration.GetSource(file);
+                    search.SourceFile = file;
                     List<SearchMatch> matches = search.Matches(src);
                     FRSearch.ExtractResultsLineText(matches, src);
                     results[file] = matches;
@@ -94,6 +95,7 @@ namespace PluginCore.FRService
                 foreach (String file in files)
                 {
                     src = configuration.GetSource(file);
+                    search.SourceFile = file;
                     results[file] = matches = search.Matches(src);
                     foreach (SearchMatch match in matches)
                     {
@@ -237,6 +239,7 @@ namespace PluginCore.FRService
                         {
                             // work
                             src = configuration.GetSource(file);
+                            search.SourceFile = file;
                             results[file] = matches = search.Matches(src);
 
                             if (matches.Count > 0)

--- a/PluginCore/PluginCore/FRService/FRSearch.cs
+++ b/PluginCore/PluginCore/FRService/FRSearch.cs
@@ -379,7 +379,7 @@ namespace PluginCore.FRService
                 isHaxeFile = Helpers.FileInspector.IsHaxeFile(SourceFile, ext);
 
                 // Haxe, ActionScript, JavaScript and LoomScript support Regex literals
-                hasRegexLiterals = Helpers.FileInspector.IsActionScript(SourceFile, ext) || isHaxeFile ||
+                hasRegexLiterals = isHaxeFile || Helpers.FileInspector.IsActionScript(SourceFile, ext) ||
                                    Helpers.FileInspector.IsMxml(SourceFile, ext) ||
                                    Helpers.FileInspector.IsHtml(SourceFile, ext) || ext == ".js" || ext == ".ls" ||
                                    ext == ".ts";

--- a/PluginCore/PluginCore/FRService/FRSearch.cs
+++ b/PluginCore/PluginCore/FRService/FRSearch.cs
@@ -355,7 +355,36 @@ namespace PluginCore.FRService
             }
         }
 
-        public string SourceFile { get; set; }
+        private bool hasRegexLiterals;
+        private bool isHaxeFile;
+        private string sourceFile;
+        public string SourceFile
+        {
+            get { return sourceFile; } 
+            set
+            {
+                if (sourceFile == value) return;
+                
+                sourceFile = value;
+
+                if (sourceFile == null)
+                {
+                    hasRegexLiterals = false;
+                    isHaxeFile = false;
+                    return;
+                }
+
+                string ext = System.IO.Path.GetExtension(SourceFile).ToLowerInvariant();
+
+                isHaxeFile = Helpers.FileInspector.IsHaxeFile(SourceFile, ext);
+
+                // Haxe, ActionScript, JavaScript and LoomScript support Regex literals
+                hasRegexLiterals = Helpers.FileInspector.IsActionScript(SourceFile, ext) || isHaxeFile ||
+                                   Helpers.FileInspector.IsMxml(SourceFile, ext) ||
+                                   Helpers.FileInspector.IsHtml(SourceFile, ext) || ext == ".js" || ext == ".ls" ||
+                                   ext == ".ts";
+            }
+        }
 
         #endregion
 
@@ -614,15 +643,7 @@ namespace PluginCore.FRService
 
         private bool LookupRegex(string ba, ref int i)
         {
-            if (SourceFile == null)
-                return false;
-
-            string ext = System.IO.Path.GetExtension(SourceFile).ToLowerInvariant();
-
-            // Haxe, ActionScript, and JavaScript support Regex literals
-            if (!Helpers.FileInspector.IsActionScript(SourceFile, ext) &&
-                !Helpers.FileInspector.IsHaxeFile(SourceFile, ext) && !Helpers.FileInspector.IsMxml(SourceFile, ext) &&
-                !Helpers.FileInspector.IsHtml(SourceFile, ext) && ext != ".js")
+            if (!hasRegexLiterals)
                 return false;
 
             int len = ba.Length;
@@ -630,7 +651,7 @@ namespace PluginCore.FRService
             char c;
             // regex in valid context
 
-            if (!Helpers.FileInspector.IsHaxeFile(SourceFile, ext))
+            if (!isHaxeFile)
                 i0 = i - 2;
             else
             {

--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -5423,6 +5423,7 @@ namespace ScintillaNet
             search.WholeWord = true; 
             search.NoCase = true;
             search.Filter = SearchFilter.OutsideCodeComments | SearchFilter.OutsideStringLiterals;
+            search.SourceFile = FileName;
             RemoveHighlights(1);
             List<SearchMatch> test = search.Matches(Text);
             AddHighlights(1, test, color);


### PR DESCRIPTION
  - Parse Haxe regex literals correctly.
  - Take into account regex literals can follow an object literal property.
  - Take into account regexes in FRSearch.

It could cause some (minor) completion issues but more importantly, it's responsible for this:

https://twitter.com/_bigp/status/594314905878134786

EDIT: Surely regex parsing should take into account the possible flags as well.