### PR TITLE
ShortcutDialog improvements.

### DIFF
--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -251,18 +251,18 @@ namespace FlashDevelop.Dialogs
         /// </summary>
         private static void UpdateItemHighlightFont(ShortcutListItem item)
         {
-            item.ForeColor = item.Conflicts == null ? SystemColors.ControlText : Color.DarkRed;
-            item.SubItems[1].ForeColor = item.KeysString == "None" ? SystemColors.GrayText : SystemColors.ControlText;
-            if (item.IsModified)
+            if (item.Conflicts == null)
             {
-                item.Font = new Font(Globals.Settings.DefaultFont, FontStyle.Bold);
-                item.UseItemStyleForSubItems = true;
+                item.ForeColor = SystemColors.ControlText;
+                item.SubItems[1].ForeColor = item.Custom == Keys.None ? SystemColors.GrayText : SystemColors.ControlText;
             }
             else
             {
-                item.Font = new Font(Globals.Settings.DefaultFont, FontStyle.Regular);
-                item.UseItemStyleForSubItems = false;
+                item.ForeColor = Color.DarkRed;
+                item.SubItems[1].ForeColor = Color.DarkRed;
             }
+            item.Font = new Font(Globals.Settings.DefaultFont, item.IsModified ? FontStyle.Bold : FontStyle.Regular);
+            item.UseItemStyleForSubItems = item.IsModified;
         }
 
         /// <summary>

--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -392,7 +392,6 @@ namespace FlashDevelop.Dialogs
             if (item.Custom == shortcut) return;
             item.Custom = shortcut;
             item.Selected = true;
-            ResetConflicts(item);
             this.GetConflictItems(item);
             if (item.HasConflicts)
             {
@@ -446,21 +445,19 @@ namespace FlashDevelop.Dialogs
             var keys = target.Custom;
             if (keys == 0) return;
 
-            var conflicts = new List<ShortcutListItem> { target };
+            List<ShortcutListItem> conflicts = null;
 
             for (int i = 0; i < this.shortcutListItems.Length; i++)
             {
                 var item = this.shortcutListItems[i];
 
-                if (item == target) continue;
-                if (item.Custom == keys)
-                {
-                    conflicts.Add(item);
-                    item.Conflicts = conflicts; 
-                }
+                if (item.Custom != keys || item == target) continue;
+                if (conflicts == null) conflicts = new List<ShortcutListItem> { target };
+                conflicts.Add(item);
+                item.Conflicts = conflicts;
             }
 
-            if (conflicts.Count > 1) target.Conflicts = conflicts;
+            target.Conflicts = conflicts;
         }
 
         /// <summary>
@@ -635,7 +632,6 @@ namespace FlashDevelop.Dialogs
                 get { return this.conflicts; }
                 set
                 {
-                    if (this.conflicts == value) return;
                     this.conflicts = value;
                     UpdateItemHighlightFont(this);
                 }
@@ -665,10 +661,10 @@ namespace FlashDevelop.Dialogs
                 get { return this.custom; }
                 set
                 {
-                    if (this.custom == value) return;
                     this.custom = value;
                     this.KeysString = DataConverter.KeysToString(this.custom);
                     this.SubItems[1].Text = this.KeysString;
+                    ResetConflicts(this);
                     UpdateItemHighlightFont(this);
                 }
             }
@@ -695,11 +691,13 @@ namespace FlashDevelop.Dialogs
             /// </summary>
             public ShortcutListItem(ShortcutItem shortcutItem)
             {
-                this.SubItems.Add(string.Empty);
-                this.Name = this.Text = shortcutItem.Id;
                 this.item = shortcutItem;
                 this.conflicts = null;
-                this.Custom = shortcutItem.Custom;
+                this.custom = this.Item.Custom;
+                this.KeysString = DataConverter.KeysToString(this.Custom);
+                this.Name = this.Text = this.Id;
+                this.SubItems.Add(this.KeysString);
+                UpdateItemHighlightFont(this);
             }
 
             /// <summary>

--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -287,11 +287,22 @@ namespace FlashDevelop.Dialogs
                 this.GetConflictItems(item);
                 conflicts = conflicts || item.HasConflicts;
             }
-            if (conflicts)
+            if (conflicts) this.ShowConflictsPresent();
+        }
+
+        /// <summary>
+        /// Display a warning message to show conflicts.
+        /// </summary>
+        bool ShowConflictsPresent()
+        {
+            string text = TextHelper.GetString("Info.ShortcutConflictsPresent");
+            string caption = TextHelper.GetString("Title.WarningDialog");
+            if (MessageBox.Show(this, text, " " + caption, MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)
             {
-                ErrorManager.ShowWarning(TextHelper.GetString("Info.ShortcutConflictsPresent"), null);
                 this.filterTextBox.Text = ViewConflictsKey.ToString();
+                return true;
             }
+            return false;
         }
 
         /// <summary>
@@ -395,10 +406,14 @@ namespace FlashDevelop.Dialogs
             this.GetConflictItems(item);
             if (item.HasConflicts)
             {
-                ErrorManager.ShowWarning(TextHelper.GetString("Info.ShortcutIsAlreadyUsed"), null);
+                string text = TextHelper.GetString("Info.ShortcutIsAlreadyUsed");
+                string caption = TextHelper.GetString("Title.WarningDialog");
+                if (MessageBox.Show(Globals.MainForm, text, " " + caption, MessageBoxButtons.RetryCancel, MessageBoxIcon.Warning) == DialogResult.Yes)
+                {
+                    this.filterTextBox.Text = ViewConflictsKey + item.KeysString;
+                    this.filterTextBox.SelectAll();
+                }
                 this.filterTextBox.Focus(); // Set focus to filter...
-                this.filterTextBox.Text = ViewConflictsKey + item.KeysString;
-                this.filterTextBox.SelectAll();
             }
         }
         
