### PR TITLE
Fixed behavior after click of on the target build selector

### DIFF
--- a/External/Plugins/ProjectManager/Controls/FDMenus.cs
+++ b/External/Plugins/ProjectManager/Controls/FDMenus.cs
@@ -85,6 +85,7 @@ namespace ProjectManager.Controls
             TargetBuildSelector = new ToolStripComboBoxEx();
             TargetBuildSelector.Name = "TargetBuildSelector";
             TargetBuildSelector.ToolTipText = TextHelper.GetString("ToolTip.TargetBuild");
+            TargetBuildSelector.DropDownStyle = ComboBoxStyle.DropDownList;
             TargetBuildSelector.AutoSize = false;
             TargetBuildSelector.Width = ScaleHelper.Scale(85);
             TargetBuildSelector.Margin = new Padding(1, 0, 0, 0);


### PR DESCRIPTION
Click of on "target build selector" before fix:
![bug_click_on_targetbuildselector](https://cloud.githubusercontent.com/assets/1700940/10039976/fa33601c-61df-11e5-95a0-be93ad8df387.gif)

Click after fix:
![fixes_click_ob_targetbuildselector](https://cloud.githubusercontent.com/assets/1700940/10039981/03177ba0-61e0-11e5-8a3c-2a451b5cf099.gif)