### PR TITLE
Changed scintilla marker images from using XPM to RGBA.

### DIFF
--- a/External/Plugins/FlashDebugger/Helpers/ScintillaHelper.cs
+++ b/External/Plugins/FlashDebugger/Helpers/ScintillaHelper.cs
@@ -50,9 +50,9 @@ namespace FlashDebugger
             var enabledImage = ScaleHelper.Scale(Properties.Resource.Enabled);
             var disabledImage = ScaleHelper.Scale(Properties.Resource.Disabled);
             var curlineImage = ScaleHelper.Scale(Properties.Resource.CurLine);
-            sci.MarkerDefinePixmap(markerBPEnabled, ScintillaNet.XPM.ConvertToXPM(enabledImage, "#00FF00"));
-            sci.MarkerDefinePixmap(markerBPDisabled, ScintillaNet.XPM.ConvertToXPM(disabledImage, "#00FF00"));
-            sci.MarkerDefinePixmap(markerCurrentLine, ScintillaNet.XPM.ConvertToXPM(curlineImage, "#00FF00"));
+            sci.MarkerDefineRGBAImage(markerBPEnabled, enabledImage);
+            sci.MarkerDefineRGBAImage(markerBPDisabled, disabledImage);
+            sci.MarkerDefineRGBAImage(markerCurrentLine, curlineImage);
             Language lang = PluginBase.MainForm.SciConfig.GetLanguage("as3"); // default
             sci.MarkerSetBack(markerBPEnabled, lang.editorstyle.ErrorLineBack); // enable
             sci.MarkerSetBack(markerBPDisabled, lang.editorstyle.DisabledLineBack); // disable

--- a/FlashDevelop/Managers/ScintillaManager.cs
+++ b/FlashDevelop/Managers/ScintillaManager.cs
@@ -23,12 +23,11 @@ namespace FlashDevelop.Managers
     {
         public static Scintilla SciConfig;
         public static ConfigurationUtility SciConfigUtil;
-        public static System.String XpmBookmark;
+        public static Bitmap Bookmark;
 
         static ScintillaManager()
         {
-            Bitmap bookmark = ScaleHelper.Scale(new Bitmap(ResourceHelper.GetStream("BookmarkIcon.png")));
-            XpmBookmark = ScintillaNet.XPM.ConvertToXPM(bookmark, "#00FF00");
+            Bookmark = ScaleHelper.Scale(new Bitmap(ResourceHelper.GetStream("BookmarkIcon.png")));
             LoadConfiguration();
         }
 
@@ -230,7 +229,7 @@ namespace FlashDevelop.Managers
                     if (colorizeMarkerBack) sci.SetMarginTypeN(0, (Int32)ScintillaNet.Enums.MarginType.Fore);
                     else sci.SetMarginTypeN(0, (Int32)ScintillaNet.Enums.MarginType.Symbol);
                 }
-                /** 
+                /**
                 * Set correct line number margin width
                 */
                 Boolean viewLineNumbers = Globals.Settings.ViewLineNumbers;
@@ -298,7 +297,7 @@ namespace FlashDevelop.Managers
         }
 
         /// <summary>
-        /// Creates a new editor control for the document 
+        /// Creates a new editor control for the document
         /// </summary>
         public static ScintillaControl CreateControl(String file, String text, Int32 codepage)
         {
@@ -361,7 +360,7 @@ namespace FlashDevelop.Managers
             sci.SetMarginMaskN(2, -33554432 | 1 << 2);
             sci.MarginSensitiveN(2, true);
             sci.SetMultiSelectionTyping(true);
-            sci.MarkerDefinePixmap(0, XpmBookmark);
+            sci.MarkerDefineRGBAImage(0, Bookmark);
             sci.MarkerDefine(2, ScintillaNet.Enums.MarkerSymbol.Fullrect);
             sci.MarkerDefine((Int32)ScintillaNet.Enums.MarkerOutline.Folder, ScintillaNet.Enums.MarkerSymbol.BoxPlus);
             sci.MarkerDefine((Int32)ScintillaNet.Enums.MarkerOutline.FolderOpen, ScintillaNet.Enums.MarkerSymbol.BoxMinus);

--- a/PluginCore/PluginCore.csproj
+++ b/PluginCore/PluginCore.csproj
@@ -428,6 +428,7 @@
     <Compile Include="ScintillaNet\Lexers.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="ScintillaNet\RGBA.cs" />
     <Compile Include="ScintillaNet\RTF.cs" />
     <Compile Include="ScintillaNet\ScintillaControl.cs">
       <SubType>Component</SubType>

--- a/PluginCore/ScintillaNet/RGBA.cs
+++ b/PluginCore/ScintillaNet/RGBA.cs
@@ -1,0 +1,52 @@
+﻿using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace ScintillaNet
+{
+    public static class RGBA
+    {
+        /// <summary>
+        /// Converts Bitmap images to RGBA data.
+        /// </summary>
+        public static unsafe byte[] ConvertToRGBA(Bitmap image)
+        {
+            var rect = new Rectangle(0, 0, image.Width, image.Height);
+
+            // Get the bitmap into a 32bpp ARGB format (if it isn't already)
+            if (image.PixelFormat != PixelFormat.Format32bppArgb)
+            {
+                var clone = new Bitmap(image.Width, image.Height, PixelFormat.Format32bppArgb);
+                using (var graphics = Graphics.FromImage(clone))
+                    graphics.DrawImage(image, rect);
+
+                image = clone;
+            }
+
+            // Convert ARGB to RGBA
+            var bitmapData = image.LockBits(rect, ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+            var size = bitmapData.Stride * bitmapData.Height;
+            var bytes = new byte[size];
+            try
+            {
+                var source = (byte*)bitmapData.Scan0;
+                fixed (byte* destination = bytes)
+                {
+                    for (int offset = 0; offset < size; offset += 4)
+                    {
+                        // 4 bytes per pixel
+                        destination[offset] = source[offset + 2]; // R
+                        destination[offset + 1] = source[offset + 1]; // G
+                        destination[offset + 2] = source[offset]; // B
+                        destination[offset + 3] = source[offset + 3]; // A
+                    }
+                }
+            }
+            finally
+            {
+                image.UnlockBits(bitmapData);
+            }
+
+            return bytes;
+        }
+    }
+}

--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -3211,7 +3211,26 @@ namespace ScintillaNet
             {
                  SPerform(2049, (uint)markerNumber, (uint)b);
             }   
-        }           
+        }
+
+        /// <summary>
+        /// Define a marker image from a bitmap. Supports alpha channel.
+        /// </summary>
+        unsafe public void MarkerDefineRGBAImage(int markerNumber, Bitmap image)
+        {
+            var rgba = RGBA.ConvertToRGBA(image);
+
+            //SCI_RGBAIMAGESETWIDTH
+            SPerform(2624, (uint)image.Width, 0);
+            //SCI_RGBAIMAGESETHEIGHT
+            SPerform(2625, (uint)image.Height, 0);
+
+            fixed (byte* b = rgba)
+            {
+                //SCI_MARKERDEFINERGBAIMAGE
+                SPerform(2626, (uint)markerNumber, (uint)b);
+            }
+        }
 
         /// <summary>
         /// Reset the default style to its state at startup


### PR DESCRIPTION
Since RGBA supports an alpha channel marker images look better when scaled for high dpi.

- Added MarkerDefineRGBAImage method.
- Added RGBA static class for converting a Bitmap into a byte[].
- Updated the breakpoint, current line, and bookmark markers to use
  DefineRGBA method.