### PR TITLE
Add packages/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ PluginCore/Bin
 /FlashDevelop/Bin/Debug/Exceptions.log
 /FlashDevelop/Bin/Debug/Tools/fdbuild/fdbuild.exe
 FlashDevelop/Bin/Debug/Settings/Themes/CURRENT
+packages/


### PR DESCRIPTION
The new unit test project from #1012 installs NuGet packages which leads to untracked files.