### PR TITLE
Add a conditional output path argument: "{Build}"

### DIFF
--- a/External/Plugins/ProjectManager/Projects/Project.cs
+++ b/External/Plugins/ProjectManager/Projects/Project.cs
@@ -348,9 +348,9 @@ namespace ProjectManager.Projects
         public string FixDebugReleasePath(string path)
         {
             if (!TraceEnabled)
-                return Regex.Replace(path, @"([a-zA-Z0-9])[-_.]debug([\\/.])", "$1$2");
+                return Regex.Replace(path, @"([a-zA-Z0-9])[-_.]debug([\\/.])", "$1$2").Replace("{Build}", "Release");
             else
-                return path;
+                return path.Replace("{Build}", "Debug");
         }
 
         /// <summary>


### PR DESCRIPTION
The argument "{Build}" should resolve to the current build configuration to enable better support for conditional output path.