### PR TITLE
Delayed Update for ShortcutDialog

### DIFF
--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -16,6 +16,7 @@ namespace FlashDevelop.Dialogs
 {
     public class ShortcutDialog : SmartForm
     {
+        private Timer updateTimer;
         private ToolStripMenuItem removeShortcut;
         private ToolStripMenuItem revertToDefault;
         private ToolStripMenuItem revertAllToDefault;
@@ -41,6 +42,7 @@ namespace FlashDevelop.Dialogs
             this.InitializeGraphics();
             this.PopulateListView("", false);
             this.ApplyScaling();
+            this.SetupUpdateTimer();
         }
 
         #region Windows Form Designer Generated Code
@@ -287,8 +289,8 @@ namespace FlashDevelop.Dialogs
             foreach (ShortcutItem item in ShortcutManager.RegisteredItems.Values)
             {
                 if (!this.listView.Items.ContainsKey(item.Id) && 
-                    (item.Id.ToLower().Contains(filter.ToLower()) || 
-                    GetKeysAsString(item.Custom).ToLower().Contains(filter.ToLower())))
+                    (item.Id.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0 || 
+                    GetKeysAsString(item.Custom).IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0))
                 {
                     if (viewCustom && item.Custom == item.Default) continue;
                     ListViewItem lvi = new ListViewItem();
@@ -439,12 +441,33 @@ namespace FlashDevelop.Dialogs
         }
 
         /// <summary>
-        /// Updated the list with the filter
+        /// Set up the timer for delayed list update with filters.
+        /// </summary>
+        private void SetupUpdateTimer()
+        {
+            updateTimer = new Timer();
+            updateTimer.Enabled = false;
+            updateTimer.Interval = 200;
+            updateTimer.Tick += UpdateTimer_Tick;
+        }
+
+        /// <summary>
+        /// Update the list with filter.
+        /// </summary>
+        private void UpdateTimer_Tick(Object sender, EventArgs e)
+        {
+            updateTimer.Enabled = false;
+            String searchText = this.filterTextBox.Text.Trim();
+            this.PopulateListView(searchText, viewCustom.Checked);
+        }
+
+        /// <summary>
+        /// Restart the timer for updating the list.
         /// </summary>
         private void FilterTextChanged(Object sender, EventArgs e)
         {
-            String searchText = this.filterTextBox.Text.Trim();
-            this.PopulateListView(searchText, viewCustom.Checked);
+            updateTimer.Stop();
+            updateTimer.Start();
         }
 
         /// <summary>


### PR DESCRIPTION
The dialog waits for a certain delay when the filter is updated, before re-populating the list.
This prevents the lag caused on slow computers (mine) when typing fast enough. 