### PR TITLE
Automatically add the semicolon after imports

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -3958,7 +3958,8 @@ namespace ASCompletion.Completion
                 ContextFeatures features = ASContext.Context.Features;
 
                 // add ; for imports
-                if (expr.WordBefore == features.importKey || expr.WordBefore == features.importKeyAlt)
+                if (trigger != ';' && (expr.WordBefore == features.importKey ||
+                    expr.WordBefore == features.importKeyAlt))
                 {
                     sci.InsertText(sci.CurrentPos, ";");
                     sci.SetSel(sci.CurrentPos + 1, sci.CurrentPos + 1);

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -184,10 +184,9 @@ namespace ASCompletion.Completion
                         if (features.hasGenerics && position > 2)
                         {
                             char c0 = (char)Sci.CharAt(position - 2);
-                            bool result = false;
                             if (c0 == '.' /*|| Char.IsLetterOrDigit(c0)*/)
                                 return HandleColonCompletion(Sci, "", autoHide);
-                            return result;
+                            return false;
                         }
                         else break;
 
@@ -3956,8 +3955,17 @@ namespace ASCompletion.Completion
                 ASExpr expr = GetExpression(sci, position + text.Length);
                 if (expr.Value == null) return;
 
-                // look for a snippet
                 ContextFeatures features = ASContext.Context.Features;
+
+                // add ; for imports
+                if (expr.WordBefore == features.importKey || expr.WordBefore == features.importKeyAlt)
+                {
+                    sci.InsertText(sci.CurrentPos, ";");
+                    sci.SetSel(sci.CurrentPos + 1, sci.CurrentPos + 1);
+                    return;
+                }
+
+                // look for a snippet
                 if (trigger == '\t' && expr.Value.IndexOf(features.dot) < 0)
                 {
                     foreach(string key in features.codeKeywords)
@@ -4052,7 +4060,7 @@ namespace ASCompletion.Completion
             if (inFile == null || import == null)
                 return false;
 
-            if (expr.Separator == ' ' && expr.WordBefore != null && expr.WordBefore != "")
+            if (expr.Separator == ' ' && !string.IsNullOrEmpty(expr.WordBefore))
             {
                 if (expr.WordBefore == features.importKey || expr.WordBefore == features.importKeyAlt
                     /*|| (!features.HasTypePreKey(expr.WordBefore) && expr.WordBefore != "case" && expr.WordBefore != "return")*/)

--- a/PluginCore/PluginCore/Controls/CompletionList.cs
+++ b/PluginCore/PluginCore/Controls/CompletionList.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Drawing;
 using System.Collections.Generic;
-using System.Drawing.Imaging;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using PluginCore.Managers;
@@ -840,17 +839,11 @@ namespace PluginCore.Controls
         
         #region Event Handling
         
-        /// <summary>
-        /// 
-        /// </summary> 
         static public IntPtr GetHandle()
         {
             return completionList.Handle;
         }
 
-        /// <summary>
-        /// 
-        /// </summary> 
         static public void OnChar(ScintillaControl sci, int value)
         {
             char c = (char)value;
@@ -889,9 +882,6 @@ namespace PluginCore.Controls
             }
         }
 
-        /// <summary>
-        /// 
-        /// </summary> 
         static public bool HandleKeys(ScintillaControl sci, Keys key)
         {
             int index;


### PR DESCRIPTION
![semicolon](https://cloud.githubusercontent.com/assets/2620907/8316386/ea47a5c2-19f6-11e5-808e-0f48dbdfdeca.gif)

Having to type the `;` manually every time when you already selected the item from the completion list is somewhat tedious.