### PR TITLE
Include available Refactor menus in Contextual Code Generation list

### DIFF
--- a/External/Plugins/AS2Context/Context.cs
+++ b/External/Plugins/AS2Context/Context.cs
@@ -99,7 +99,9 @@ namespace AS2Context
             features.objectKey = "Object";
             features.booleanKey = "Boolean";
             features.numberKey = "Number";
+            features.stringKey = "String";
             features.arrayKey = "Array";
+            features.dynamicKey = "*";
             features.importKey = "import";
             features.typesPreKeys = new string[] { "import", "new", "instanceof", "extends", "implements" };
             features.codeKeywords = new string[] { 

--- a/External/Plugins/AS3Context/Context.cs
+++ b/External/Plugins/AS3Context/Context.cs
@@ -101,7 +101,9 @@ namespace AS3Context
             features.objectKey = "Object";
             features.booleanKey = "Boolean";
             features.numberKey = "Number";
+            features.stringKey = "String";
             features.arrayKey = "Array";
+            features.dynamicKey = "*";
             features.importKey = "import";
             features.typesPreKeys = new string[] { "import", "new", "typeof", "is", "as", "extends", "implements" };
             features.codeKeywords = new string[] { 

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -860,10 +860,9 @@ namespace ASCompletion.Completion
             NotifyContextChanged();
         }
 
-        private static void NotifyContextChanged()
+        public static void NotifyContextChanged()
         {
-            if (OnResolvedContextChanged != null) 
-                OnResolvedContextChanged(CurrentResolvedContext);
+            OnResolvedContextChanged?.Invoke(CurrentResolvedContext);
         }
 
         /// <summary>

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -860,9 +860,10 @@ namespace ASCompletion.Completion
             NotifyContextChanged();
         }
 
-        public static void NotifyContextChanged()
+        private static void NotifyContextChanged()
         {
-            OnResolvedContextChanged?.Invoke(CurrentResolvedContext);
+            if (OnResolvedContextChanged != null)
+                OnResolvedContextChanged.Invoke(CurrentResolvedContext);
         }
 
         /// <summary>

--- a/External/Plugins/ASCompletion/Completion/ContextFeatures.cs
+++ b/External/Plugins/ASCompletion/Completion/ContextFeatures.cs
@@ -72,7 +72,9 @@ namespace ASCompletion.Completion
         public string objectKey;
         public string booleanKey;
         public string numberKey;
+        public string stringKey;
         public string arrayKey;
+        public string dynamicKey;
         public string importKey;
         public string importKeyAlt;
         public string[] typesPreKeys = new string[] { };

--- a/External/Plugins/ASCompletion/PluginMain.cs
+++ b/External/Plugins/ASCompletion/PluginMain.cs
@@ -446,104 +446,107 @@ namespace ASCompletion
                 // Actionscript context specific
                 //
                 if (ASContext.Context.IsFileValid)
