### PR TITLE
Metadata completion fixes, closes #765

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -170,8 +170,7 @@ namespace ASCompletion.Completion
                         break;
 
                     case ':':
-                        if (ASContext.Context.CurrentModel.haXe && 
-                            ASContext.Context.CurrentMember == null && prevValue == '@')
+                        if (ASContext.Context.CurrentModel.haXe && prevValue == '@')
                         {
                             return HandleMetadataCompletion(Sci, autoHide);
                         }

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -259,7 +259,7 @@ namespace HaXeContext
             String metaList = process.StandardOutput.ReadToEnd();
             process.Close();
 
-            Regex regex = new Regex("@:([a-zA-Z]*)(?: : )(.*?)(?= @:[a-zA-Z]* :)");
+            Regex regex = new Regex("@:([a-zA-Z]*)(?: : )(.*?)(?=( @:[a-zA-Z]* :|$))");
             metaList = Regex.Replace(metaList, "\\s+", " ");
 
             MatchCollection matches = regex.Matches(metaList);


### PR DESCRIPTION
Checking for `CurrentMember == null` was broken (see #765) and isn't a good approach to begin with, since metadata can be used inside of functions as well (`@:mergeBlock` for example).