### PR TITLE
Updates to MainForm (plus Related Things)

### DIFF
--- a/External/Plugins/AS3Context/PluginMain.cs
+++ b/External/Plugins/AS3Context/PluginMain.cs
@@ -265,25 +265,23 @@ namespace AS3Context
                     else if (inMXML)
                     {
                         DataEvent de = e as DataEvent;
-                        if (de.Action == "XMLCompletion.Element")
+                        switch (de.Action)
                         {
-                            de.Handled = MxmlComplete.HandleElement(de.Data);
-                        }
-                        if (de.Action == "XMLCompletion.Namespace")
-                        {
-                            de.Handled = MxmlComplete.HandleNamespace(de.Data);
-                        }
-                        else if (de.Action == "XMLCompletion.CloseElement")
-                        {
-                            de.Handled = MxmlComplete.HandleElementClose(de.Data);
-                        }
-                        else if (de.Action == "XMLCompletion.Attribute")
-                        {
-                            de.Handled = MxmlComplete.HandleAttribute(de.Data);
-                        }
-                        else if (de.Action == "XMLCompletion.AttributeValue")
-                        {
-                            de.Handled = MxmlComplete.HandleAttributeValue(de.Data);
+                            case "XMLCompletion.Element":
+                                de.Handled = MxmlComplete.HandleElement(de.Data);
+                                break;
+                            case "XMLCompletion.Namespace":
+                                de.Handled = MxmlComplete.HandleNamespace(de.Data);
+                                break;
+                            case "XMLCompletion.CloseElement":
+                                de.Handled = MxmlComplete.HandleElementClose(de.Data);
+                                break;
+                            case "XMLCompletion.Attribute":
+                                de.Handled = MxmlComplete.HandleAttribute(de.Data);
+                                break;
+                            case "XMLCompletion.AttributeValue":
+                                de.Handled = MxmlComplete.HandleAttributeValue(de.Data);
+                                break;
                         }
                     }
                 }

--- a/External/Plugins/ProjectManager/Helpers/LineEntryDialog.cs
+++ b/External/Plugins/ProjectManager/Helpers/LineEntryDialog.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Drawing;
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows.Forms;
 using PluginCore;
@@ -13,13 +14,12 @@ namespace ProjectManager.Helpers
     /// </summary>
     public class LineEntryDialog : Form
     {
-        readonly Keys shortcutToLowercase;
-        readonly Keys shortcutToUppercase;
         string line;
+        readonly Dictionary<Keys, string> shortcuts;
 
         #region Form Designer Components
 
-        protected System.Windows.Forms.TextBox lineBox;
+        private System.Windows.Forms.TextBox lineBox;
         private System.Windows.Forms.Button btnOK;
         private System.Windows.Forms.Button btnCancel;
         /// <summary>
@@ -40,17 +40,15 @@ namespace ProjectManager.Helpers
 
         public LineEntryDialog(string captionText, string labelText, string defaultLine)
         {
-            shortcutToLowercase = PluginBase.MainForm.GetShortcutItemKeys("EditMenu.ToLowercase");
-            shortcutToUppercase = PluginBase.MainForm.GetShortcutItemKeys("EditMenu.ToUppercase");
             InitializeComponent();
             InititalizeLocalization();
             this.Font = PluginBase.Settings.DefaultFont;
             this.Text = " " + captionText;
             titleLabel.Text = labelText;
-            lineBox.KeyDown += OnLineBoxOnKeyDown;
-            lineBox.Text = (defaultLine != null) ? defaultLine : string.Empty;
+            lineBox.Text = defaultLine ?? string.Empty;
             lineBox.SelectAll();
             lineBox.Focus();
+            shortcuts = PluginBase.MainForm.GetShortcutItemsByKeys();
         }
 
         #region Dispose
@@ -100,6 +98,7 @@ namespace ProjectManager.Helpers
             this.lineBox.Name = "lineBox";
             this.lineBox.Size = new System.Drawing.Size(260, 20);
             this.lineBox.TabIndex = 0;
+            this.lineBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.LineBox_KeyDown);
             // 
             // btnOK
             // 
