### PR TITLE
Scale the Splitter size based on DPI

### DIFF
--- a/FlashDevelop/Docking/TabbedDocument.cs
+++ b/FlashDevelop/Docking/TabbedDocument.cs
@@ -294,6 +294,7 @@ namespace FlashDevelop.Docking
             this.editor2.Dock = DockStyle.Fill;
             this.splitContainer = new SplitContainer();
             this.splitContainer.Name = "fdSplitView";
+            this.splitContainer.SplitterWidth = ScaleHelper.Scale(this.splitContainer.SplitterWidth);
             this.splitContainer.Orientation = Orientation.Horizontal;
             this.splitContainer.BackColor = SystemColors.Control;
             this.splitContainer.Panel1.Controls.Add(this.editor);


### PR DESCRIPTION
When editing in split mode the splitter size was not being scaled based on DPI.