### PR TITLE
ClassBrowser: fix imported types being included, closes #775

### DIFF
--- a/External/Plugins/ASClassWizard/Controls/TreeView/SimpleDirectoryNode.cs
+++ b/External/Plugins/ASClassWizard/Controls/TreeView/SimpleDirectoryNode.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.IO;
+﻿using System.IO;
 using System.Windows.Forms;
-using System.Diagnostics;
 
 namespace ASClassWizard.Controls.TreeView
 {

--- a/External/Plugins/ASClassWizard/PluginMain.cs
+++ b/External/Plugins/ASClassWizard/PluginMain.cs
@@ -1,34 +1,19 @@
-#region imports
-
 using System;
 using System.IO;
-using System.Drawing;
 using System.Windows.Forms;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Collections;
-
 using PluginCore.Localization;
 using PluginCore.Utilities;
 using PluginCore.Managers;
-using PluginCore.Helpers;
 using PluginCore;
-
 using ProjectManager.Projects;
-using ProjectManager.Projects.AS3;
-using ProjectManager.Projects.AS2;
-
 using ASCompletion.Model;
 using ASCompletion.Context;
-
 using ASClassWizard.Resources;
 using ASClassWizard.Wizards;
-
-using System.Text.RegularExpressions;
 using ASCompletion.Completion;
 using System.Collections.Generic;
-
-#endregion
 
 namespace ASClassWizard
 {
@@ -464,7 +449,5 @@ namespace ASClassWizard
         }
 
         #endregion
-
     }
-    
 }

--- a/External/Plugins/ASClassWizard/Resources/ASClassOptions.cs
+++ b/External/Plugins/ASClassWizard/Resources/ASClassOptions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.IO;
-using System.Diagnostics;
+﻿using System.Collections.Generic;
 
 namespace ASClassWizard.Resources
 {
@@ -38,7 +34,6 @@ namespace ASClassWizard.Resources
             isPublic = is_public;
             isDynamic = is_dynamic;
             isFinal = is_final;
-
         }
     }
 }

--- a/External/Plugins/ASClassWizard/Wizards/AS3ClassWizard.cs
+++ b/External/Plugins/ASClassWizard/Wizards/AS3ClassWizard.cs
@@ -1,32 +1,16 @@
-﻿
-#region Imports
-using System;
-using System.Collections;
+﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
-using System.Text;
 using System.IO;
 using System.Windows.Forms;
 using System.Text.RegularExpressions;
-
 using PluginCore;
 using PluginCore.Localization;
 using ProjectManager.Projects;
-
-using ASClassWizard.Wizards;
-using ASClassWizard.Resources;
-
 using ASCompletion.Context;
 using ASCompletion.Model;
-
-using AS3Context;
-using AS2Context;
 using System.Reflection;
 using System.Diagnostics;