-                switch (e.Type)
-                {
-                    case EventType.ProcessArgs:
-                        TextEvent te = (TextEvent)e;
-                        if (reArgs.IsMatch(te.Value))
-                        {
-                            // resolve current element
-                            Hashtable details = ASComplete.ResolveElement(sci, null);
-                            te.Value = ArgumentsProcessor.Process(te.Value, details);
-
-                            if (te.Value.IndexOf("$") >= 0 && reCostlyArgs.IsMatch(te.Value))
+                    switch (e.Type)
+                    {
+                        case EventType.ProcessArgs:
+                            TextEvent te = (TextEvent) e;
+                            if (reArgs.IsMatch(te.Value))
                             {
-                                ASResult result = ASComplete.CurrentResolvedContext.Result ?? new ASResult();
-                                details = new Hashtable();
-                                // Get closest list (Array or Vector)
-                                string closestListName = "", closestListItemType = "";
-                                ASComplete.FindClosestList(ASContext.Context, result.Context, sci.CurrentLine, ref closestListName, ref closestListItemType);
-                                details.Add("TypClosestListName", closestListName);
-                                details.Add("TypClosestListItemType", closestListItemType);
-                                // get free iterator index
-                                string iterator = ASComplete.FindFreeIterator(ASContext.Context, ASContext.Context.CurrentClass, result.Context);
-                                details.Add("ItmUniqueVar", iterator);
+                                // resolve current element
+                                Hashtable details = ASComplete.ResolveElement(sci, null);
                                 te.Value = ArgumentsProcessor.Process(te.Value, details);
-                            }
-                        }
-                        break;
 
-                    // menu commands
-                    case EventType.Command:
-                        string command = (e as DataEvent).Action ?? "";
-                        if (command.StartsWith("ASCompletion."))
-                        {
-                            string cmdData = (e as DataEvent).Data as string;
-                            // run MTASC
-                            if (command == "ASCompletion.CustomBuild")
-                            {
-                                if (cmdData != null) ASContext.Context.RunCMD(cmdData);
-                                else ASContext.Context.RunCMD("");
-                                e.Handled = true;
-                            }
-
-                            // build the SWF using MTASC
-                            else if (command == "ASCompletion.QuickBuild")
-                            {
-                                ASContext.Context.BuildCMD(false);
-                                e.Handled = true;
-                            }
-
-                            // resolve element under cusor and open declaration
-                            else if (command == "ASCompletion.GotoDeclaration")
-                            {
-                                ASComplete.DeclarationLookup(sci);
-                                e.Handled = true;
-                            }
-
-                            // resolve element under cursor and send a CustomData event
-                            else if (command == "ASCompletion.ResolveElement")
-                            {
-                                ASComplete.ResolveElement(sci, cmdData);
-                                e.Handled = true;
-                            }
-                            else if (command == "ASCompletion.MakeIntrinsic")
-                            {
-                                ASContext.Context.MakeIntrinsic(cmdData);
-                                e.Handled = true;
-                            }
-
-                            // alternative to default shortcuts
-                            else if (command == "ASCompletion.CtrlSpace")
-                            {
-                                ASComplete.OnShortcut(Keys.Control | Keys.Space, ASContext.CurSciControl);
-                                e.Handled = true;
-                            }
-                            else if (command == "ASCompletion.CtrlShiftSpace")
-                            {
-                                ASComplete.OnShortcut(Keys.Control | Keys.Shift | Keys.Space, ASContext.CurSciControl);
-                                e.Handled = true;
-                            }
-                            else if (command == "ASCompletion.CtrlAltSpace")
-                            {
-                                ASComplete.OnShortcut(Keys.Control | Keys.Alt | Keys.Space, ASContext.CurSciControl);
-                                e.Handled = true;
-                            }
-                            else if (command == "ASCompletion.ContextualGenerator")
-                            {
-                                if (ASContext.HasContext && ASContext.Context.IsFileValid)
+                                if (te.Value.IndexOf("$") >= 0 && reCostlyArgs.IsMatch(te.Value))
                                 {
-                                    ASGenerator.ContextualGenerator(ASContext.CurSciControl);
+                                    ASResult result = ASComplete.CurrentResolvedContext.Result ?? new ASResult();
+                                    details = new Hashtable();
+                                    // Get closest list (Array or Vector)
+                                    string closestListName = "", closestListItemType = "";
+                                    ASComplete.FindClosestList(ASContext.Context, result.Context, sci.CurrentLine, ref closestListName, ref closestListItemType);
+                                    details.Add("TypClosestListName", closestListName);
+                                    details.Add("TypClosestListItemType", closestListItemType);
+                                    // get free iterator index
+                                    string iterator = ASComplete.FindFreeIterator(ASContext.Context, ASContext.Context.CurrentClass, result.Context);
+                                    details.Add("ItmUniqueVar", iterator);
+                                    te.Value = ArgumentsProcessor.Process(te.Value, details);
                                 }
                             }
-                        }
-                        return;
+                            break;
 
-                    case EventType.ProcessEnd:
-                        string procResult = (e as TextEvent).Value;
-                        ASContext.Context.OnProcessEnd(procResult);
-                        break;
-                }
+                        // menu commands
+                        case EventType.Command:
+                            de = e as DataEvent;
+                            string command = de.Action ?? "";
+                            if (command.StartsWith("ASCompletion."))
+                            {
+                                string cmdData = de.Data as string;
+                                // run MTASC
+                                if (command == "ASCompletion.CustomBuild")
+                                {
+                                    if (cmdData != null) ASContext.Context.RunCMD(cmdData);
+                                    else ASContext.Context.RunCMD("");
+                                    e.Handled = true;
+                                }
+
+                                // build the SWF using MTASC
+                                else if (command == "ASCompletion.QuickBuild")
+                                {
+                                    ASContext.Context.BuildCMD(false);
+                                    e.Handled = true;
+                                }
+
+                                // resolve element under cursor and open declaration
+                                else if (command == "ASCompletion.GotoDeclaration")
+                                {
+                                    ASComplete.DeclarationLookup(sci);
+                                    e.Handled = true;
+                                }
+
+                                // resolve element under cursor and send a CustomData event
+                                else if (command == "ASCompletion.ResolveElement")
+                                {
+                                    ASComplete.ResolveElement(sci, cmdData);
+                                    e.Handled = true;
+                                }
+                                else if (command == "ASCompletion.MakeIntrinsic")
+                                {
+                                    ASContext.Context.MakeIntrinsic(cmdData);
+                                    e.Handled = true;
+                                }
+
+                                // alternative to default shortcuts
+                                else if (command == "ASCompletion.CtrlSpace")
+                                {
+                                    ASComplete.OnShortcut(Keys.Control | Keys.Space, ASContext.CurSciControl);
+                                    e.Handled = true;
+                                }
+                                else if (command == "ASCompletion.CtrlShiftSpace")
+                                {
+                                    ASComplete.OnShortcut(Keys.Control | Keys.Shift | Keys.Space, ASContext.CurSciControl);
+                                    e.Handled = true;
+                                }
+                                else if (command == "ASCompletion.CtrlAltSpace")
+                                {
+                                    ASComplete.OnShortcut(Keys.Control | Keys.Alt | Keys.Space, ASContext.CurSciControl);
+                                    e.Handled = true;
+                                }
+                                else if (command == "ASCompletion.ContextualGenerator")
+                                {
+                                    if (ASContext.HasContext && ASContext.Context.IsFileValid)
+                                    {
+                                        ASGenerator.ContextualGenerator(ASContext.CurSciControl);
+                                        AddRefactorMenus(ASGenerator.KnownList, de.Data as ToolStripMenuItem);
+                                        CompletionList.Show(ASGenerator.KnownList, false);
+                                    }
+                                }
+                            }
+                            return;
+
+                        case EventType.ProcessEnd:
+                            string procResult = (e as TextEvent).Value;
+                            ASContext.Context.OnProcessEnd(procResult);
+                            break;
+                    }
             }
             catch(Exception ex)
             {
@@ -959,6 +962,59 @@ namespace ASCompletion
             pluginUI.OutlineTree.Enabled = ASContext.Context.CurrentModel != null;
             SetItemsEnabled(enableItems, ASContext.Context.CanBuild);
         }