@@ -550,9 +565,7 @@ namespace FlashDevelop.Dialogs
             {
                 if (this.shortcutListItems[i].HasConflicts)
                 {
-                    ErrorManager.ShowError(TextHelper.GetString("Info.ShortcutConflictsPresent"), null);
-                    this.filterTextBox.Text = ViewConflictsKey.ToString();
-                    e.Cancel = true;
+                    e.Cancel = this.ShowConflictsPresent();
                     break;
                 }
             }

--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -455,10 +455,8 @@ namespace FlashDevelop.Dialogs
                 if (item == target) continue;
                 if (item.Custom == keys)
                 {
-                    if (item.HasConflicts) conflicts.AddRange(item.Conflicts);
-                    else conflicts.Add(item);
-
-                    item.Conflicts = conflicts;
+                    conflicts.Add(item);
+                    item.Conflicts = conflicts; 
                 }
             }
 
@@ -637,6 +635,7 @@ namespace FlashDevelop.Dialogs
                 get { return this.conflicts; }
                 set
                 {
+                    if (this.conflicts == value) return;
                     this.conflicts = value;
                     UpdateItemHighlightFont(this);
                 }
@@ -666,6 +665,7 @@ namespace FlashDevelop.Dialogs
                 get { return this.custom; }
                 set
                 {
+                    if (this.custom == value) return;
                     this.custom = value;
                     this.KeysString = DataConverter.KeysToString(this.custom);
                     this.SubItems[1].Text = this.KeysString;

--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -204,9 +204,9 @@ namespace FlashDevelop.Dialogs
             using (var imageList = new ImageList())
             {
                 imageList.ColorDepth = ColorDepth.Depth32Bit;
-                imageList.ImageSize = new Size(16, 16);
-                imageList.Images.Add(ScaleHelper.Scale((Bitmap) Globals.MainForm.FindImage("229", false)));
-                imageList.Images.Add(ScaleHelper.Scale((Bitmap) Globals.MainForm.FindImage("153", false)));
+                imageList.ImageSize = ScaleHelper.Scale(new Size(16, 16));
+                imageList.Images.Add(Globals.MainForm.FindImage("229", false));
+                imageList.Images.Add(Globals.MainForm.FindImage("153", false));
                 this.pictureBox.Image = imageList.Images[0];
                 this.clearButton.Image = imageList.Images[1];
             }
@@ -408,6 +408,7 @@ namespace FlashDevelop.Dialogs
             else if (!ToolStripManager.IsValidShortcut(shortcut)) return;
 
             if (item.Custom == shortcut) return;
+            var oldShortcut = item.Custom;
             item.Custom = shortcut;
             item.Selected = true;
             this.GetConflictItems(item);
@@ -415,12 +416,18 @@ namespace FlashDevelop.Dialogs
             {
                 string text = TextHelper.GetString("Info.ShortcutIsAlreadyUsed");
                 string caption = TextHelper.GetString("Title.WarningDialog");
-                if (MessageBox.Show(Globals.MainForm, text, " " + caption, MessageBoxButtons.RetryCancel, MessageBoxIcon.Warning) == DialogResult.Yes)
+                switch (MessageBox.Show(Globals.MainForm, text, " " + caption, MessageBoxButtons.AbortRetryIgnore, MessageBoxIcon.Warning))
                 {
-                    this.filterTextBox.Text = ViewConflictsKey + item.KeysString;
-                    this.filterTextBox.SelectAll();
+                    case DialogResult.Abort:
+                        item.Custom = oldShortcut;
+                        this.GetConflictItems(item);
+                        break;
+                    case DialogResult.Retry:
+                        this.filterTextBox.Text = ViewConflictsKey + item.KeysString;
+                        this.filterTextBox.SelectAll();
+                        this.filterTextBox.Focus(); // Set focus to filter...
+                        break;
                 }
-                this.filterTextBox.Focus(); // Set focus to filter...
             }
         }
         

--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -506,6 +506,7 @@ namespace FlashDevelop.Dialogs
         {
             this.viewCustom.Checked = false;
             this.filterTextBox.Text = string.Empty;
+            this.filterTextBox.Select();
         }
 
         /// <summary>

