### PR TITLE
Fixed Scintilla loading

### DIFF
--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -1,13 +1,14 @@
 using System;
-using System.IO;
-using System.Text;
-using System.Drawing;
 using System.Collections;
-using System.Windows.Forms;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using ScintillaNet.Configuration;
+using System.ComponentModel;
+using System.Drawing;
 using System.Drawing.Printing;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows.Forms;
+using ScintillaNet.Configuration;
 using PluginCore.FRService;
 using PluginCore.Utilities;
 using PluginCore.Managers;
@@ -231,9 +232,15 @@ namespace ScintillaNet
                     hwndScintilla = CreateWindowEx(0, "Scintilla", "", WS_CHILD_VISIBLE_TABSTOP, 0, 0, this.Width, this.Height, this.Handle, 0, new IntPtr(0), null);
                     directPointer = (IntPtr)SlowPerform(2185, 0, 0);
                     IntPtr sciFunctionPointer = GetProcAddress(new HandleRef(null, lib), "Scintilla_DirectFunction");
-/*                    if (sciFunctionPointer == IntPtr.Zero)
-                        throw new Win32Exception(Resources.Exception_CannotCreateDirectFunction, new Win32Exception(Marshal.GetLastWin32Error()));
-*/
+                    if (sciFunctionPointer == IntPtr.Zero)
+                        sciFunctionPointer = GetProcAddress(new HandleRef(null, lib), "_Scintilla_DirectFunction@16");
+
+                    if (sciFunctionPointer == IntPtr.Zero)
+                    {
+                        string msg = "The Scintilla module has no export for the 'Scintilla_DirectFunction' procedure.";
+                        throw new Win32Exception(msg, new Win32Exception(Marshal.GetLastWin32Error()));
+                    }
+
                     _sciFunction = (Perform)Marshal.GetDelegateForFunctionPointer(
                         sciFunctionPointer,
                         typeof(Perform));


### PR DESCRIPTION
It seems to be related to how latest Scintilla in the repo has been compiled. Check here about this problem:

https://www.autoitscript.com/forum/topic/166711-compile-scilexer-library-x32x64-visual-studio-2010-2012-2013/

This PR fixes this case, but from reading around and checking latest ScintillaNet libraries, I'd say Scintilla should be recompiled.