+        #endregion
+
+        #region Contextual Code Generation Utilities
+
+        void AddRefactorMenus(List<ICompletionListItem> list, ToolStripMenuItem menu)
+        {
+            if (list == null)
+                return;
+
+            ASComplete.NotifyContextChanged();
+            Type RefactorMenu = menu.GetType();
+
+            var RenameMenuItem = GetItem(RefactorMenu, menu, "RenameMenuItem");
+            var ExtractMethodMenuItem = GetItem(RefactorMenu, menu, "ExtractMethodMenuItem");
+            var ExtractLocalVariableMenuItem = GetItem(RefactorMenu, menu, "ExtractLocalVariableMenuItem");
+            var DelegateMenuItem = GetItem(RefactorMenu, menu, "DelegateMenuItem");
+
+            if (RenameMenuItem.Enabled) list.Add(new RefactorItem(RenameMenuItem));
+            if (ExtractMethodMenuItem.Enabled) list.Add(new RefactorItem(ExtractMethodMenuItem));
+            if (ExtractLocalVariableMenuItem.Enabled) list.Add(new RefactorItem(ExtractLocalVariableMenuItem));
+            if (DelegateMenuItem.Enabled) list.Add(new RefactorItem(DelegateMenuItem));
+
+            var features = ASContext.Context.Features;
+
+            if (!features.hasImports)
+                return;
+
+            var sci = ASContext.CurSciControl;
+            string line = sci.GetLine(sci.CurrentLine).TrimStart();
+
+            if (line.StartsWith(features.importKey, StringComparison.Ordinal)
+                || !string.IsNullOrEmpty(features.importKeyAlt) && line.StartsWith(features.importKeyAlt, StringComparison.Ordinal))
+            {
+                var OrganizeMenuItem = GetItem(RefactorMenu, menu, "OrganizeMenuItem");
+
+                if (OrganizeMenuItem.Enabled)
+                    list.Add(new RefactorItem(OrganizeMenuItem));
+
+                if (features.hasImportsWildcard)
+                {
+                    var TruncateMenuItem = GetItem(RefactorMenu, menu, "TruncateMenuItem");
+
+                    if (TruncateMenuItem.Enabled)
+                        list.Add(new RefactorItem(TruncateMenuItem)); 
+                }
+            }
+        }
+
+        ToolStripMenuItem GetItem(Type type, ToolStripMenuItem menu, string item)
+        {
+            return type.GetProperty(item).GetValue(menu, null) as ToolStripMenuItem;
+        }
+
         #endregion
     }
 