@@ -172,18 +171,22 @@ namespace ProjectManager.Helpers
             this.Close();
         }
 
-        void OnLineBoxOnKeyDown(object sender, KeyEventArgs args)
+        void LineBox_KeyDown(object sender, KeyEventArgs e)
         {
-            string selectedText = lineBox.SelectedText;
-            if (string.IsNullOrEmpty(selectedText)) return;
-            Keys keys = args.KeyData;
-            if (keys == shortcutToLowercase) selectedText = selectedText.ToLower();
-            else if (keys == shortcutToUppercase) selectedText = selectedText.ToUpper();
-            else return;
-            int selectionStart = lineBox.SelectionStart;
-            int selectionLength = lineBox.SelectionLength;
-            lineBox.Paste(selectedText);
-            SelectRange(selectionStart, selectionLength);
+            string shortcutId;
+            if (!shortcuts.TryGetValue(e.KeyData, out shortcutId)) return;
+            switch (shortcutId)
+            {
+                case "EditMenu.ToLowercase":
+                case "EditMenu.ToUppercase":
+                    string text = lineBox.SelectedText;
+                    if (string.IsNullOrEmpty(text)) break;
+                    text = shortcutId == "EditMenu.ToLowercase" ? text.ToLower() : text.ToUpper();
+                    int selectionStart = lineBox.SelectionStart;
+                    lineBox.Paste(text);
+                    SelectRange(selectionStart, text.Length);
+                    break;
+            }
         }
 
         public void SelectRange(int start, int length)

--- a/External/Plugins/ProjectManager/PluginMain.cs
+++ b/External/Plugins/ProjectManager/PluginMain.cs
@@ -561,38 +561,38 @@ namespace ProjectManager
         {
             if (activeProject == null) return false;
 
-            if (ke.Value == PluginBase.MainForm.GetShortcutItemKeys("ProjectMenu.ConfigurationSelector"))
+            switch (PluginBase.MainForm.GetShortcutItemId(ke.Value))
             {
-                pluginUI.menus.ConfigurationSelector.Focus();
-            }
-            else if (ke.Value == PluginBase.MainForm.GetShortcutItemKeys("ProjectMenu.ConfigurationSelectorToggle"))
-            {
-                pluginUI.menus.ToggleDebugRelease();
-            }
-            else if (ke.Value == PluginBase.MainForm.GetShortcutItemKeys("ProjectMenu.TargetBuildSelector"))
-            {
-                pluginUI.menus.TargetBuildSelector.Focus();
-            }
-            else if (ke.Value == PluginBase.MainForm.GetShortcutItemKeys("ProjectTree.LocateActiveFile"))
-            {
-                ToggleTrackActiveDocument();
+                case "ProjectMenu.ConfigurationSelector":
+                    pluginUI.menus.ConfigurationSelector.Focus();
+                    break;
+                case "ProjectMenu.ConfigurationSelectorToggle":
+                    pluginUI.menus.ToggleDebugRelease();
+                    break;
+                case "ProjectMenu.TargetBuildSelector":
+                    pluginUI.menus.TargetBuildSelector.Focus();
+                    break;
+                case "ProjectTree.LocateActiveFile":
+                    ToggleTrackActiveDocument();
+                    break;
+                default:
+                    if (Tree.Focused && !pluginUI.IsEditingLabel)
+                    {
+                        if (ke.Value == (Keys.Control | Keys.C) && pluginUI.Menu.Contains(pluginUI.Menu.Copy)) TreeCopyItems();
+                        else if (ke.Value == (Keys.Control | Keys.X) && pluginUI.Menu.Contains(pluginUI.Menu.Cut)) TreeCutItems();
+                        else if (ke.Value == (Keys.Control | Keys.V) && pluginUI.Menu.Contains(pluginUI.Menu.Paste)) TreePasteItems();
+                        else if (ke.Value == Keys.Delete && pluginUI.Menu.Contains(pluginUI.Menu.Delete)) TreeDeleteItems();
+                        else if (ke.Value == Keys.Enter && pluginUI.Menu.Contains(pluginUI.Menu.Open)) TreeOpenItems();
+                        else if (ke.Value == Keys.Enter && pluginUI.Menu.Contains(pluginUI.Menu.Insert)) TreeInsertItem();
+                        else return false;
+                    }
+                    else return false;
+                    break;
             }
 
-            // Handle tree-level simple shortcuts like copy/paste/del
-            else if (Tree.Focused && !pluginUI.IsEditingLabel && ke != null)
-            {
-                if (ke.Value == (Keys.Control | Keys.C) && pluginUI.Menu.Contains(pluginUI.Menu.Copy)) TreeCopyItems();
-                else if (ke.Value == (Keys.Control | Keys.X) && pluginUI.Menu.Contains(pluginUI.Menu.Cut)) TreeCutItems();
-                else if (ke.Value == (Keys.Control | Keys.V) && pluginUI.Menu.Contains(pluginUI.Menu.Paste)) TreePasteItems();
-                else if (ke.Value == Keys.Delete && pluginUI.Menu.Contains(pluginUI.Menu.Delete)) TreeDeleteItems();
-                else if (ke.Value == Keys.Enter && pluginUI.Menu.Contains(pluginUI.Menu.Open)) TreeOpenItems();
-                else if (ke.Value == Keys.Enter && pluginUI.Menu.Contains(pluginUI.Menu.Insert)) TreeInsertItem();
-                else return false;
-            }
-            else return false;
             return true;
         }
