### PR TITLE
When looking up keywords, verify they have spaces around

### DIFF
--- a/External/Plugins/ASCompletion/ASCompletion.csproj
+++ b/External/Plugins/ASCompletion/ASCompletion.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Completion\ArgumentsProcessor.cs" />
     <Compile Include="Completion\ASComplete.cs" />
     <Compile Include="Completion\ASGenerator.cs" />
+    <Compile Include="Completion\CodeUtils.cs" />
     <Compile Include="Completion\Reformater.cs" />
     <Compile Include="Completion\TemplateUtils.cs" />
     <Compile Include="Context\ASContext.cs" />

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -1257,20 +1257,43 @@ namespace ASCompletion.Completion
             return true;
         }
 
+        /// <summary>
+        /// Lookup type declaration keywords anywhere in the provided text
+        /// </summary>
         private static bool IsTypeDecl(string line, string[] typesKeywords)
         {
+            var max = line.Length - 1;
             foreach (string keyword in typesKeywords)
-                if (line.IndexOf(keyword) >= 0) return true;
+            {
+                var p = line.IndexOf(keyword);
+                if (p >= 0) 
+                {
+                    // verify keyword between spaces
+                    var end = p + keyword.Length;
+                    if ((p == 0 || line[p-1] <= 32) 
+                        && end < max && line[end] <= 32) return true;
+                }
+            }
             return false;
         }
 
+        /// <summary>
+        /// Look if the provided text starts with any declaration keyword
+        /// </summary>
         private static bool IsDeclaration(string line, ContextFeatures features)
         {
             foreach (string keyword in features.accessKeywords)
-                if (line.StartsWith(keyword)) return true;
+                if (line.StartsWith(keyword) && SpaceFollows(line, keyword)) return true;
             foreach (string keyword in features.declKeywords)
-                if (line.StartsWith(keyword)) return true;
+                if (line.StartsWith(keyword) && SpaceFollows(line, keyword)) return true;
             return false;
+        }
+
+        private static bool SpaceFollows(string line, string keyword)
+        {
+            var len = keyword.Length;
+            if (line.Length > len) return line[len] <= 32;
+            else return true;
         }
 
         #endregion

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -1229,13 +1229,13 @@ namespace ASCompletion.Completion
             while (tempLine > 0)
             {
                 tempText = Sci.GetLine(tempLine).Trim();
-                if (insideClass && IsTypeDecl(tempText, features.typesKeywords))
+                if (insideClass && CodeUtils.IsTypeDecl(tempText, features.typesKeywords))
                 {
                     tempIndent = Sci.GetLineIndentation(tempLine);
                     tab = tempIndent + Sci.TabWidth;
                     break;
                 }
-                if (tempText.Length > 0 && (tempText.EndsWith("}") || IsDeclaration(tempText, features)))
+                if (tempText.Length > 0 && (tempText.EndsWith("}") || CodeUtils.IsDeclaration(tempText, features)))
                 {
                     tempIndent = Sci.GetLineIndentation(tempLine);
                     tab = tempIndent;
@@ -1258,45 +1258,6 @@ namespace ASCompletion.Completion
             // show
             CompletionList.Show(known, autoHide, tail);
             return true;
-        }
-
-        /// <summary>
-        /// Lookup type declaration keywords anywhere in the provided text
-        /// </summary>
-        private static bool IsTypeDecl(string line, string[] typesKeywords)
-        {
-            var max = line.Length - 1;
-            foreach (string keyword in typesKeywords)
-            {
-                var p = line.IndexOf(keyword);
-                if (p >= 0) 
-                {
-                    // verify keyword between spaces
-                    var end = p + keyword.Length;
-                    if ((p == 0 || line[p-1] <= 32) 
-                        && end < max && line[end] <= 32) return true;
-                }
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Look if the provided text starts with any declaration keyword
-        /// </summary>
-        private static bool IsDeclaration(string line, ContextFeatures features)
-        {
-            foreach (string keyword in features.accessKeywords)
-                if (line.StartsWith(keyword) && SpaceFollows(line, keyword)) return true;
-            foreach (string keyword in features.declKeywords)
-                if (line.StartsWith(keyword) && SpaceFollows(line, keyword)) return true;
-            return false;
-        }
-
-        private static bool SpaceFollows(string line, string keyword)
-        {
-            var len = keyword.Length;
-            if (line.Length > len) return line[len] <= 32;
-            else return true;
         }
 
         #endregion

--- a/External/Plugins/ASCompletion/Completion/CodeUtils.cs
+++ b/External/Plugins/ASCompletion/Completion/CodeUtils.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ASCompletion.Completion
+{
+    static class CodeUtils
+    {
+        /// <summary>
+        /// Lookup type declaration keywords anywhere in the provided text
+        /// </summary>
+        public static bool IsTypeDecl(string line, string[] typesKeywords)
+        {
+            var max = line.Length - 1;
+            foreach (string keyword in typesKeywords)
+            {
+                var p = line.IndexOf(keyword);
+                if (p >= 0) return IsSpaceAt(line, p - 1) && IsSpaceAt(line, p + keyword.Length);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Look if the provided text starts with any declaration keyword
+        /// </summary>
+        public static bool IsDeclaration(string line, ContextFeatures features)
+        {
+            foreach (string keyword in features.accessKeywords)
+                if (line.StartsWith(keyword) && IsSpaceAt(line, keyword.Length)) return true;
+            foreach (string keyword in features.declKeywords)
+                if (line.StartsWith(keyword) && IsSpaceAt(line, keyword.Length)) return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Look if character after first word of line is whitespace
+        /// </summary>
+        public static bool IsSpaceAt(string line, int index)
+        {
+            if (index < 0 || index >= line.Length) return true;
+            else return line[index] <= 32;
+        }
+    }
+}


### PR DESCRIPTION
(eg. `classList` isn't a `class` declaration)

Fixes issue #960