-#endregion
-
 
 namespace ASClassWizard.Wizards
 {
@@ -139,8 +123,6 @@ namespace ASClassWizard.Wizards
         /// <summary>
         /// Browse project packages
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
         private void packageBrowse_Click(object sender, EventArgs e)
         {
 
@@ -200,8 +182,6 @@ namespace ASClassWizard.Wizards
         /// <summary>
         /// Added interface
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
         private void implementBrowse_Click(object sender, EventArgs e)
         {
             using (ClassBrowser browser = new ClassBrowser())
@@ -240,8 +220,6 @@ namespace ASClassWizard.Wizards
         /// <summary>
         /// Remove interface
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
         private void interfaceRemove_Click(object sender, EventArgs e)
         {
             if (this.implementList.SelectedItem != null)
@@ -275,7 +253,7 @@ namespace ASClassWizard.Wizards
 
         #endregion
 
-        public static Image GetResource( string resourceID )
+        public static Image GetResource(string resourceID)
         {
             resourceID = "ASClassWizard." + resourceID;
             Assembly assembly = Assembly.GetExecutingAssembly();

--- a/External/Plugins/ASClassWizard/Wizards/ClassBrowser.cs
+++ b/External/Plugins/ASClassWizard/Wizards/ClassBrowser.cs
@@ -77,6 +77,8 @@ namespace ASClassWizard.Wizards
             {
                 foreach (MemberModel item in this.ClassList)
                 {
+                    // exclude types imported in the current file
+                    if (item.Name != item.Type) continue;
                     if (ExcludeFlag > 0) if ((item.Flags & ExcludeFlag) > 0) continue;
                     if (IncludeFlag > 0)
                     {

--- a/External/Plugins/ASClassWizard/Wizards/ClassBrowser.cs
+++ b/External/Plugins/ASClassWizard/Wizards/ClassBrowser.cs
@@ -1,23 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Text;
 using System.Windows.Forms;
-using System.Reflection;
 using PluginCore;
 using PluginCore.Localization;
 using ASCompletion.Model;
-using ASClassWizard.Wizards;
-using ASClassWizard.Resources;
 using PluginCore.Controls;
 
 namespace ASClassWizard.Wizards
 {
     public partial class ClassBrowser : SmartForm
     {
-
         private MemberList all;
         private List<GListBox.GListBoxItem> dataProvider;
         private FlagType invalidFlag;
@@ -78,7 +70,7 @@ namespace ASClassWizard.Wizards
 
         private void ClassBrowser_Load(object sender, EventArgs e)
         {
-            ASClassWizard.Wizards.GListBox.GListBoxItem node;
+            GListBox.GListBoxItem node;
             this.itemList.BeginUpdate();
             this.itemList.Items.Clear();
             if (this.ClassList != null)
@@ -91,7 +83,7 @@ namespace ASClassWizard.Wizards
                         if (!((item.Flags & IncludeFlag) > 0)) continue;
                     }
                     if (this.itemList.Items.Count > 0 && item.Name == this.itemList.Items[this.itemList.Items.Count - 1].ToString()) continue;
-                    node = new ASClassWizard.Wizards.GListBox.GListBoxItem(item.Name, (item.Flags & FlagType.Interface) > 0 ? 6 : 8);
+                    node = new GListBox.GListBoxItem(item.Name, (item.Flags & FlagType.Interface) > 0 ? 6 : 8);
                     this.itemList.Items.Add(node);
                     this.DataProvider.Add(node);
                 }
@@ -106,9 +98,9 @@ namespace ASClassWizard.Wizards
         }
 
         /// <summary>
-        /// Filder the list
+        /// Filter the list
         /// </summary>
-        private void filterBox_TextChanged( Object sender, EventArgs e)
+        private void filterBox_TextChanged(Object sender, EventArgs e)
         {
             string text = this.filterBox.Text;
             this.itemList.BeginUpdate();
@@ -138,11 +130,9 @@ namespace ASClassWizard.Wizards
         }
 
         /// <summary>
-        /// Filder the results
+        /// Filter the results
         /// </summary>
-        /// <param name="item"></param>
-        /// <returns></returns>
-        private bool FindAllItems( GListBox.GListBoxItem item )
+        private bool FindAllItems(GListBox.GListBoxItem item)
         {
             if (matchLen == 0) return true;
             int score = PluginCore.Controls.CompletionList.SmartMatch(item.Text, matchToken, matchLen);
@@ -162,15 +152,12 @@ namespace ASClassWizard.Wizards
         /// <summary>
         /// Select None button click
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
         private void cancelButton_Click(object sender, EventArgs e)
         {
             this.itemList.SelectedItem = null;
         }
 
-
-        private void itemList_DoubleClick( object sender, EventArgs e )
+        private void itemList_DoubleClick(object sender, EventArgs e)
         {
             this.DialogResult = DialogResult.OK;
             this.Close();

--- a/External/Plugins/ASClassWizard/Wizards/GListBox.cs
+++ b/External/Plugins/ASClassWizard/Wizards/GListBox.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections;
-using System.Text;
-using System.Drawing;
+﻿using System.Drawing;
 using System.Windows.Forms;
 
 namespace ASClassWizard.Wizards
 {
-
-    // GListBox class 
     public class GListBox : ListBox
     {
         private ImageList _myImageList;
@@ -62,40 +56,36 @@ namespace ASClassWizard.Wizards
             base.OnDrawItem(e);
         }
 
-    
-    public class GListBoxItem
-    {
-        public int matchScore;
+        public class GListBoxItem
+        {
+            public int matchScore;
         
-        private string _myText;
-        private int _myImageIndex;
+            private string _myText;
+            private int _myImageIndex;
 
-        // properties 
-        public string Text
-        {
-            get { return _myText; }
-            set { _myText = value; }
-        }
-        public int ImageIndex
-        {
-            get { return _myImageIndex; }
-            set { _myImageIndex = value; }
-        }
+            // properties 
+            public string Text
+            {
+                get { return _myText; }
+                set { _myText = value; }
+            }
+            public int ImageIndex
+            {
+                get { return _myImageIndex; }
+                set { _myImageIndex = value; }
+            }
         
-        //constructor
-        public GListBoxItem(string text, int index)
-        {
-            _myText = text;
-            _myImageIndex = index;
+            public GListBoxItem(string text, int index)
+            {
+                _myText = text;
+                _myImageIndex = index;
+            }
+            public GListBoxItem(string text) : this(text, -1) { }
+            public GListBoxItem() : this("") { }
+            public override string ToString()
+            {
+             return _myText;
+            }
         }
-        public GListBoxItem(string text) : this(text, -1) { }
-        public GListBoxItem() : this("") { }
-        public override string ToString()
-        {
-            return _myText;
-        }
-
-
-    }//End of GListBoxItem class
-    }//End of GListBox class
+    }
 }

--- a/External/Plugins/ASClassWizard/Wizards/PackageBrowser.cs
+++ b/External/Plugins/ASClassWizard/Wizards/PackageBrowser.cs
@@ -1,9 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Text;
 using System.IO;
 using System.Windows.Forms;
 using ProjectManager.Controls;
@@ -12,13 +8,11 @@ using PluginCore;
 using PluginCore.Localization;
 using PluginCore.Controls;
 using ASClassWizard.Controls.TreeView;
-using ASClassWizard.Resources;
 
 namespace ASClassWizard.Wizards
 {
     public partial class PackageBrowser : SmartForm
     {
-
         List<string> classpathList;
         Project project;
 
@@ -61,7 +55,6 @@ namespace ASClassWizard.Wizards
             classpathList = new List<string>();
         }
 
-
         public void AddClassPath(string value)
         {
             classpathList.Add(value);
@@ -96,7 +89,6 @@ namespace ASClassWizard.Wizards
                 }
             }
             this.browserView.EndUpdate();
-
         }
 
         private void PackageBrowser_Load(object sender, EventArgs e)
@@ -133,8 +125,6 @@ namespace ASClassWizard.Wizards
         /// <summary>
         /// Verify if a given directory is hidden
         /// </summary>
-        /// <param name="path"></param>
-        /// <returns></returns>
         protected bool IsDirectoryExcluded(string path)
         {
             string dirName = Path.GetFileName(path);
@@ -148,8 +138,6 @@ namespace ASClassWizard.Wizards
             return Project.IsPathHidden(path) && !Project.ShowHiddenPaths;
         }
 
-
-
         private void okButton_Click(object sender, EventArgs e)
         {
             this.DialogResult = DialogResult.OK;
@@ -162,6 +150,5 @@ namespace ASClassWizard.Wizards
             this.DialogResult = DialogResult.Cancel;
             this.Close();
         }
-
     }
 }

--- a/External/Plugins/ASCompletion/Model/MemberModel.cs
+++ b/External/Plugins/ASCompletion/Model/MemberModel.cs
@@ -4,14 +4,7 @@
 
 using System;
 using System.Collections;
-using System.Collections.Specialized;
 using System.Collections.Generic;
-using System.Text;
-using System.IO;
-using System.Diagnostics;
-using PluginCore;
-using PluginCore.Managers;
-using ASCompletion.Context;
 
 namespace ASCompletion.Model
 {
@@ -91,7 +84,7 @@ namespace ASCompletion.Model
         public override string ToString()
         {
             string res = FullName;
-            string type = (Type != null && Type.Length > 0) ? FormatType(Type) : null;
+            string type = !string.IsNullOrEmpty(Type) ? FormatType(Type) : null;
             string comment = "";
             if ((Flags & FlagType.Function) > 0)
             {
@@ -99,7 +92,7 @@ namespace ASCompletion.Model
 
                 if ((Flags & FlagType.Variable) > 0 || (Flags & FlagType.Getter) > 0)
                 {
-                    if (type != null && type.Length > 0)
+                    if (!string.IsNullOrEmpty(type))
                         functDecl += ":" + type;
 
                     res += " : Function" + TypedCallbackHLStart + functDecl + TypedCallbackHLEnd;
@@ -112,7 +105,7 @@ namespace ASCompletion.Model
             {
                 if ((Flags & FlagType.Setter) > 0)
                 {
-                    if (Parameters != null && Parameters.Count > 0 && Parameters[0].Type != null && Parameters[0].Type.Length > 0)
+                    if (Parameters != null && Parameters.Count > 0 && !string.IsNullOrEmpty(Parameters[0].Type))
                         return res + " : " + FormatType(Parameters[0].Type);
                 }
             }
@@ -120,7 +113,7 @@ namespace ASCompletion.Model
             if ((Flags & FlagType.Constructor) > 0)
                 return res;
             
-            if (type != null && type.Length > 0)
+            if (!string.IsNullOrEmpty(type))
                 res += " : " + type + comment;
 
             return res;


### PR DESCRIPTION
Includes a bit of code cleanup, the relevant part is the diff from the second commit: https://github.com/fdorg/flashdevelop/commit/68a4bc8260b76402fc62f0818c87bdbc9c4d5ffd