### PR TITLE
Update ASDocumentation.GetShortcutDocs to use theme color if set

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASDocumentation.cs
+++ b/External/Plugins/ASCompletion/Completion/ASDocumentation.cs
@@ -16,6 +16,7 @@ using ASCompletion.Context;
 using PluginCore.Localization;
 using PluginCore.Utilities;
 using ScintillaNet;
+using System.Drawing;
 
 namespace ASCompletion.Completion
 {
@@ -456,7 +457,9 @@ namespace ASCompletion.Completion
 
         static private string GetShortcutDocs()
         {
-            return "\n[COLOR=#666666:MULTIPLY][i](" + TextHelper.GetString("Info.ShowDetails") + ")[/i][/COLOR]";
+            Color themeForeColor = PluginBase.MainForm.GetThemeColor("RichToolTip.ForeColor");
+            string foreColorString = themeForeColor != Color.Empty ? ColorTranslator.ToHtml(themeForeColor) : "#666666:MULTIPLY";
+            return "\n[COLOR=" + foreColorString + "][i](" + TextHelper.GetString("Info.ShowDetails") + ")[/i][/COLOR]";
         }
 
         /// <summary>


### PR DESCRIPTION
Use the RichToolTip.ForeColor if it is set by the UI theme.

![image](https://cloud.githubusercontent.com/assets/611219/9806942/c4ff5b50-5819-11e5-9c1e-5e2c32c68ce5.png)
