### PR TITLE
Line Comment: use block comment on the current line if not available

### DIFF
--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -3714,7 +3714,7 @@ namespace FlashDevelop
             Int32 indentPos = sci.LineIndentPosition(sci.CurrentLine);
             Int32 lineEndPos = sci.LineEndPosition(sci.CurrentLine);
             bool afterBlockStart = sci.CurrentPos > indentPos;
-            bool afterBlockEnd = sci.CurrentPos > lineEndPos;
+            bool afterBlockEnd = sci.CurrentPos >= lineEndPos;
 
             sci.SelectionStart = indentPos;
             sci.SelectionEnd = lineEndPos;

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -3568,6 +3568,11 @@ namespace FlashDevelop
         /// </summary>
         public void CommentSelection(Object sender, System.EventArgs e)
         {
+            CommentSelection();
+        }
+
+        private bool? CommentSelection()
+        {
             ScintillaControl sci = Globals.SciControl;
             Int32 selEnd = sci.SelectionEnd;
             Int32 selStart = sci.SelectionStart;
@@ -3578,14 +3583,15 @@ namespace FlashDevelop
                 sci.BeginUndoAction();
                 try
                 {
-                    Int32 indexLenght = sci.SelText.Length - commentStart.Length - commentEnd.Length;
-                    String withoutComment = sci.SelText.Substring(commentStart.Length, indexLenght);
+                    Int32 indexLength = sci.SelText.Length - commentStart.Length - commentEnd.Length;
+                    String withoutComment = sci.SelText.Substring(commentStart.Length, indexLength);
                     sci.ReplaceSel(withoutComment);
                 }
                 finally
                 {
                     sci.EndUndoAction();
                 }
+                return false;
             }
             else if (sci.SelText.Length > 0)
             {
@@ -3599,7 +3605,9 @@ namespace FlashDevelop
                 {
                     sci.EndUndoAction();
                 }
+                return true;
             }
+            return null;
         }
 
         /// <summary>
@@ -3663,6 +3671,14 @@ namespace FlashDevelop
             ScintillaControl sci = Globals.SciControl;
             String lineComment = ScintillaManager.GetLineComment(sci.ConfigurationLanguage);
             Int32 position = sci.CurrentPos;
+            
+            // try doing a block comment on the current line instead (xml, html...)
+            if (lineComment == "")
+            {
+                ToggleBlockOnCurrentLine(sci);
+                return;
+            }
+
             Int32 curLine = sci.LineFromPosition(position);
             Int32 startPosInLine = position - sci.PositionFromLine(curLine);
             Int32 startLine = sci.LineFromPosition(sci.SelectionStart);
@@ -3689,6 +3705,32 @@ namespace FlashDevelop
 
             if (containsCodeLine) this.CommentLine(null, null);
             else this.UncommentLine(null, null);
+        }
+
+        private void ToggleBlockOnCurrentLine(ScintillaControl sci)
+        {
+            Int32 selStart = sci.SelectionStart;
+
+            Int32 indentPos = sci.LineIndentPosition(sci.CurrentLine);
+            Int32 lineEndPos = sci.LineEndPosition(sci.CurrentLine);
+            bool afterBlockStart = sci.CurrentPos > indentPos;
+            bool afterBlockEnd = sci.CurrentPos > lineEndPos;
+
+            sci.SelectionStart = indentPos;
+            sci.SelectionEnd = lineEndPos;
+
+            bool? added = CommentSelection();
+            if (added == null) return;
+
+            int factor = (bool)added ? 1 : -1;
+
+            String commentEnd = ScintillaManager.GetCommentEnd(sci.ConfigurationLanguage);
+            String commentStart = ScintillaManager.GetCommentStart(sci.ConfigurationLanguage);
+
+            // preserve cursor pos
+            if (afterBlockStart) selStart += commentStart.Length * factor;
+            if (afterBlockEnd) selStart += commentEnd.Length * factor;
+            sci.SetSel(selStart, selStart);
         }
 
         /// <summary>


### PR DESCRIPTION
This is very convenient in XML and HTML files (which have no line comments in the traditional sense) - instead of having to select the line and do a block comment, line comment simply does a block comment on the current line.

![linecomment](https://cloud.githubusercontent.com/assets/2620907/8293359/29a06398-1935-11e5-9ba7-4f5a07bedb68.gif)
