### PR TITLE
Fixes: Find And Replace In Files *.hxp extension filter includes .hproj #694

### DIFF
--- a/PluginCore/PluginCore/Utilities/PathWalker.cs
+++ b/PluginCore/PluginCore/Utilities/PathWalker.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using PluginCore;
 using System.ComponentModel;
 using System.Windows.Forms;
+using System.Text.RegularExpressions;
 
 namespace PluginCore.Utilities
 {
@@ -19,6 +20,7 @@ namespace PluginCore.Utilities
         private Boolean recursive;
         private List<String> knownPathes;
         private List<String> foundFiles;
+        private Regex reUnsafeMask = new Regex("^\\*(\\.[a-z0-9]{3})$"); 
 
         public PathWalker(String basePath, String fileMask, Boolean recursive)
         {
@@ -98,7 +100,8 @@ namespace PluginCore.Utilities
             foreach (String mask in masks)
             {
                 String[] files = Directory.GetFiles(path, mask);
-                String control = mask.Length == 5 && mask[0] == '*' && mask[1] == '.' ? mask.Substring(1) : null;
+                String control = mask.Length == 5 ? getMaskControl(mask) : null;
+
                 foreach (String file in files)
                 {
                     //prevent too generous extension matching: *.hxp matching .hxproj
@@ -127,6 +130,13 @@ namespace PluginCore.Utilities
                 }
                 catch { /* Might be system folder.. */ };
             }
+        }
+
+        private string getMaskControl(string mask)
+        {
+            Match m = reUnsafeMask.Match(mask);
+            if (m.Success) return m.Groups[1].Value;
+            else return null;
         }
 
     }

--- a/PluginCore/PluginCore/Utilities/PathWalker.cs
+++ b/PluginCore/PluginCore/Utilities/PathWalker.cs
@@ -98,8 +98,13 @@ namespace PluginCore.Utilities
             foreach (String mask in masks)
             {
                 String[] files = Directory.GetFiles(path, mask);
+                String control = mask.Length == 5 && mask[0] == '*' && mask[1] == '.' ? mask.Substring(1) : null;
                 foreach (String file in files)
                 {
+                    //prevent too generous extension matching: *.hxp matching .hxproj
+                    if (control != null && Path.GetExtension(file).ToLower() != control) 
+                        continue;
+
                     //prevents the addition of the same file multiple times if it happens to match multiple masks
                     if (!this.foundFiles.Contains(file))
                     {


### PR DESCRIPTION
When extension mask is 3 chars (ie. not .as or .hx, but .hxp) it will match any extension of more characters (ie. .hxproj).

The fix adds a verification that the matched file extension really matches the mask.