### PR TITLE
Use the same Explorer icon everywhere

### DIFF
--- a/External/Plugins/ProjectManager/Controls/Icons.cs
+++ b/External/Plugins/ProjectManager/Controls/Icons.cs
@@ -139,7 +139,7 @@ namespace ProjectManager.Controls
             AddFile = Get("526|0|5|4");
             OpenFile = Get(214);
             EditFile = Get(282);
-            Browse = Get(56);
+            Browse = Get(46);
 
             FindAndReplace = Get(484);
             FindInFiles = Get(209);

--- a/FlashDevelop/Bin/Debug/Settings/TabMenu.xml
+++ b/FlashDevelop/Bin/Debug/Settings/TabMenu.xml
@@ -12,5 +12,5 @@
 	<button label="Label.SaveAs" click="SaveAs" keyid="FileMenu.SaveAs" flags="Enable:IsEditable" />
 	<separator />
 	<button label="Label.CommandPrompt" click="PluginCommand" tag="FileExplorer.PromptHere;$(CurDir)" image="57" keyid="GeneralToolsMenu.CommandPrompt" />
-	<button label="Label.WindowsExplorer" click="PluginCommand" tag="FileExplorer.Explore;$(CurDir)" image="56" keyid="GeneralToolsMenu.WindowsExplorer" />
+	<button label="Label.WindowsExplorer" click="PluginCommand" tag="FileExplorer.Explore;$(CurDir)" image="46" keyid="GeneralToolsMenu.WindowsExplorer" />
 </tabmenu>


### PR DESCRIPTION
The icons used in the TabMenu and the PM context menu were inconcistent with the one in the main menu.