### PR TITLE
Do not generate super calls with Haxe's '?' marker (optional parameter).

### DIFF
--- a/External/Plugins/ASClassWizard/PluginMain.cs
+++ b/External/Plugins/ASClassWizard/PluginMain.cs
@@ -361,7 +361,8 @@ namespace ASClassWizard
                                 foreach (MemberModel param in member.Parameters)
                                 {
                                     if (param.Name.StartsWith(".")) break;
-                                    superConstructor += (index > 0 ? ", " : "") + param.Name;
+                                    var pname = TemplateUtils.GetParamName(param);
+                                    superConstructor += (index > 0 ? ", " : "") + pname;
                                     index++;
                                 }
                                 superConstructor += ");\n" + (lastFileOptions.Language == "as3" ? "\t\t\t" : "\t\t");

--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -4207,7 +4207,7 @@ namespace ASCompletion.Completion
                 foreach (MemberModel param in member.Parameters)
                 {
                     if (param.Name.StartsWith(".")) break;
-                    args += ", " + param.Name;
+                    args += ", " + TemplateUtils.GetParamName(param);
                     addTypeOnce(typesUsed, getQualifiedType(param.Type, aType));
                 }
 

--- a/External/Plugins/ASCompletion/Completion/TemplateUtils.cs
+++ b/External/Plugins/ASCompletion/Completion/TemplateUtils.cs
@@ -143,7 +143,8 @@ namespace ASCompletion.Completion
                     else
                         one = ReplaceTemplateVariable(one, "PComma", null);
 
-                    one = ReplaceTemplateVariable(one, "PName", param.Name);
+                    var pname = GetParamName(param);
+                    one = ReplaceTemplateVariable(one, "PName", pname);
 
                     one = ReplaceTemplateVariable(one, "PType", null);
                     one = ReplaceTemplateVariable(one, "PDefaultValue", null);
@@ -264,6 +265,11 @@ namespace ASCompletion.Completion
                 sr.Close();
             }
             return content;
+        }
+
+        public static string GetParamName(MemberModel param)
+        {
+            return (param.Name ?? "").Replace("?", ""); // '?' is a marker for optional arguments
         }
     }
 }


### PR DESCRIPTION
Fixes #801: Bug: [Haxe] - Overriding method with optional parameters generates incorrect super() call