--- a/External/Plugins/CodeRefactor/CodeRefactor.csproj
+++ b/External/Plugins/CodeRefactor/CodeRefactor.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Provider\MovingHelper.cs" />
     <Compile Include="Provider\RefactoringHelper.cs" />
     <Compile Include="Provider\UserInterfaceManager.cs" />
+    <Compile Include="RefactorItem.cs" />
     <Compile Include="Settings.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/External/Plugins/CodeRefactor/Commands/RefactorCommand.cs
+++ b/External/Plugins/CodeRefactor/Commands/RefactorCommand.cs
@@ -4,7 +4,7 @@ using CodeRefactor.Provider;
 namespace CodeRefactor.Commands
 {
     /// <summary>
-    /// Basic underyling Refactoring command.  Refactoring commands can derive from this.
+    /// Basic underlying Refactoring command.  Refactoring commands can derive from this.
     /// </summary>
     /// <typeparam name="RefactorResultType">The refactoring results return type</typeparam>
     public abstract class RefactorCommand<RefactorResultType>

--- a/External/Plugins/CodeRefactor/PluginMain.cs
+++ b/External/Plugins/CodeRefactor/PluginMain.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
@@ -690,50 +689,5 @@ namespace CodeRefactor
         }
 
         #endregion
-
-    }
-
-    class RefactorItem : ICompletionListItem
-    {
-        ToolStripItem item;
-        string label;
-        Bitmap icon;
-
-        public static void AddItemToList(ToolStripMenuItem item, List<ICompletionListItem> list)
-        {
-            if (item.Enabled)
-                list.Add(new RefactorItem(item));
-        }
-
-        public RefactorItem(ToolStripItem item)
-        {
-            this.item = item;
-            label = Regex.Replace(item.Text, "[&.]", string.Empty);
-            icon = new Bitmap(item.Image ?? PluginBase.MainForm.FindImage("452")); //452, 473
-        }
-
-        public string Description
-        {
-            get { return label; /*TextHelper.GetString("ASCompletion.Info.GeneratorTemplate");*/ }
-        }
-
-        public Bitmap Icon
-        {
-            get { return icon; }
-        }
-
-        public string Label
-        {
-            get { return label; }
-        }
-
-        public string Value
-        {
-            get
-            {
-                item.PerformClick();
-                return null;
-            }
-        }
     }
 }

--- a/External/Plugins/CodeRefactor/PluginMain.cs
+++ b/External/Plugins/CodeRefactor/PluginMain.cs
@@ -629,7 +629,7 @@ namespace CodeRefactor
         /// </summary>
         private void CodeGeneratorMenuItemClicked(Object sender, EventArgs e)
         {
-            DataEvent de = new DataEvent(EventType.Command, "ASCompletion.ContextualGenerator", null);
+            DataEvent de = new DataEvent(EventType.Command, "ASCompletion.ContextualGenerator", refactorContextMenu);
             EventManager.DispatchEvent(this, de);
         }
 

