### PR TITLE
Haxe type parameters improvements

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -2331,32 +2331,35 @@ namespace ASCompletion.Completion
                     known = found;
                 }
             }
-            
-            if (ASContext.Context.Features.hasDelegates && !ASContext.Context.CurrentClass.IsVoid())
+
+            if (!ASContext.Context.CurrentClass.IsVoid())
             {
-                MemberList delegates = new MemberList();
-
-                foreach (MemberModel field in ASContext.Context.CurrentClass.Members)
-                    if ((field.Flags & FlagType.Delegate) > 0)
-                        delegates.Add(field);
-
-                if (delegates.Count > 0)
+                if (ASContext.Context.Features.hasDelegates)
                 {
-                    delegates.Sort();
-                    delegates.Merge(known);
-                    known = delegates;
+                    MemberList delegates = new MemberList();
+
+                    foreach (MemberModel field in ASContext.Context.CurrentClass.Members)
+                        if ((field.Flags & FlagType.Delegate) > 0)
+                            delegates.Add(field);
+
+                    if (delegates.Count > 0)
+                    {
+                        delegates.Sort();
+                        delegates.Merge(known);
+                        known = delegates;
+                    }
                 }
-            }
 
-            if (ASContext.Context.Features.hasGenerics && !ASContext.Context.CurrentClass.IsVoid())
-            {
-                var typeParams = GetVisibleTypeParameters();
-
-                if (typeParams != null && typeParams.Items.Count > 0)
+                if (ASContext.Context.Features.hasGenerics)
                 {
-                    typeParams.Add(known);
-                    typeParams.Sort();
-                    known = typeParams;
+                    var typeParams = GetVisibleTypeParameters();
+
+                    if (typeParams != null && typeParams.Items.Count > 0)
+                    {
+                        typeParams.Add(known);
+                        typeParams.Sort();
+                        known = typeParams;
+                    }
                 }
             }
 

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -2356,8 +2356,8 @@ namespace ASCompletion.Completion
 
                     if (typeParams != null && typeParams.Items.Count > 0)
                     {
-                        typeParams.Add(known);
                         typeParams.Sort();
+                        typeParams.Merge(known);
                         known = typeParams;
                     }
                 }
@@ -3895,12 +3895,19 @@ namespace ASCompletion.Completion
 
         static private MemberList GetVisibleElements()
         {
-            MemberList known = new MemberList();
-            known.Add(ASContext.Context.GetVisibleExternalElements());
+            MemberList known = ASContext.Context.GetVisibleExternalElements();
 
             if (ASContext.Context.Features.hasGenerics && !ASContext.Context.CurrentClass.IsVoid())
             {
-                known.Merge(GetVisibleTypeParameters());
+                var typeParams = GetVisibleTypeParameters();
+
+                if (typeParams != null && typeParams.Count > 0)
+                {
+                    typeParams.Sort();
+                    typeParams.Merge(known);
+
+                    known = typeParams;
+                }
             }
 
             return known;


### PR DESCRIPTION
When displaying classes check for type parameters and display them if existing.

![typeparams1](https://cloud.githubusercontent.com/assets/2273861/11467262/27c726a2-9747-11e5-9ed4-79559baa90db.png)

When autocompleting after : check in functions for the existance of type parameters. Previously this case was breaking completion completely.

![typeparams2](https://cloud.githubusercontent.com/assets/2273861/11467266/2d369b36-9747-11e5-9f8e-8a0493ff18e8.png)

The first screenshot also shows this fix, before the completion list wouldn't be shown in there unless forced with Ctrl+Alt+Space.