--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -13,13 +13,14 @@ namespace FlashDevelop.Dialogs
 {
     public class ShortcutDialog : SmartForm
     {
-        const string ViewConflictsKey = "?";
-        const string ViewCustomKey = "*";
+        const string ViewConflictsKey = "?"; // TODO: Change the type to char after #969 is merged
+        const string ViewCustomKey = "*"; // TODO: Change the type to char after #969 is merged
         
-        private Timer updateTimer;
-        private ToolStripMenuItem removeShortcut;
-        private ToolStripMenuItem revertToDefault;
-        private ToolStripMenuItem revertAllToDefault;
+        Timer updateTimer;
+        ToolStripMenuItem removeShortcut;
+        ToolStripMenuItem revertToDefault;
+        ToolStripMenuItem revertAllToDefault;
+        ShortcutListItem[] shortcutListItems;
         private System.Windows.Forms.Label infoLabel;
         private System.Windows.Forms.Label searchLabel;
         private System.Windows.Forms.ListView listView;
@@ -30,9 +31,8 @@ namespace FlashDevelop.Dialogs
         private System.Windows.Forms.CheckBox viewCustom;
         private System.Windows.Forms.Button clearButton;
         private System.Windows.Forms.Button closeButton;
-        private ShortcutListItem[] shortcutListItems;
 
-        public ShortcutDialog()
+        ShortcutDialog()
         {
             this.Owner = Globals.MainForm;
             this.Font = Globals.Settings.DefaultFont;
@@ -40,11 +40,11 @@ namespace FlashDevelop.Dialogs
             this.InitializeComponent();
             this.InitializeContextMenu();
             this.ApplyLocalizedTexts();
+            this.SetupUpdateTimer();
             this.InitializeGraphics();
             this.InitializeShortcutListItems();
-            this.PopulateListView(String.Empty);
+            this.PopulateListView(string.Empty);
             this.ApplyScaling();
-            this.SetupUpdateTimer();
         }
 
         #region Windows Form Designer Generated Code
@@ -197,36 +197,37 @@ namespace FlashDevelop.Dialogs
         #region Methods And Event Handlers
 
         /// <summary>
-        /// Initializes the graphics
+        /// Initializes the graphics.
         /// </summary>
-        private void InitializeGraphics()
+        void InitializeGraphics()
         {
             this.pictureBox.Image = Globals.MainForm.FindImage("229");
             this.clearButton.Image = Globals.MainForm.FindImage("153");
         }
 
         /// <summary>
-        /// Initializes the ListView context menu
+        /// Initializes the <see cref="ListView"/> context menu.
         /// </summary>
-        private void InitializeContextMenu()
+        void InitializeContextMenu()
         {
-            ContextMenuStrip cms = new ContextMenuStrip();
+            var cms = new ContextMenuStrip();
             cms.Font = Globals.Settings.DefaultFont;
             cms.Renderer = new DockPanelStripRenderer(false, false);
-            this.removeShortcut = new ToolStripMenuItem(TextHelper.GetString("Label.RemoveShortcut"), null, this.RemoveShortcutClick, Keys.Delete);
+            this.removeShortcut = new ToolStripMenuItem(TextHelper.GetString("Label.RemoveShortcut"), null, this.RemoveShortcutClick);
             this.revertToDefault = new ToolStripMenuItem(TextHelper.GetString("Label.RevertToDefault"), null, this.RevertToDefaultClick);
             this.revertAllToDefault = new ToolStripMenuItem(TextHelper.GetString("Label.RevertAllToDefault"), null, this.RevertAllToDefaultClick);
+            this.removeShortcut.ShortcutKeyDisplayString = DataConverter.KeysToString(Keys.Delete);
             cms.Items.Add(this.removeShortcut);
             cms.Items.Add(this.revertToDefault);
             cms.Items.Add(this.revertAllToDefault);
-            this.listView.ContextMenuStrip = cms;
             cms.Opening += this.ContextMenuOpening;
+            this.listView.ContextMenuStrip = cms;
         }
 
         /// <summary>
-        /// Applies the localized texts to the form
+        /// Applies the localized texts to the form.
         /// </summary>
-        private void ApplyLocalizedTexts()
+        void ApplyLocalizedTexts()
         {
             this.idHeader.Text = TextHelper.GetString("Label.Command");
             this.keyHeader.Text = TextHelper.GetString("Label.Shortcut");
@@ -238,94 +239,104 @@ namespace FlashDevelop.Dialogs
         }
 
         /// <summary>
-        /// Applies additional scaling to controls in order to support HDPI
+        /// Applies additional scaling to controls in order to support HDPI.
         /// </summary>
-        private void ApplyScaling()
+        void ApplyScaling()
         {
             this.idHeader.Width = ScaleHelper.Scale(this.idHeader.Width);
             this.keyHeader.Width = ScaleHelper.Scale(this.keyHeader.Width);
         }
         
         /// <summary>
-        /// Updates the font highlight of the item
+        /// Updates the font highlight of the item.
         /// </summary>
-        private static void UpdateItemHighlightFont(ShortcutListItem item)
+        static void UpdateItemHighlightFont(ShortcutListItem item)
         {
-            if (item.Conflicts == null)
-            {
-                item.ForeColor = SystemColors.ControlText;
-                item.SubItems[1].ForeColor = item.Custom == Keys.None ? SystemColors.GrayText : SystemColors.ControlText;
-            }
-            else
+            if (item.HasConflicts)
             {
                 item.ForeColor = Color.DarkRed;
                 item.SubItems[1].ForeColor = Color.DarkRed;
             }
-            item.Font = new Font(Globals.Settings.DefaultFont, item.IsModified ? FontStyle.Bold : FontStyle.Regular);
+            else
+            {
+                item.ForeColor = SystemColors.ControlText;
+                item.SubItems[1].ForeColor = item.Custom == 0 ? SystemColors.GrayText : SystemColors.ControlText;
+            }
+            item.Font = new Font(Globals.Settings.DefaultFont, item.IsModified ? FontStyle.Bold : 0);
             item.UseItemStyleForSubItems = item.IsModified;
         }
 
         /// <summary>
         /// Initialize the full shortcut list.
         /// </summary>
-        private void InitializeShortcutListItems()
+        void InitializeShortcutListItems()
         {
-            Dictionary<String, ShortcutItem>.ValueCollection collection = ShortcutManager.RegisteredItems.Values;
+            var collection = ShortcutManager.RegisteredItems.Values;
             this.shortcutListItems = new ShortcutListItem[collection.Count];
-            Int32 counter = 0;
-            foreach (ShortcutItem item in collection)
+            int counter = 0;
+            foreach (var item in collection)
             {
-                ShortcutListItem shortcutListItem = new ShortcutListItem(item);
-                UpdateItemHighlightFont(shortcutListItem);
-                this.shortcutListItems[counter++] = shortcutListItem;
+                this.shortcutListItems[counter++] = new ShortcutListItem(item);
             }
             Array.Sort(this.shortcutListItems, new ShorcutListItemComparer());
+
+            bool conflicts = false;
+            for (int i = 0; i < this.shortcutListItems.Length; i++)
+            {
+                var item = this.shortcutListItems[i];
+                this.GetConflictItems(item);
+                conflicts = conflicts || item.HasConflicts;
+            }
+            if (conflicts)
+            {
+                ErrorManager.ShowWarning(TextHelper.GetString("Info.ShortcutConflictsPresent"), null);
+                this.filterTextBox.Text = ViewConflictsKey.ToString();
+            }
         }
 
         /// <summary>
-        /// Populates the shortcut list view
+        /// Populates the shortcut list view.
         /// </summary>
-        private void PopulateListView(String filter)
+        void PopulateListView(string filter)
         {
-            Boolean viewCustom = false, viewConflicts = false;
+            bool viewCustom = false, viewConflicts = false;
             filter = ExtractFilterKeywords(filter, ref viewCustom, ref viewConflicts);
 
             this.listView.BeginUpdate();
             this.listView.Items.Clear();
-            foreach (ShortcutListItem item in this.shortcutListItems)
+            for (int i = 0; i < this.shortcutListItems.Length; i++)
             {
-                if (String.IsNullOrEmpty(filter) ||
+                var item = this.shortcutListItems[i];
+                if (string.IsNullOrEmpty(filter) ||
                     item.Id.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0 || 
                     item.KeysString.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0)
                 {
                     if (viewCustom && !item.IsModified) continue;
-                    if (viewConflicts && item.Conflicts == null) continue;
+                    if (viewConflicts && !item.HasConflicts) continue;
                     this.listView.Items.Add(item);
                 }
             }
             this.keyHeader.Width = -2;
             this.listView.EndUpdate();
-            if (this.listView.Items.Count > 0)
-            {
-                this.listView.Items[0].Selected = true;
-            }
+
+            if (this.listView.Items.Count > 0) this.listView.Items[0].Selected = true;
         }
 
         /// <summary>
         /// Reads and removes filter keywords from the start of the filter.
         /// Order of the keywords is irrelevant.
         /// </summary>
-        private static String ExtractFilterKeywords(String filter, ref Boolean viewCustom, ref Boolean viewConflicts)
+        static string ExtractFilterKeywords(string filter, ref bool viewCustom, ref bool viewConflicts)
         {
             if (!viewCustom && filter.StartsWith(ViewCustomKey))
             {
-                filter = filter.Substring(ViewCustomKey.Length);
+                filter = filter.Substring(1);
                 viewCustom = true;
                 return ExtractFilterKeywords(filter, ref viewCustom, ref viewConflicts);
             }
             if (!viewConflicts && filter.StartsWith(ViewConflictsKey))
             {
-                filter = filter.Substring(ViewConflictsKey.Length);
+                filter = filter.Substring(1);
                 viewConflicts = true;
                 return ExtractFilterKeywords(filter, ref viewCustom, ref viewConflicts);
             }
@@ -335,12 +346,12 @@ namespace FlashDevelop.Dialogs
         /// <summary>
         /// Raised when the context menu for the list view is opening.
         /// </summary>
-        private void ContextMenuOpening(Object sender, EventArgs e)
+        void ContextMenuOpening(object sender, EventArgs e)
         {
             if (this.listView.SelectedItems.Count > 0)
             {
-                ShortcutListItem item = (ShortcutListItem) this.listView.SelectedItems[0];
-                this.removeShortcut.Enabled = item.Custom != Keys.None;
+                var item = (ShortcutListItem) this.listView.SelectedItems[0];
+                this.removeShortcut.Enabled = item.Custom != 0;
                 this.revertToDefault.Enabled = this.revertAllToDefault.Enabled = item.IsModified;
                 if (this.revertAllToDefault.Enabled) return;
             }
@@ -357,13 +368,13 @@ namespace FlashDevelop.Dialogs
         }
 
         /// <summary>
-        /// Assign a new valid shortcut when keys are pressed
+        /// Assign a new valid shortcut when keys are pressed.
         /// </summary>
-        private void ListViewKeyDown(Object sender, KeyEventArgs e)
+        void ListViewKeyDown(object sender, KeyEventArgs e)
         {
             if (this.listView.SelectedItems.Count == 0) return;
 
-            ShortcutListItem item = (ShortcutListItem) this.listView.SelectedItems[0];
+            var item = (ShortcutListItem) this.listView.SelectedItems[0];
             this.AssignNewShortcut(item, e.KeyData);
 
             // Don't trigger list view default shortcuts like Ctrl+Add
@@ -373,24 +384,18 @@ namespace FlashDevelop.Dialogs
         /// <summary>
         /// Assign the new shortcut.
         /// </summary>
-        private void AssignNewShortcut(ShortcutListItem item, Keys shortcut)
+        void AssignNewShortcut(ShortcutListItem item, Keys shortcut)
         {
-            if (shortcut == Keys.None || shortcut == Keys.Delete) shortcut = 0;
+            if (shortcut == 0 || shortcut == Keys.Delete) shortcut = 0;
             else if (!ToolStripManager.IsValidShortcut(shortcut)) return;
 
             if (item.Custom == shortcut) return;
             item.Custom = shortcut;
             item.Selected = true;
             ResetConflicts(item);
-            List<ShortcutListItem> conflicts = this.GetConflictItems(shortcut);
-            if (conflicts == null) UpdateItemHighlightFont(item);
-            else
+            this.GetConflictItems(item);
+            if (item.HasConflicts)
             {
-                foreach (ShortcutListItem i in conflicts)
-                {
-                    i.Conflicts = conflicts;
-                    UpdateItemHighlightFont(i);
-                }
                 ErrorManager.ShowWarning(TextHelper.GetString("Info.ShortcutIsAlreadyUsed"), null);
                 this.filterTextBox.Focus(); // Set focus to filter...
                 this.filterTextBox.Text = ViewConflictsKey + item.KeysString;
@@ -401,30 +406,30 @@ namespace FlashDevelop.Dialogs
         /// <summary>
         /// Resets the conflicts status of an item.
         /// </summary>
-        private static void ResetConflicts(ShortcutListItem item)
+        static void ResetConflicts(ShortcutListItem item)
         {
-            List<ShortcutListItem> conflicts = item.Conflicts;
-            if (conflicts == null) return;
-            item.Conflicts = null;
+            if (!item.HasConflicts) return;
+            var conflicts = item.Conflicts;
             conflicts.Remove(item);
+            item.Conflicts = null;
+
             if (conflicts.Count == 1)
             {
                 item = conflicts[0];
-                item.Conflicts = null; // empty conflicts list will be garbage collected
                 conflicts.RemoveAt(0);
-                UpdateItemHighlightFont(item);
+                item.Conflicts = null; // empty conflicts list will be garbage collected
             }
         }
 
         /// <summary>
-        /// Filter the list view for custom items
+        /// [Deprecated] Filter the list view for custom items.
         /// </summary>
-        private void ViewCustomCheckedChanged(Object sender, EventArgs e)
+        void ViewCustomCheckedChanged(object sender, EventArgs e)
         {
             if (this.filterTextBox.Text.StartsWith(ViewCustomKey))
             {
                 if (!this.viewCustom.Checked)
-                    this.filterTextBox.Text = this.filterTextBox.Text.Substring(ViewCustomKey.Length);
+                    this.filterTextBox.Text = this.filterTextBox.Text.Substring(1);
             }
             else
             {
@@ -434,77 +439,79 @@ namespace FlashDevelop.Dialogs
         }
         
         /// <summary>
-        /// Gets a list of all conflicting entries. Returns null if the length is 0 or 1.
+        /// Gets a list of all conflicting entries.
         /// </summary>
-        private List<ShortcutListItem> GetConflictItems(Keys keys)
+        void GetConflictItems(ShortcutListItem target)
         {
-            if (keys == Keys.None) return null;
-            // To prevent creation of unnecessary List<T> objects
-            ShortcutListItem first = null;
-            List<ShortcutListItem> items = null;
-            foreach (ShortcutListItem item in this.shortcutListItems)
+            var keys = target.Custom;
+            if (keys == 0) return;
+
+            var conflicts = new List<ShortcutListItem> { target };
+
+            for (int i = 0; i < this.shortcutListItems.Length; i++)
             {
+                var item = this.shortcutListItems[i];
+
+                if (item == target) continue;
                 if (item.Custom == keys)
                 {
-                    if (first == null) first = item;
-                    else
-                    {
-                        if (items == null) items = new List<ShortcutListItem> { first };
-                        items.Add(item); 
-                    }
+                    if (item.HasConflicts) conflicts.AddRange(item.Conflicts);
+                    else conflicts.Add(item);
+
+                    item.Conflicts = conflicts;
                 }
             }
-            return items;
+
+            if (conflicts.Count > 1) target.Conflicts = conflicts;
         }
 
         /// <summary>
-        /// Reverts the shortcut to default value
+        /// Reverts the shortcut to default value.
         /// </summary>
-        private void RevertToDefaultClick(Object sender, EventArgs e)
+        void RevertToDefaultClick(object sender, EventArgs e)
         {
             if (this.listView.SelectedItems.Count > 0)
                 this.RevertToDefault((ShortcutListItem) this.listView.SelectedItems[0]);
         }
 
         /// <summary>
-        /// Reverts all shortcut to their default value
+        /// Reverts all visible shortcuts to their default value.
         /// </summary>
-        private void RevertAllToDefaultClick(Object sender, EventArgs e)
+        void RevertAllToDefaultClick(object sender, EventArgs e)
         {
             foreach (ShortcutListItem item in this.listView.Items) this.RevertToDefault(item);
         }
 
         /// <summary>
-        /// Revert the selected items shortcut to default
+        /// Revert the selected items shortcut to default.
         /// </summary>
-        private void RevertToDefault(ShortcutListItem item)
+        void RevertToDefault(ShortcutListItem item)
         {
             this.AssignNewShortcut(item, item.Default);
         }
 
         /// <summary>
-        /// Removes the shortcut by setting it to Keys.None
+        /// Removes the shortcut by setting it to <see cref="Keys.None"/>.
         /// </summary>
-        private void RemoveShortcutClick(Object sender, EventArgs e)
+        void RemoveShortcutClick(object sender, EventArgs e)
         {
-            if (this.listView.SelectedItems.Count == 0) return;
-            ShortcutListItem item = (ShortcutListItem) this.listView.SelectedItems[0];
-            this.AssignNewShortcut(item, Keys.None);
+            if (this.listView.SelectedItems.Count > 0)
+                this.AssignNewShortcut((ShortcutListItem) this.listView.SelectedItems[0], 0);
         }
 
         /// <summary>
-        /// Clears the filter text field
+        /// Clears the filter text field.
         /// </summary>
-        private void ClearFilterClick(Object sender, EventArgs e)
+        void ClearFilterClick(object sender, EventArgs e)
         {
             this.viewCustom.Checked = false;
-            this.filterTextBox.Text = "";
+            this.filterTextBox.Text = string.Empty;
         }
 
         /// <summary>
         /// Set up the timer for delayed list update with filters.
         /// </summary>
-        private void SetupUpdateTimer()
+        void SetupUpdateTimer()
         {
             this.updateTimer = new Timer();
             this.updateTimer.Enabled = false;
@@ -515,7 +522,7 @@ namespace FlashDevelop.Dialogs
         /// <summary>
         /// Update the list with filter.
         /// </summary>
-        private void UpdateTimer_Tick(Object sender, EventArgs e)
+        void UpdateTimer_Tick(object sender, EventArgs e)
         {
             this.updateTimer.Enabled = false;
             this.PopulateListView(this.filterTextBox.Text);
@@ -524,31 +531,31 @@ namespace FlashDevelop.Dialogs
         /// <summary>
         /// Restart the timer for updating the list.
         /// </summary>
-        private void FilterTextChanged(Object sender, EventArgs e)
+        void FilterTextChanged(object sender, EventArgs e)
         {
             this.updateTimer.Stop();
             this.updateTimer.Start();
         }
 
         /// <summary>
-        /// Closes the shortcut dialog
+        /// Closes the shortcut dialog.
         /// </summary>
-        private void CloseButtonClick(Object sender, EventArgs e)
+        void CloseButtonClick(object sender, EventArgs e)
         {
             this.Close();
         }
 
         /// <summary>
-        /// When the form is about to close, check for any conflicts.
+        /// When the form is about to close, checks for any conflicts.
         /// </summary>
-        private void DialogClosing(Object sender, FormClosingEventArgs e)
+        void DialogClosing(object sender, FormClosingEventArgs e)
         {
-            foreach (ShortcutListItem item in this.shortcutListItems)
+            for (int i = 0; i < this.shortcutListItems.Length; i++)
             {
-                if (item.Conflicts != null)
+                if (this.shortcutListItems[i].HasConflicts)
                 {
                     ErrorManager.ShowError(TextHelper.GetString("Info.ShortcutConflictsPresent"), null);
-                    this.filterTextBox.Text = ViewConflictsKey;
+                    this.filterTextBox.Text = ViewConflictsKey.ToString();
                     e.Cancel = true;
                     break;
                 }
@@ -556,23 +563,20 @@ namespace FlashDevelop.Dialogs
         }
 
         /// <summary>
-        /// When the form is closed, applies shortcuts
+        /// When the form is closed, applies shortcuts.
         /// </summary>
-        private void DialogClosed(Object sender, FormClosedEventArgs e)
+        void DialogClosed(object sender, FormClosedEventArgs e)
         {
-            foreach (ShortcutListItem item in this.shortcutListItems)
-            {
-                item.ApplyChanges();
-            }
+            for (int i = 0; i < this.shortcutListItems.Length; i++) this.shortcutListItems[i].ApplyChanges();
             Globals.MainForm.ApplyAllSettings();
         }
 
         /// <summary>
-        /// Shows the shortcut dialog
+        /// Shows the shortcut dialog.
         /// </summary>
         public static new void Show()
         {
-            ShortcutDialog shortcutDialog = new ShortcutDialog();
+            var shortcutDialog = new ShortcutDialog();
             shortcutDialog.CenterToParent();
             shortcutDialog.Show(Globals.MainForm);
             shortcutDialog.filterTextBox.Focus();
@@ -580,87 +584,130 @@ namespace FlashDevelop.Dialogs
 
         #endregion
 
-    }
 
-    #region ListViewComparer
+        #region ListViewComparer
 
-    /// <summary>
-    /// Defines a method that compares two <see cref="ShortcutListItem"/> objects.
-    /// </summary>
-    class ShorcutListItemComparer : IComparer<ShortcutListItem>
-    {
-        Int32 IComparer<ShortcutListItem>.Compare(ShortcutListItem x, ShortcutListItem y)
+        /// <summary>
+        /// Defines a method that compares two <see cref="ShortcutListItem"/> objects.
+        /// </summary>
+        class ShorcutListItemComparer : IComparer<ShortcutListItem>
         {
-            return StringComparer.Ordinal.Compare(x.Text, y.Text);
-        }
-    }
-
-    #endregion
-
-    /// <summary>
-    /// Represents a copy of a <see cref="ShortcutItem"/> as well as a visual component.
-    /// </summary>
-    class ShortcutListItem : ListViewItem
-    {
-        private Keys custom;
-
-        /// <summary>
-        /// Gets the associated <see cref="ShortcutItem"/> object.
-        /// </summary>
-        public ShortcutItem Item { get; private set; }
-        /// <summary>
-        /// Gets or sets a list of <see cref="ShortcutListItem"/> objects that have conflicting keys with this instance.
-        /// </summary>
-        public List<ShortcutListItem> Conflicts { get; set; }
-        /// <summary>
-        /// Gets the ID of the associated <see cref="ShortcutItem"/>.
-        /// </summary>
-        public String Id { get { return this.Item.Id; } }
-        /// <summary>
-        /// Gets the default shortcut keys.
-        /// </summary>
-        public Keys Default { get { return this.Item.Default; } }
-        /// <summary>
-        /// Gets or sets the custom shortcut keys.
-        /// </summary>
-        public Keys Custom
-        {
-            get { return this.custom; }
-            set
+            /// <summary>
+            /// Compares two <see cref="ShortcutListItem"/> objects.
+            /// </summary>
+            int IComparer<ShortcutListItem>.Compare(ShortcutListItem x, ShortcutListItem y)
             {
-                this.custom = value;
-                this.KeysString = DataConverter.KeysToString(value);
-                this.SubItems[1].Text = this.KeysString;
+                return StringComparer.Ordinal.Compare(x.Text, y.Text);
             }
         }
-        /// <summary>
-        /// Gets the string representation of the custom shortcut keys.
-        /// </summary>
-        public String KeysString { get; private set; }
-        /// <summary>
-        /// Gets the modification status of the shortcut.
-        /// </summary>
-        public Boolean IsModified { get { return this.Custom != this.Default; } }
+
+        #endregion
 
         /// <summary>
-        /// Creates a new instance of <see cref="ShortcutListItem"/> with an associated <see cref="ShortcutItem"/>.
+        /// Represents a visual representation of a <see cref="ShortcutItem"/> object.
         /// </summary>
-        public ShortcutListItem(ShortcutItem item)
+        class ShortcutListItem : ListViewItem
         {
-            this.SubItems.Add(string.Empty);
-            this.Name = this.Text = item.Id;
-            this.Item = item;
-            this.Conflicts = null;
-            this.Custom = item.Custom;
-        }
+            readonly ShortcutItem item;
+            List<ShortcutListItem> conflicts;
+            Keys custom;
 
-        /// <summary>
-        /// Apply changes made to this instance to the associated <see cref="ShortcutItem"/>.
-        /// </summary>
-        public void ApplyChanges()
-        {
-            this.Item.Custom = this.Custom;
+            /// <summary>
+            /// Gets the associated <see cref="ShortcutItem"/> object.
+            /// </summary>
+            public ShortcutItem Item
+            {
+                get { return this.item; }
+            }
+
+            /// <summary>
+            /// Gets whether this <see cref="ShortcutListItem"/> has other conflicting <see cref="ShortcutListItem"/> objects.
+            /// </summary>
+            public bool HasConflicts
+            {
+                get { return this.Conflicts != null; }
+            }
+
+            /// <summary>
+            /// Gets or sets a collection of <see cref="ShortcutListItem"/> objects that have conflicting keys with this instance.
+            /// </summary>
+            public List<ShortcutListItem> Conflicts
+            {
+                get { return this.conflicts; }
+                set
+                {
+                    this.conflicts = value;
+                    UpdateItemHighlightFont(this);
+                }
+            }
+
+            /// <summary>
+            /// Gets the ID of the associated <see cref="ShortcutItem"/>.
+            /// </summary>
+            public string Id
+            {
+                get { return this.Item.Id; }
+            }
+
+            /// <summary>
+            /// Gets the default shortcut keys.
+            /// </summary>
+            public Keys Default
+            {
+                get { return this.Item.Default; }
+            }
+
+            /// <summary>
+            /// Gets or sets the custom shortcut keys.
+            /// </summary>
+            public Keys Custom
+            {
+                get { return this.custom; }
+                set
+                {
+                    this.custom = value;
+                    this.KeysString = DataConverter.KeysToString(this.custom);
+                    this.SubItems[1].Text = this.KeysString;
+                    UpdateItemHighlightFont(this);
+                }
+            }
+
+            /// <summary>
+            /// Gets the string representation of the custom shortcut keys.
+            /// </summary>
+            public string KeysString
+            {
+                get;
+                private set;
+            }
+
+            /// <summary>
+            /// Gets the modification status of the shortcut.
+            /// </summary>
+            public bool IsModified
+            {
+                get { return this.Custom != this.Default; }
+            }
+
+            /// <summary>
+            /// Creates a new instance of <see cref="ShortcutListItem"/> with an associated <see cref="ShortcutItem"/>.
+            /// </summary>
+            public ShortcutListItem(ShortcutItem shortcutItem)
+            {
+                this.SubItems.Add(string.Empty);
+                this.Name = this.Text = shortcutItem.Id;
+                this.item = shortcutItem;
+                this.conflicts = null;
+                this.Custom = shortcutItem.Custom;
+            }
+
+            /// <summary>
+            /// Apply changes made to this instance to the associated <see cref="ShortcutItem"/>.
+            /// </summary>
+            public void ApplyChanges()
+            {
+                this.Item.Custom = this.Custom;
+            }
         }
     }
-
 }

--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -201,8 +201,15 @@ namespace FlashDevelop.Dialogs
         /// </summary>
         void InitializeGraphics()
         {
-            this.pictureBox.Image = Globals.MainForm.FindImage("229");
-            this.clearButton.Image = Globals.MainForm.FindImage("153");
+            using (var imageList = new ImageList())
+            {
+                imageList.ColorDepth = ColorDepth.Depth32Bit;
+                imageList.ImageSize = new Size(16, 16);
+                imageList.Images.Add(ScaleHelper.Scale((Bitmap) Globals.MainForm.FindImage("229", false)));
+                imageList.Images.Add(ScaleHelper.Scale((Bitmap) Globals.MainForm.FindImage("153", false)));
+                this.pictureBox.Image = imageList.Images[0];
+                this.clearButton.Image = imageList.Images[1];
+            }
         }
 
         /// <summary>

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -2016,7 +2016,7 @@ namespace FlashDevelop
         {
             if (this.InvokeRequired)
             {
-                this.BeginInvoke((MethodInvoker)delegate { this.ApplyAllSettings(); });
+                this.BeginInvoke((MethodInvoker) this.ApplyAllSettings);
                 return;
             }
             ShortcutManager.ApplyAllShortcuts();

--- a/PluginCore/PluginCore/Resources/de_DE.resX
+++ b/PluginCore/PluginCore/Resources/de_DE.resX
@@ -5964,4 +5964,8 @@ Eigene Sprachumgebungen müssen eine Erweiterung der Standard-Sprachumgebung sei
     <value>Highlight word:</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Info.ShortcutConflictsPresent" xml:space="preserve">
+    <value>There are one or more conflicts present.</value>
+    <comment>REQUIRES TRANSLATION</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/de_DE.resX
+++ b/PluginCore/PluginCore/Resources/de_DE.resX
@@ -5965,8 +5965,9 @@ Eigene Sprachumgebungen müssen eine Erweiterung der Standard-Sprachumgebung sei
     <comment>Added after 5.0.2</comment>
   </data>
   <data name="FlashDevelop.Info.ShortcutConflictsPresent" xml:space="preserve">
-    <value>There are one or more conflicts present.</value>
+    <value>There are one or more conflicts present. Ignore and continue?</value>
     <comment>REQUIRES TRANSLATION</comment>
+  </data>
   <data name="ASCompletion.Info.NoContextGeneratorCode" xml:space="preserve">
     <value>No contextual code generation available.</value>
     <comment>REQUIRES TRANSLATION</comment>

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -5981,7 +5981,8 @@ Custom locales must be an extension of a default locale, e.g. en-US.</value>
     <comment>Added after 5.0.2</comment>
   </data>
   <data name="FlashDevelop.Info.ShortcutConflictsPresent" xml:space="preserve">
-    <value>There are one or more conflicts present.</value>
+    <value>There are one or more conflicts present. Ignore and continue?</value>
+  </data>
   <data name="ASCompletion.Info.NoContextGeneratorCode" xml:space="preserve">
     <value>No contextual code generation available.</value>
   </data>

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -5980,4 +5980,7 @@ Custom locales must be an extension of a default locale, e.g. en-US.</value>
     <value>Highlight word:</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Info.ShortcutConflictsPresent" xml:space="preserve">
+    <value>There are one or more conflicts present.</value>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/eu_ES.resX
+++ b/PluginCore/PluginCore/Resources/eu_ES.resX
@@ -5961,4 +5961,8 @@ Lokalizazio pertsonalizatuek lehenetsiaren luzapen bat izan behar dute, adb. en-
     <value>Highlight word:</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Info.ShortcutConflictsPresent" xml:space="preserve">
+    <value>There are one or more conflicts present.</value>
+    <comment>REQUIRES TRANSLATION</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/eu_ES.resX
+++ b/PluginCore/PluginCore/Resources/eu_ES.resX
@@ -5962,8 +5962,9 @@ Lokalizazio pertsonalizatuek lehenetsiaren luzapen bat izan behar dute, adb. en-
     <comment>Added after 5.0.2</comment>
   </data>
   <data name="FlashDevelop.Info.ShortcutConflictsPresent" xml:space="preserve">
-    <value>There are one or more conflicts present.</value>
+    <value>There are one or more conflicts present. Ignore and continue?</value>
     <comment>REQUIRES TRANSLATION</comment>
+  </data>
   <data name="ASCompletion.Info.NoContextGeneratorCode" xml:space="preserve">
     <value>No contextual code generation available.</value>
     <comment>REQUIRES TRANSLATION</comment>

--- a/PluginCore/PluginCore/Resources/ja_JP.resX
+++ b/PluginCore/PluginCore/Resources/ja_JP.resX
@@ -6022,4 +6022,8 @@ UseData:"</value>
     <value>Highlight word:</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Info.ShortcutConflictsPresent" xml:space="preserve">
+    <value>There are one or more conflicts present.</value>
+    <comment>REQUIRES TRANSLATION</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/ja_JP.resX
+++ b/PluginCore/PluginCore/Resources/ja_JP.resX
@@ -6023,8 +6023,9 @@ UseData:"</value>
     <comment>Added after 5.0.2</comment>
   </data>
   <data name="FlashDevelop.Info.ShortcutConflictsPresent" xml:space="preserve">
-    <value>There are one or more conflicts present.</value>
+    <value>There are one or more conflicts present. Ignore and continue?</value>
     <comment>REQUIRES TRANSLATION</comment>
+  </data>
   <data name="ASCompletion.Info.NoContextGeneratorCode" xml:space="preserve">
     <value>No contextual code generation available.</value>
     <comment>REQUIRES TRANSLATION</comment>

--- a/PluginCore/PluginCore/Resources/zh_CN.resx
+++ b/PluginCore/PluginCore/Resources/zh_CN.resx
@@ -5974,4 +5974,8 @@
     <value>Highlight word:</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Info.ShortcutConflictsPresent" xml:space="preserve">
+    <value>There are one or more conflicts present.</value>
+    <comment>REQUIRES TRANSLATION</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/zh_CN.resx
+++ b/PluginCore/PluginCore/Resources/zh_CN.resx
@@ -5975,8 +5975,9 @@
     <comment>Added after 5.0.2</comment>
   </data>
   <data name="FlashDevelop.Info.ShortcutConflictsPresent" xml:space="preserve">
-    <value>There are one or more conflicts present.</value>
+    <value>There are one or more conflicts present. Ignore and continue?</value>
     <comment>REQUIRES TRANSLATION</comment>
+  </data>
   <data name="ASCompletion.Info.NoContextGeneratorCode" xml:space="preserve">
     <value>No contextual code generation available.</value>
     <comment>REQUIRES TRANSLATION</comment>


### PR DESCRIPTION
As @Neverbirth suggested, closes #784.

The change fixes numerous bugs caused from the previous structure, and also adds new features:
 * All conflicts are highlighted in `Color.DarkRed`.

 * View custom shortcuts without moving your mouse to click the check box. Start the filter with the key `"*"`.
![image](https://cloud.githubusercontent.com/assets/13545633/11765478/02456d36-a1be-11e5-88b5-ceda6dedce97.png)

 * View all conflicts with the filter starting keyword `"?"`.
![image](https://cloud.githubusercontent.com/assets/13545633/11765483/21cda308-a1be-11e5-835f-08bbf2794683.png)

 * Have options filter keywords combined in any order.
![image](https://cloud.githubusercontent.com/assets/13545633/11765490/443de268-a1be-11e5-8b81-f5ddfb8ae74c.png)
![image](https://cloud.githubusercontent.com/assets/13545633/11765491/5324f0d2-a1be-11e5-9e6c-488742aa7c6b.png)

 * The dialog is now very very grumpy that it won't close until you resolve all conflicts. 
![image](https://cloud.githubusercontent.com/assets/13545633/11765494/6db140d6-a1be-11e5-8b2d-2a42f65be2a8.png)

 * All changes are only applied when the dialog closes.