### PR TITLE
ProjectManager: apply some sorting to references, #704

### DIFF
--- a/External/Plugins/ProjectManager/Controls/TreeView/OtherNodes.cs
+++ b/External/Plugins/ProjectManager/Controls/TreeView/OtherNodes.cs
@@ -217,9 +217,11 @@ namespace ProjectManager.Controls.TreeView
                 projectClasspaths.AddRange(project.Classpaths);
                 if (project.AdditionalPaths != null) projectClasspaths.AddRange(project.AdditionalPaths);
             }
+            projectClasspaths.Sort();
 
             if (PluginMain.Settings.ShowGlobalClasspaths)
                 globalClasspaths.AddRange(PluginMain.Settings.GlobalClasspaths);
+            globalClasspaths.Sort();
 
             // create references nodes
             ClasspathNode cpNode;


### PR DESCRIPTION
Doesn't solve the original issue from #704 but at least the order of haxelibs is alphabetical now:

![](http://i.imgur.com/WcZkUJU.png)

(compared to)

![](https://camo.githubusercontent.com/f4c9ba7f74e9b9385296ce42e7b6caaa2fde98df/687474703a2f2f692e696d6775722e636f6d2f396c35786a43442e706e67)