### PR TITLE
Project Manager: add a "collapse all" button, closes #721

### DIFF
--- a/External/Plugins/AirProperties/PluginMain.cs
+++ b/External/Plugins/AirProperties/PluginMain.cs
@@ -198,7 +198,7 @@ namespace AirProperties
             this.pmMenuButton.DisplayStyle = ToolStripItemDisplayStyle.Image;
             this.pmMenuButton.Click += new EventHandler(this.OpenWizard);
             PluginBase.MainForm.RegisterSecondaryItem("ProjectMenu.AirApplicationProperties", this.pmMenuButton);
-            toolStrip.Items.Insert(5, this.pmMenuButton);
+            toolStrip.Items.Insert(6, this.pmMenuButton);
         }
 
         /// <summary>

--- a/External/Plugins/ProjectManager/Controls/Icons.cs
+++ b/External/Plugins/ProjectManager/Controls/Icons.cs
@@ -27,7 +27,7 @@ namespace ProjectManager.Controls
     }
 
     /// <summary>
-    /// Contains all icons used by the Project Explorer
+    /// Contains all icons used by the Project Manager
     /// </summary>
     public class Icons
     {
@@ -95,6 +95,7 @@ namespace ProjectManager.Controls
         public static FDImage LibrarypathFolder;
         public static FDImage DocumentClass;
         public static FDImage CommandPrompt;
+        public static FDImage CollapseAll;
 
         public static ImageList ImageList { get { return imageList; } }
 
@@ -112,9 +113,9 @@ namespace ProjectManager.Controls
             XmlFile = GetResource("Icons.XmlFile.png");
             MxmlFile = GetResource("Icons.MxmlFile.png");
             MxmlFileCompile = GetResource("Icons.MxmlFileCompile.png");
-            HiddenItems = GetGray("292");
-            HiddenFolder = GetGray("203");
-            HiddenFile = GetGray("526");
+            HiddenItems = GetGray(292);
+            HiddenFolder = GetGray(203);
+            HiddenFile = GetGray(526);
             BlankFile = Get(526);
             Project = Get(274);
             ProjectClasspath = Get(98);
@@ -166,6 +167,12 @@ namespace ProjectManager.Controls
             LibrarypathFolder = Get(208);
             DocumentClass = Get(147);
             CommandPrompt = Get(57);
+            CollapseAll = GetGray(166);
+        }
+
+        public static FDImage GetGray(int fdIndex)
+        {
+            return GetGray(fdIndex.ToString());
         }
 
         public static FDImage GetGray(string data)

--- a/External/Plugins/ProjectManager/Controls/TreeBar.cs
+++ b/External/Plugins/ProjectManager/Controls/TreeBar.cs
@@ -19,6 +19,7 @@ namespace ProjectManager.Controls
         public ToolStripButton ProjectTypes;
         public ToolStripButton Synchronize;
         public ToolStripButton SynchronizeMain;
+        public ToolStripButton CollapseAll;
         public ToolStripSeparator Separator;
 
         private ProjectContextMenu treeMenu;
@@ -57,6 +58,10 @@ namespace ProjectManager.Controls
             SynchronizeMain.ToolTipText = TextHelper.GetString("ToolTip.SynchronizeMain");
             SynchronizeMain.Padding = new Padding(0);
 
+            CollapseAll = new ToolStripButton(Icons.CollapseAll.Img);
+            CollapseAll.ToolTipText = TextHelper.GetString("FlashDevelop.Label.CollapseAll");
+            CollapseAll.Padding = new Padding(0);
+
             ProjectTypes = new ToolStripButton(Icons.AllClasses.Img);
             ProjectTypes.ToolTipText = TextHelper.GetString("ToolTip.ProjectTypes");
             ProjectTypes.Alignment = ToolStripItemAlignment.Right;
@@ -70,6 +75,7 @@ namespace ProjectManager.Controls
             Items.Add(Synchronize);
             Items.Add(SynchronizeMain);
             Items.Add(RefreshSelected);
+            Items.Add(CollapseAll);
             Items.Add(Separator);
             Items.Add(ProjectProperties);
             Items.Add(ProjectTypes);

--- a/External/Plugins/ProjectManager/PluginMain.cs
+++ b/External/Plugins/ProjectManager/PluginMain.cs
@@ -239,6 +239,7 @@ namespace ProjectManager
             pluginUI.TreeBar.ShowHidden.Click += delegate { ToggleShowHidden(); };
             pluginUI.TreeBar.Synchronize.Click += delegate { ToggleTrackActiveDocument(); };
             pluginUI.TreeBar.SynchronizeMain.Click += delegate { TreeSyncToMainFile(); };
+            pluginUI.TreeBar.CollapseAll.Click += delegate { CollapseAll(); };
             pluginUI.TreeBar.ProjectProperties.Click += delegate { OpenProjectProperties(); };
             pluginUI.TreeBar.RefreshSelected.Click += delegate { TreeRefreshSelectedNode(); };
             pluginUI.TreeBar.ProjectTypes.Click += delegate 
@@ -1595,6 +1596,17 @@ namespace ProjectManager
             {
                 Tree.Select(activeProject.GetAbsolutePath(activeProject.CompileTargets[0]));
                 Tree.SelectedNode.EnsureVisible();
+            }
+        }
+
+        private void CollapseAll()
+        {
+            foreach (TreeNode rootNode in Tree.Nodes)
+            {
+                foreach (TreeNode node in rootNode.Nodes)
+                {
+                    node.Collapse(false);
+                }
             }
         }
 


### PR DESCRIPTION
![](http://i.imgur.com/MCIYXhE.png)

Not 100% sure how this should behave when "track active document" is enabled. Currently it just collapses all nodes except root / project nodes and track active document is applied again when switching documents.
It might seem weird if clicking the "collapse all" button doesn't close the source node, which would be the case if track active document was applied after collapse all.