### PR TITLE
ASFileParser#FinalizeModel(): check for invalid file name chars, closes #715

### DIFF
--- a/External/Plugins/ASCompletion/Model/ASFileParser.cs
+++ b/External/Plugins/ASCompletion/Model/ASFileParser.cs
@@ -1761,7 +1761,11 @@ namespace ASCompletion.Model
             if (model.PrivateSectionIndex == 0) model.PrivateSectionIndex = line;
             if (version == 2)
             {
-                string testPackage = Path.Combine(Path.GetDirectoryName(model.FileName), model.GetPublicClass().Name);
+                string className = model.GetPublicClass().Name;
+                if (className.IndexOfAny(Path.GetInvalidFileNameChars()) > 0)
+                    return;
+
+                string testPackage = Path.Combine(Path.GetDirectoryName(model.FileName), className);
                 if (Directory.Exists(testPackage)) model.TryAsPackage = true;
             }
         }


### PR DESCRIPTION
Not sure if this is the best solution (maybe `.dump` / non-`.hx` files should not be parsed in the first place?), but at least it gets rid of the exception for now.