### PR TITLE
Track active document fixes.

### DIFF
--- a/External/Plugins/ProjectManager/PluginMain.cs
+++ b/External/Plugins/ProjectManager/PluginMain.cs
@@ -647,6 +647,9 @@ namespace ProjectManager
                 RestoreProjectSession(project);
             }
 
+            // track active file
+            if (Settings.TrackActiveDocument) TreeSyncToCurrentFile();
+
             if (stealFocus)
             {
                 OpenPanel();
@@ -1629,8 +1632,19 @@ namespace ProjectManager
             ITabbedDocument doc = PluginBase.MainForm.CurrentDocument;
             if (activeProject != null && doc != null && doc.IsEditable && !doc.IsUntitled)
             {
-                Tree.Select(doc.FileName);
-                Tree.SelectedNode.EnsureVisible();
+                string path = doc.FileName;
+
+                if (Tree.SelectedNode != null && Tree.SelectedNode.BackingPath == path)
+                    return;
+
+                Tree.Select(path);
+                if (Tree.SelectedNode.BackingPath == path)
+                {
+                    Tree.SelectedNode.EnsureVisible();
+                    Tree.PathToSelect = null;
+                }
+                else
+                    Tree.PathToSelect = path;
             }
         }
 


### PR DESCRIPTION
  - Try to resync on project opening.
  - If the node for the file is not found, try to find it in the future. This can happen with files created through wizards. I don't think this has any negative impact on files outside of the project, the check is quite simple and only happens on file changes.

This should fix issue #928 