--- a/External/Plugins/CodeRefactor/RefactorItem.cs
+++ b/External/Plugins/CodeRefactor/RefactorItem.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using System.Text.RegularExpressions;
+using System.Windows.Forms;
+using PluginCore;
+using PluginCore.Localization;
+
+namespace CodeRefactor
+{
+    class RefactorItem : ICompletionListItem
+    {
+        Bitmap icon;
+        string description;
+        string label;
+        ToolStripItem item;
+
+        public static void AddItemToList(ToolStripItem item, List<ICompletionListItem> list)
+        {
+            if (item.Enabled)
+                list.Add(new RefactorItem(item));
+        }
+
+        public RefactorItem(ToolStripItem item)
+        {
+            this.item = item;
+            label = Regex.Replace(item.Text, "[&.]", string.Empty);
+            description = TextHelper.GetString("Label.Refactor").Replace("&", string.Empty);
+            icon = new Bitmap(item.Image ?? PluginBase.MainForm.FindImage("452")); //452 or 473
+        }
+
+        public string Description
+        {
+            get { return description; }
+        }
+
+        public Bitmap Icon
+        {
+            get { return icon; }
+        }
+
+        public string Label
+        {
+            get { return label; }
+        }
+
+        public string Value
+        {
+            get
+            {
+                item.PerformClick();
+                return null;
+            }
+        }
+    }
+}

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -115,7 +115,9 @@ namespace HaXeContext
             features.objectKey = "Dynamic";
             features.booleanKey = "Bool";
             features.numberKey = "Float";
+            features.stringKey = "String";
             features.arrayKey = "Array<T>";
+            features.dynamicKey = "Dynamic";
             features.importKey = "import";
             features.importKeyAlt = "using";
             features.typesPreKeys = new string[] { "import", "new", "extends", "implements", "using" };

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -117,7 +117,6 @@ namespace HaXeContext
             features.numberKey = "Float";
             features.stringKey = "String";
             features.arrayKey = "Array<T>";
-            features.dynamicKey = "Dynamic";
             features.importKey = "import";
             features.importKeyAlt = "using";
             features.typesPreKeys = new string[] { "import", "new", "extends", "implements", "using" };

--- a/External/Plugins/LoomContext/Context.cs
+++ b/External/Plugins/LoomContext/Context.cs
@@ -73,6 +73,7 @@ namespace LoomContext
             features.objectKey = "Object";
             features.booleanKey = "Boolean";
             features.numberKey = "Number";
+            features.stringKey = "String";
             features.arrayKey = "Array";
             features.importKey = "import";
             features.typesPreKeys = new string[] { "import", "new", "typeof", "is", "as", "extends", "implements" };

--- a/PluginCore/PluginCore/Controls/CompletionList.cs
+++ b/PluginCore/PluginCore/Controls/CompletionList.cs
@@ -236,7 +236,7 @@ namespace PluginCore.Controls
         }
 
         /// <summary>
-        /// Require that completion items are explicitely inserted (Enter, Tab, mouse-click)
+        /// Require that completion items are explicitly inserted (Enter, Tab, mouse-click)
         /// </summary>
         public static void DisableAutoInsertion()
         {


### PR DESCRIPTION
I had a feeling that the Refactor menus are very useful, but they are not easily accessible due to the fact that every option needs a separate shortcut assigned in order to access using keyboard only (unless you press the right-click button on your keyboard which is cheating). So, inspired by Visual Studio, I thought it would be nice if the available options were to show up in the existing code generator menu (assign the shortcut to `Ctrl+OemPeriod` and boom). 
![capture](https://cloud.githubusercontent.com/assets/13545633/11030909/eae46590-8735-11e5-9cd5-5dbe4648d74d.PNG)![capture2](https://cloud.githubusercontent.com/assets/13545633/11031086/f0433aba-8736-11e5-9c7f-4f14418cd1be.PNG)![capture3](https://cloud.githubusercontent.com/assets/13545633/11031128/2c5472e4-8737-11e5-9024-c32a877894b5.PNG)
Currently
- Rename
- Extract Method
- Extract Local Variable
- Generate Delegate Methods
- Organise Imports
- Truncate Imports

are available in the completion list, but more can be added with just 2 lines of code for each. (Edit: 1 line of code after 54bdb08)

Plus, extended the support of `Convert to Constant` to also work for strings.
![capture4](https://cloud.githubusercontent.com/assets/13545633/11031179/7a7800e4-8737-11e5-9d72-bd8257fc7979.PNG)