### PR TITLE
Update QuickFind to fallback on the DockPanelStripRenderer

### DIFF
--- a/FlashDevelop/Controls/QuickFind.cs
+++ b/FlashDevelop/Controls/QuickFind.cs
@@ -605,7 +605,7 @@ namespace FlashDevelop.Controls
             {
                 UiRenderMode renderMode = Globals.Settings.RenderMode;
                 if (renderMode == UiRenderMode.System) this.renderer = new ToolStripSystemRenderer();
-                else this.renderer = new ToolStripProfessionalRenderer();
+                else this.renderer = new DockPanelStripRenderer();
             }
 
             protected override void Initialize(ToolStrip toolStrip)


### PR DESCRIPTION
Improves the appearance of the QuickFind control when using a dark theme.

Adding ComboBox.ForeColor to the ui theme completes the look.
![image](https://cloud.githubusercontent.com/assets/611219/9806547/ee4afe48-5813-11e5-8319-c6116da46ba0.png)
