### PR TITLE
Prevent occasional loss of target build value when building

### DIFF
--- a/External/Plugins/ProjectManager/Controls/FDMenus.cs
+++ b/External/Plugins/ProjectManager/Controls/FDMenus.cs
@@ -98,7 +98,9 @@ namespace ProjectManager.Controls
 
         public void EnableTargetBuildSelector(bool enabled)
         {
+            var target = TargetBuildSelector.Text; // prevent occasional loss of value when the control is disabled
             TargetBuildSelector.Enabled = enabled;
+            TargetBuildSelector.Text = target;
         }
 
         public bool DisabledForBuild
@@ -139,16 +141,24 @@ namespace ProjectManager.Controls
             {
                 TargetBuildSelector.Items.AddRange(project.MovieOptions.TargetBuildTypes);
                 string target = project.TargetBuild ?? project.MovieOptions.TargetBuildTypes[0];
-                if (!String.IsNullOrEmpty(target) && !TargetBuildSelector.Items.Contains(target)) TargetBuildSelector.Items.Insert(0, target);
+                AddTargetBuild(target);
                 TargetBuildSelector.Text = target;
             }
             else
             {
                 string target = project.TargetBuild ?? "";
-                if (target != "") TargetBuildSelector.Items.Insert(0, target);
+                AddTargetBuild(target);
                 TargetBuildSelector.Text = target;
             }
             EnableTargetBuildSelector(true);
+        }
+
+        internal void AddTargetBuild(string target)
+        {
+            if (target == null) return;
+            target = target.Trim();
+            if (target.Length > 0 && !TargetBuildSelector.Items.Contains(target)) 
+                TargetBuildSelector.Items.Insert(0, target);
         }
 
         

--- a/External/Plugins/ProjectManager/PluginMain.cs
+++ b/External/Plugins/ProjectManager/PluginMain.cs
@@ -322,8 +322,7 @@ namespace ProjectManager
             Project project = activeProject;
             if (project != null && project.TargetBuild != target)
             {
-                if (!menus.TargetBuildSelector.Items.Contains(target))
-                    menus.TargetBuildSelector.Items.Insert(0, target);
+                menus.AddTargetBuild(target);
                 FlexCompilerShell.Cleanup();
                 project.TargetBuild = menus.TargetBuildSelector.Text;
                 project.UpdateVars(false);


### PR DESCRIPTION
Sometimes the TargetBuild combo loses its value when building - an empty element sometimes gets inserted in the recent targetbuilds list also.