-        
+
         #endregion
 
         #region Custom Methods

--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -284,7 +284,7 @@ namespace FlashDevelop.Dialogs
             this.listView.BeginUpdate();
             this.listView.Items.Clear();
             this.listView.ListViewItemSorter = new ListViewComparer();
-            foreach (ShortcutItem item in ShortcutManager.RegisteredItems)
+            foreach (ShortcutItem item in ShortcutManager.RegisteredItems.Values)
             {
                 if (!this.listView.Items.ContainsKey(item.Id) && 
                     (item.Id.ToLower().Contains(filter.ToLower()) || 

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -1754,6 +1754,30 @@ namespace FlashDevelop
         }
 
         /// <summary>
+        /// Gets a theme enumeration value.
+        /// </summary>
+        public T GetThemeValue<T>(String id) where T : struct
+        {
+            return GetThemeValue(id, default(T));
+        }
+
+        /// <summary>
+        /// Gets a theme enumeration value with a fallback.
+        /// </summary>
+        public T GetThemeValue<T>(String id, T fallback) where T : struct
+        {
+            String value = ThemeManager.GetThemeValue(id);
+            try
+            {
+                return (T) Enum.Parse(typeof(T), value);
+            }
+            catch
+            {
+                return fallback;
+            }
+        }
+
+        /// <summary>
         /// Finds the specified menu item by name
         /// </summary>
         public ToolStripItem FindMenuItem(String name)
@@ -1800,11 +1824,11 @@ namespace FlashDevelop
         /// Returns a <see cref="Dictionary{TKey, TValue}"/> object containing all registered
         /// shortcuts with the shortcut values as keys.
         /// </summary>
-        public Dictionary<Keys, string> GetShortcutItemsByKeys()
+        public Dictionary<Keys, String> GetShortcutItemsByKeys()
         {
-            var list = ShortcutManager.RegisteredItems.Values;
-            var items = new Dictionary<Keys, string>(list.Count);
-            foreach (var item in list)
+            Dictionary<String, ShortcutItem>.ValueCollection list = ShortcutManager.RegisteredItems.Values;
+            Dictionary<Keys, String> items = new Dictionary<Keys, String>(list.Count);
+            foreach (ShortcutItem item in list)
             {
                 if (item.Custom == Keys.None) continue;
                 items[item.Custom] = item.Id;

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -1710,8 +1710,7 @@ namespace FlashDevelop
         public Color GetThemeColor(String id, Color fallback)
         {
             Color color = ThemeManager.GetThemeColor(id);
-            if (color != Color.Empty) return color;
-            else return fallback;
+            return color.IsEmpty ? fallback : color;
         }
 
         /// <summary>
@@ -1728,8 +1727,30 @@ namespace FlashDevelop
         public String GetThemeValue(String id, String fallback)
         {
             String value = ThemeManager.GetThemeValue(id);
-            if (!String.IsNullOrEmpty(value)) return value;
-            else return fallback;
+            return String.IsNullOrEmpty(value) ? fallback : value;
+        }
+
+        /// <summary>
+        /// Gets a theme flag value.
+        /// </summary>
+        public Boolean GetThemeFlag(String id)
+        {
+            return GetThemeFlag(id, false);
+        }
+
+        /// <summary>
+        /// Gets a theme flag value with a fallback.
+        /// </summary>
+        public Boolean GetThemeFlag(String id, Boolean fallback)
+        {
+            String value = ThemeManager.GetThemeValue(id);
+            if (String.IsNullOrEmpty(value)) return fallback;
+            switch (value.ToLower())
+            {
+                case "true": return true;
+                case "false": return false;
+                default: return fallback;
+            }
         }
 
         /// <summary>
@@ -1763,8 +1784,32 @@ namespace FlashDevelop
         public Keys GetShortcutItemKeys(String id)
         {
             ShortcutItem item = ShortcutManager.GetRegisteredItem(id);
-            if (item != null) return item.Custom;
-            else return Keys.None;
+            return item != null ? item.Custom : Keys.None;
+        }
+
+        /// <summary>
+        /// Gets the shortcut id associated the keys.
+        /// </summary>
+        public string GetShortcutItemId(Keys keys)
+        {
+            ShortcutItem item = ShortcutManager.GetRegisteredItem(keys);
+            return item != null ? item.Id : null;
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Dictionary{TKey, TValue}"/> object containing all registered
+        /// shortcuts with the shortcut values as keys.
+        /// </summary>
+        public Dictionary<Keys, string> GetShortcutItemsByKeys()
+        {
+            var list = ShortcutManager.RegisteredItems.Values;
+            var items = new Dictionary<Keys, string>(list.Count);
+            foreach (var item in list)
+            {
+                if (item.Custom == Keys.None) continue;
+                items[item.Custom] = item.Id;
+            }
+            return items;
         }
 
         /// <summary>

--- a/FlashDevelop/Managers/ShortcutManager.cs
+++ b/FlashDevelop/Managers/ShortcutManager.cs
@@ -14,19 +14,19 @@ namespace FlashDevelop.Managers
     {
         public static readonly List<Keys> AllShortcuts;
         public static readonly List<ToolStripItem> SecondaryItems;
-        public static readonly Dictionary<string, ShortcutItem> RegisteredItems;
+        public static readonly Dictionary<String, ShortcutItem> RegisteredItems;
 
         static ShortcutManager()
         {
             AllShortcuts = new List<Keys>();
             SecondaryItems = new List<ToolStripItem>();
-            RegisteredItems = new Dictionary<string, ShortcutItem>();
+            RegisteredItems = new Dictionary<String, ShortcutItem>();
         }
 
         /// <summary>
         /// Registers a shortcut item.
         /// </summary>
-        public static void RegisterItem(string key, Keys keys)
+        public static void RegisterItem(String key, Keys keys)
         {
             RegisteredItems.Add(key, new ShortcutItem(key, keys));
         }
@@ -34,7 +34,7 @@ namespace FlashDevelop.Managers
         /// <summary>
         /// Registers a shortcut item.
         /// </summary>
-        public static void RegisterItem(string key, ToolStripMenuItem item)
+        public static void RegisterItem(String key, ToolStripMenuItem item)
         {
             RegisteredItems.Add(key, new ShortcutItem(key, item.ShortcutKeys));
         }
@@ -50,7 +50,7 @@ namespace FlashDevelop.Managers
         /// <summary>
         /// Registers a secondary item.
         /// </summary>
-        public static void RegisterSecondaryItem(string id, ToolStripItem item)
+        public static void RegisterSecondaryItem(String id, ToolStripItem item)
         {
             item.Tag = new ItemData("none;" + id, null, null);
             SecondaryItems.Add(item);
@@ -59,7 +59,7 @@ namespace FlashDevelop.Managers
         /// <summary>
         /// Gets the specified registered shortcut item.
         /// </summary>
-        public static ShortcutItem GetRegisteredItem(string id)
+        public static ShortcutItem GetRegisteredItem(String id)
         {
             ShortcutItem item;
             return RegisteredItems.TryGetValue(id, out item) ? item : null;
@@ -71,7 +71,7 @@ namespace FlashDevelop.Managers
         public static ShortcutItem GetRegisteredItem(Keys keys)
         {
             if (keys == Keys.None) return null;
-            foreach (var item in RegisteredItems.Values)
+            foreach (ShortcutItem item in RegisteredItems.Values)
             {
                 if (item.Custom == keys) return item;
             }
@@ -81,18 +81,18 @@ namespace FlashDevelop.Managers
         /// <summary>
         /// Gets the specified registered shortcut item.
         /// </summary>
-        public static ToolStripItem GetSecondaryItem(string id)
+        public static ToolStripItem GetSecondaryItem(String id)
         {
-            foreach (var item in SecondaryItems)
+            foreach (ToolStripItem item in SecondaryItems)
             {
-                string temp = string.Empty;
-                string[] ids = ((ItemData) item.Tag).Id.Split(';');
-                if (ids.Length == 2 && string.IsNullOrEmpty(ids[1]))
+                String temp = String.Empty;
+                String[] ids = ((ItemData) item.Tag).Id.Split(';');
+                if (ids.Length == 2 && String.IsNullOrEmpty(ids[1]))
                 {
                     temp = StripBarManager.GetMenuItemId(item);
                 }
                 else if (ids.Length == 2) temp = ids[1];
-                if (!string.IsNullOrEmpty(temp) && temp == id)
+                if (!String.IsNullOrEmpty(temp) && temp == id)
                 {
                     return item;
                 }
@@ -105,7 +105,7 @@ namespace FlashDevelop.Managers
         /// </summary>
         public static void UpdateAllShortcuts()
         {
-            foreach (var item in RegisteredItems.Values)
+            foreach (ShortcutItem item in RegisteredItems.Values)
             {
                 if (AllShortcuts.Contains(item.Custom)) continue;
                 AllShortcuts.Add(item.Custom);
@@ -118,7 +118,7 @@ namespace FlashDevelop.Managers
         public static void ApplyAllShortcuts()
         {
             UpdateAllShortcuts();
-            foreach (var item in RegisteredItems.Values)
+            foreach (ShortcutItem item in RegisteredItems.Values)
             {
                 if (item.Item != null)
                 {
@@ -130,7 +130,7 @@ namespace FlashDevelop.Managers
                     EventManager.DispatchEvent(Globals.MainForm, new DataEvent(EventType.Shortcut, item.Id, item.Custom));
                 }
             }
-            foreach (var button in SecondaryItems)
+            foreach (ToolStripItem button in SecondaryItems)
             {
                 ApplySecondaryShortcut(button);
             }
@@ -141,29 +141,32 @@ namespace FlashDevelop.Managers
         /// </summary>
         public static void ApplySecondaryShortcut(ToolStripItem item)
         {
-            bool view = Globals.Settings.ViewShortcuts;
             if (item == null || item.Tag == null) return;
-            string id;
-            string[] ids = ((ItemData) item.Tag).Id.Split(';');
-            if (ids.Length == 2 && string.IsNullOrEmpty(ids[1]))
+
+            String id;
+            String[] ids = ((ItemData) item.Tag).Id.Split(';');
+            if (ids.Length == 2 && String.IsNullOrEmpty(ids[1]))
             {
                 id = StripBarManager.GetMenuItemId(item);
             }
             else if (ids.Length == 2) id = ids[1];
             else return; // No work for us here...
-            var keys = Globals.MainForm.GetShortcutItemKeys(id);
+
+            Keys keys = Globals.MainForm.GetShortcutItemKeys(id);
             if (keys == Keys.None) return;
+
+            Boolean view = Globals.Settings.ViewShortcuts;
             if (item is ToolStripMenuItem)
             {
-                var casted = item as ToolStripMenuItem;
+                ToolStripMenuItem casted = item as ToolStripMenuItem;
                 if (casted.ShortcutKeys != Keys.None) return;
-                string keytext = DataConverter.KeysToString(keys);
-                casted.ShortcutKeyDisplayString = view ? keytext : string.Empty;
+                String keytext = DataConverter.KeysToString(keys);
+                casted.ShortcutKeyDisplayString = view ? keytext : String.Empty;
             }
             else
             {
-                int end = item.ToolTipText.IndexOf(" (", StringComparison.Ordinal);
-                string keytext = view ? " (" + DataConverter.KeysToString(keys) + ")" : string.Empty;
+                Int32 end = item.ToolTipText.IndexOf(" (", StringComparison.Ordinal);
+                String keytext = view ? " (" + DataConverter.KeysToString(keys) + ")" : String.Empty;
                 if (end != -1) item.ToolTipText = item.ToolTipText.Substring(0, end) + keytext;
                 else item.ToolTipText = item.ToolTipText + keytext;
             }
@@ -175,13 +178,13 @@ namespace FlashDevelop.Managers
         public static void LoadCustomShortcuts()
         {
             ScintillaControl.InitShortcuts();
-            string file = FileNameHelper.ShortcutData;
+            String file = FileNameHelper.ShortcutData;
             if (!File.Exists(file)) return;
-            var shortcuts = new List<Argument>();
+            List<Argument> shortcuts = new List<Argument>();
             shortcuts = (List<Argument>) ObjectSerializer.Deserialize(file, shortcuts, false);
-            foreach (var arg in shortcuts)
+            foreach (Argument arg in shortcuts)
             {
-                var item = GetRegisteredItem(arg.Key);
+                ShortcutItem item = GetRegisteredItem(arg.Key);
                 if (item != null) item.Custom = (Keys) Enum.Parse(typeof(Keys), arg.Value);
             }
         }
@@ -191,15 +194,15 @@ namespace FlashDevelop.Managers
         /// </summary>
         public static void SaveCustomShortcuts()
         {
-            var shortcuts = new List<Argument>();
-            foreach (var item in RegisteredItems.Values)
+            List<Argument> shortcuts = new List<Argument>();
+            foreach (ShortcutItem item in RegisteredItems.Values)
             {
                 if (item.Custom != item.Default)
                 {
                     shortcuts.Add(new Argument(item.Id, item.Custom.ToString()));
                 }
             }
-            string file = FileNameHelper.ShortcutData;
+            String file = FileNameHelper.ShortcutData;
             ObjectSerializer.Serialize(file, shortcuts);
         }
 
@@ -212,18 +215,18 @@ namespace FlashDevelop.Managers
     /// </summary>
     public class ShortcutItem
     {
-        public readonly string Id;
+        public readonly String Id;
         public Keys Custom;
         public Keys Default;
         public ToolStripMenuItem Item;
 
-        public ShortcutItem(string id, Keys keys)
+        public ShortcutItem(String id, Keys keys)
         {
             Id = id;
             Default = Custom = keys;
         }
 
-        public override string ToString()
+        public override String ToString()
         {
             return Id;
         }

--- a/PluginCore/PluginCore/Interfaces.cs
+++ b/PluginCore/PluginCore/Interfaces.cs
@@ -14,12 +14,12 @@ namespace PluginCore
     public interface IPlugin : IEventHandler
     {
         #region IPlugin Methods
-        
+
         void Dispose();
         void Initialize();
-        
+
         #endregion
-        
+
         #region IPlugin Properties
 
         Int32 Api { get; }
@@ -32,7 +32,7 @@ namespace PluginCore
 
         // List of valid API levels:
         // FlashDevelop 4.0 = 1
-        
+
         #endregion
     }
 
@@ -121,10 +121,14 @@ namespace PluginCore
         ToolStripItem FindMenuItem(String name);
         String ProcessArgString(String args);
         Keys GetShortcutItemKeys(String id);
+        String GetShortcutItemId(Keys keys);
+        Dictionary<Keys, string> GetShortcutItemsByKeys();
         String GetThemeValue(String id);
         Color GetThemeColor(String id);
+        Boolean GetThemeFlag(String id);
         String GetThemeValue(String id, String fallback);
         Color GetThemeColor(String id, Color fallback);
+        Boolean GetThemeFlag(String id, Boolean fallback);
         IPlugin FindPlugin(String guid);
         Image ImageSetAdjust(Image image);
         Image FindImage(String data);
@@ -275,7 +279,7 @@ namespace PluginCore
         Int32 CaretPeriod { get; set; }
         Int32 CaretWidth { get; set; }
         Int32 ScrollWidth { get; set; }
-        Int32 PrintMarginColumn  { get; set; }
+        Int32 PrintMarginColumn { get; set; }
         Size WindowSize { get; set; }
         FormWindowState WindowState { get; set; }
         Point WindowPosition { get; set; }
@@ -288,7 +292,7 @@ namespace PluginCore
         Boolean DisableSmartMatch { get; set; }
         Boolean SaveUnicodeWithBOM { get; set; }
         String InsertionTriggers { get; set; }
-        
+
         #endregion
     }
 

--- a/PluginCore/PluginCore/Interfaces.cs
+++ b/PluginCore/PluginCore/Interfaces.cs
@@ -122,13 +122,15 @@ namespace PluginCore
         String ProcessArgString(String args);
         Keys GetShortcutItemKeys(String id);
         String GetShortcutItemId(Keys keys);
-        Dictionary<Keys, string> GetShortcutItemsByKeys();
+        Dictionary<Keys, String> GetShortcutItemsByKeys();
         String GetThemeValue(String id);
         Color GetThemeColor(String id);
         Boolean GetThemeFlag(String id);
+        T GetThemeValue<T>(String id) where T : struct;
         String GetThemeValue(String id, String fallback);
         Color GetThemeColor(String id, Color fallback);
         Boolean GetThemeFlag(String id, Boolean fallback);
+        T GetThemeValue<T>(String id, T fallback) where T : struct;
         IPlugin FindPlugin(String guid);
         Image ImageSetAdjust(Image image);
         Image FindImage(String data);


### PR DESCRIPTION
Small changes. Currently 2 changes are made.

**1.**
`ShortcutManager.RegisteredItems` is changed to the type `Dictionary<string, ShortcutItem>` for better performance of searching by ID. In relation to this change, 
```C#
string IMainForm.GetShortcutItemId(Keys)
Dictionary<Keys, string> IMainForm.GetShortcutItemsByKeys()
```
have been added. With those changes, codes like below
```C#
if (keys == PluginBase.MainForm.GetShortcutItemKeys("Namespace.Shortcut1") { }
else if (keys == PluginBase.MainForm.GetShortcutItemKeys("Namespace.Shortcut2") { }
else if (keys == ...
```
which had to loop through the whole shortcut list _n_ number of times previously, can be replaced with either
```C#
switch (PluginBase.MainForm.GetShortcutItemId(keys))
{
    case "Namespace.Shortcut1": { } break;
    case "Namespace.Shortcut2": { } break;
    ...
}
```
or if the shortcut values would not change during a process (such as the `LineEntryDialog` class)
```C#
Dictionary<Keys, string> shortcuts = PluginBase.MainForm.GetShortcutItemsByKeys();
...
string id;
if (shortcuts.TryGetValue(keys, out id))
{
    switch (id) { ... }
}
```

**2.**
Added an option for retrieving a boolean theme value from MainForm.
```C#
bool IMainForm.GetThemeFlag(string)
bool IMainForm.GetThemeFlag(string, bool)
```