### PR TITLE
Shortcut dialog

### DIFF
--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -77,7 +77,6 @@ namespace FlashDevelop.Dialogs
             this.searchLabel.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left;
             this.searchLabel.Location = new System.Drawing.Point(10, 10);
             this.searchLabel.Name = "searchLabel";
-            this.searchLabel.Text = "Search:";
             // 
             // filterTextBox
             // 
@@ -101,12 +100,10 @@ namespace FlashDevelop.Dialogs
             // 
             // idHeader
             // 
-            this.idHeader.Text = "Command";
             this.idHeader.Width = 350;
             // 
             // keyHeader
             // 
-            this.keyHeader.Text = "Shortcut";
             this.keyHeader.Width = 208;
             // 
             // listView
@@ -139,7 +136,6 @@ namespace FlashDevelop.Dialogs
             this.infoLabel.Location = new System.Drawing.Point(33, 380);
             this.infoLabel.Name = "infoLabel";
             this.infoLabel.Size = new System.Drawing.Size(243, 32);
-            this.infoLabel.Text = "Shortcuts can be edited by selecting an item and pressing valid menu item shortcut keys.";
             this.infoLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // openButton
@@ -172,7 +168,6 @@ namespace FlashDevelop.Dialogs
             this.closeButton.Name = "closeButton";
             this.closeButton.Size = new System.Drawing.Size(90, 23);
             this.closeButton.TabIndex = 5;
-            this.closeButton.Text = "Close";
             this.closeButton.UseVisualStyleBackColor = true;
             this.closeButton.Click += new System.EventHandler(this.CloseButtonClick);
             // 
@@ -182,7 +177,6 @@ namespace FlashDevelop.Dialogs
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.ShowInTaskbar = false;
-            this.Text = " Shortcuts";
             this.Name = "ShortcutDialog";
             this.AcceptButton = this.closeButton;
             this.CancelButton = this.closeButton;

--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -31,8 +31,8 @@ namespace FlashDevelop.Dialogs
         private System.Windows.Forms.TextBox filterTextBox;
         private System.Windows.Forms.Button clearButton;
         private System.Windows.Forms.Button closeButton;
-        private System.Windows.Forms.Button openButton;
-        private System.Windows.Forms.Button saveButton;
+        private System.Windows.Forms.Button importButton;
+        private System.Windows.Forms.Button exportButton;
 
         ShortcutDialog()
         {
@@ -65,8 +65,8 @@ namespace FlashDevelop.Dialogs
             this.listView = new System.Windows.Forms.ListView();
             this.pictureBox = new System.Windows.Forms.PictureBox();
             this.infoLabel = new System.Windows.Forms.Label();
-            this.openButton = new System.Windows.Forms.Button();
-            this.saveButton = new System.Windows.Forms.Button();
+            this.importButton = new System.Windows.Forms.Button();
+            this.exportButton = new System.Windows.Forms.Button();
             this.closeButton = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)this.pictureBox).BeginInit();
             this.SuspendLayout();
@@ -140,25 +140,25 @@ namespace FlashDevelop.Dialogs
             // 
             // openButton
             // 
-            this.openButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
-            this.saveButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.openButton.Location = new System.Drawing.Point(279, 381);
-            this.openButton.Name = "openButton";
-            this.openButton.Size = new System.Drawing.Size(100, 23);
-            this.openButton.TabIndex = 3;
-            this.openButton.UseVisualStyleBackColor = true;
-            this.openButton.Click += new System.EventHandler(this.SelectCustomShortcut);
+            this.importButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            this.importButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.importButton.Location = new System.Drawing.Point(279, 381);
+            this.importButton.Name = "openButton";
+            this.importButton.Size = new System.Drawing.Size(100, 23);
+            this.importButton.TabIndex = 3;
+            this.importButton.UseVisualStyleBackColor = true;
+            this.importButton.Click += new System.EventHandler(this.SelectCustomShortcut);
             // 
             // saveButton
             // 
-            this.saveButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
-            this.saveButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.saveButton.Location = new System.Drawing.Point(382, 381);
-            this.saveButton.Name = "saveButton";
-            this.saveButton.Size = new System.Drawing.Size(100, 23);
-            this.saveButton.TabIndex = 4;
-            this.saveButton.UseVisualStyleBackColor = true;
-            this.saveButton.Click += new System.EventHandler(this.SaveCustomShortcut);
+            this.exportButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            this.exportButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.exportButton.Location = new System.Drawing.Point(382, 381);
+            this.exportButton.Name = "saveButton";
+            this.exportButton.Size = new System.Drawing.Size(100, 23);
+            this.exportButton.TabIndex = 4;
+            this.exportButton.UseVisualStyleBackColor = true;
+            this.exportButton.Click += new System.EventHandler(this.SaveCustomShortcut);
             // 
             // closeButton
             // 
@@ -190,8 +190,8 @@ namespace FlashDevelop.Dialogs
             this.Controls.Add(this.listView);
             this.Controls.Add(this.pictureBox);
             this.Controls.Add(this.infoLabel);
-            this.Controls.Add(this.openButton);
-            this.Controls.Add(this.saveButton);
+            this.Controls.Add(this.importButton);
+            this.Controls.Add(this.exportButton);
             this.Controls.Add(this.closeButton);
             this.FormClosing += new FormClosingEventHandler(this.DialogClosing);
             this.FormClosed += new FormClosedEventHandler(this.DialogClosed);
@@ -247,8 +247,8 @@ namespace FlashDevelop.Dialogs
             this.keyHeader.Text = TextHelper.GetString("Label.Shortcut");
             this.infoLabel.Text = TextHelper.GetString("Info.ShortcutEditInfo");
             this.closeButton.Text = TextHelper.GetString("Label.Close");
-            this.openButton.Text = TextHelper.GetString("Label.Open");
-            this.saveButton.Text = TextHelper.GetString("Label.SaveAs");
+            this.importButton.Text = TextHelper.GetString("Label.Import");
+            this.exportButton.Text = TextHelper.GetString("Label.Export");
             this.searchLabel.Text = TextHelper.GetStringWithoutMnemonics("Label.Search") + ":";
             this.Text = " " + TextHelper.GetString("Title.Shortcuts");
         }

--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -250,7 +250,7 @@ namespace FlashDevelop.Dialogs
             this.closeButton.Text = TextHelper.GetString("Label.Close");
             this.importButton.Text = TextHelper.GetString("Label.Import");
             this.exportButton.Text = TextHelper.GetString("Label.Export");
-            this.searchLabel.Text = TextHelper.GetStringWithoutMnemonics("Label.Search") + ":";
+            this.searchLabel.Text = TextHelper.GetString("Label.ShortcutSearch");
             this.Text = " " + TextHelper.GetString("Title.Shortcuts");
         }
 

--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -124,7 +124,7 @@ namespace FlashDevelop.Dialogs
             // pictureBox
             // 
             this.pictureBox.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
-            this.pictureBox.Location = new System.Drawing.Point(12, 385);
+            this.pictureBox.Location = new System.Drawing.Point(12, 388);
             this.pictureBox.Name = "pictureBox";
             this.pictureBox.Size = new System.Drawing.Size(16, 16);
             this.pictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
@@ -211,15 +211,8 @@ namespace FlashDevelop.Dialogs
         /// </summary>
         void InitializeGraphics()
         {
-            using (var imageList = new ImageList())
-            {
-                imageList.ColorDepth = ColorDepth.Depth32Bit;
-                imageList.ImageSize = ScaleHelper.Scale(new Size(16, 16));
-                imageList.Images.Add(Globals.MainForm.FindImage("229", false));
-                imageList.Images.Add(Globals.MainForm.FindImage("153", false));
-                this.pictureBox.Image = imageList.Images[0];
-                this.clearButton.Image = imageList.Images[1];
-            }
+            this.pictureBox.Image = Globals.MainForm.FindImage16("229", false);
+            this.clearButton.Image = Globals.MainForm.FindImage16("153", false);
         }
 
         /// <summary>

--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.IO;
 using System.Windows.Forms;
 using FlashDevelop.Managers;
+using PluginCore;
 using PluginCore.Controls;
 using PluginCore.Helpers;
 using PluginCore.Localization;
@@ -363,13 +364,13 @@ namespace FlashDevelop.Dialogs
         /// </summary>
         static string ExtractFilterKeywords(string filter, ref bool viewCustom, ref bool viewConflicts)
         {
-            if (!viewCustom && filter.Length != 0 && filter[0] == ViewCustomKey)
+            if (!viewCustom && filter.StartsWith(ViewCustomKey))
             {
                 filter = filter.Substring(1);
                 viewCustom = true;
                 return ExtractFilterKeywords(filter, ref viewCustom, ref viewConflicts);
             }
-            if (!viewConflicts && filter.Length != 0 && filter[0] == ViewConflictsKey)
+            if (!viewConflicts && filter.StartsWith(ViewConflictsKey))
             {
                 filter = filter.Substring(1);
                 viewConflicts = true;

--- a/FlashDevelop/Dialogs/ShortcutDialog.cs
+++ b/FlashDevelop/Dialogs/ShortcutDialog.cs
@@ -57,19 +57,47 @@ namespace FlashDevelop.Dialogs
         /// </summary>
         private void InitializeComponent()
         {
-            this.listView = new System.Windows.Forms.ListView();
+            this.searchLabel = new System.Windows.Forms.Label();
+            this.filterTextBox = new System.Windows.Forms.TextBox();
+            this.clearButton = new System.Windows.Forms.Button();
             this.idHeader = new System.Windows.Forms.ColumnHeader();
             this.keyHeader = new System.Windows.Forms.ColumnHeader();
-            this.closeButton = new System.Windows.Forms.Button();
+            this.listView = new System.Windows.Forms.ListView();
             this.pictureBox = new System.Windows.Forms.PictureBox();
             this.infoLabel = new System.Windows.Forms.Label();
-            this.searchLabel = new System.Windows.Forms.Label();
-            this.clearButton = new System.Windows.Forms.Button();
-            this.filterTextBox = new System.Windows.Forms.TextBox();
             this.openButton = new System.Windows.Forms.Button();
             this.saveButton = new System.Windows.Forms.Button();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).BeginInit();
+            this.closeButton = new System.Windows.Forms.Button();
+            ((System.ComponentModel.ISupportInitialize)this.pictureBox).BeginInit();
             this.SuspendLayout();
+            // 
+            // searchLabel
+            // 
+            this.searchLabel.AutoSize = true;
+            this.searchLabel.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left;
+            this.searchLabel.Location = new System.Drawing.Point(10, 10);
+            this.searchLabel.Name = "searchLabel";
+            this.searchLabel.Text = "Search:";
+            // 
+            // filterTextBox
+            // 
+            this.filterTextBox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            this.filterTextBox.Location = new System.Drawing.Point(12, 32);
+            this.filterTextBox.Name = "filterTextBox";
+            this.filterTextBox.Size = new System.Drawing.Size(531, 20);
+            this.filterTextBox.TabIndex = 0;
+            this.filterTextBox.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.filterTextBox.TextChanged += new System.EventHandler(this.FilterTextChanged);
+            // 
+            // clearButton
+            // 
+            this.clearButton.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            this.clearButton.Location = new System.Drawing.Point(549, 30);
+            this.clearButton.Name = "clearButton";
+            this.clearButton.Size = new System.Drawing.Size(26, 23);
+            this.clearButton.TabIndex = 1;
+            this.clearButton.UseVisualStyleBackColor = true;
+            this.clearButton.Click += new System.EventHandler(this.ClearFilterClick);
             // 
             // idHeader
             // 
@@ -83,94 +111,70 @@ namespace FlashDevelop.Dialogs
             // 
             // listView
             // 
-            this.listView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-            this.listView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {this.idHeader, this.keyHeader});
+            this.listView.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            this.listView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] { this.idHeader, this.keyHeader });
             this.listView.GridLines = true;
             this.listView.FullRowSelect = true;
-            this.listView.Location = new System.Drawing.Point(12, 70);
+            this.listView.Location = new System.Drawing.Point(12, 62);
             this.listView.MultiSelect = false;
             this.listView.Name = "listView";
-            this.listView.Size = new System.Drawing.Size(562, 304);
-            this.listView.TabIndex = 4;
+            this.listView.Size = new System.Drawing.Size(562, 312);
+            this.listView.TabIndex = 2;
             this.listView.UseCompatibleStateImageBehavior = false;
             this.listView.View = System.Windows.Forms.View.Details;
             this.listView.KeyDown += new KeyEventHandler(this.ListViewKeyDown);
             // 
-            // closeButton
-            // 
-            this.closeButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.closeButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.closeButton.Location = new System.Drawing.Point(485, 381);
-            this.closeButton.Name = "closeButton";
-            this.closeButton.Size = new System.Drawing.Size(90, 23);
-            this.closeButton.TabIndex = 0;
-            this.closeButton.Text = "Close";
-            this.closeButton.UseVisualStyleBackColor = true;
-            this.closeButton.Click += new System.EventHandler(this.CloseButtonClick);
-            // 
             // pictureBox
             // 
-            this.pictureBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.pictureBox.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
             this.pictureBox.Location = new System.Drawing.Point(12, 385);
             this.pictureBox.Name = "pictureBox";
             this.pictureBox.Size = new System.Drawing.Size(16, 16);
             this.pictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            this.pictureBox.TabIndex = 5;
             this.pictureBox.TabStop = false;
             // 
             // infoLabel
             // 
-            this.infoLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-            this.infoLabel.Location = new System.Drawing.Point(33, 386);
+            this.infoLabel.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            this.infoLabel.Location = new System.Drawing.Point(33, 380);
             this.infoLabel.Name = "infoLabel";
-            this.infoLabel.Size = new System.Drawing.Size(446, 16);
-            this.infoLabel.TabIndex = 6;
+            this.infoLabel.Size = new System.Drawing.Size(243, 32);
             this.infoLabel.Text = "Shortcuts can be edited by selecting an item and pressing valid menu item shortcut keys.";
-            // 
-            // searchLabel
-            // 
-            this.searchLabel.AutoSize = true;
-            this.searchLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
-            this.searchLabel.Location = new System.Drawing.Point(10, 25);
-            this.searchLabel.Name = "searchLabel";
-            this.searchLabel.TabIndex = 0;
-            this.searchLabel.Text = "Search:";
-            // 
-            // clearButton
-            // 
-            this.clearButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.clearButton.Location = new System.Drawing.Point(549, 39);
-            this.clearButton.Name = "clearButton";
-            this.clearButton.Size = new System.Drawing.Size(26, 23);
-            this.clearButton.TabIndex = 2;
-            this.clearButton.UseVisualStyleBackColor = true;
-            this.clearButton.Click += new System.EventHandler(this.ClearFilterClick);
-            // 
-            // filterTextBox
-            // 
-            this.filterTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-            this.filterTextBox.Location = new System.Drawing.Point(12, 41);
-            this.filterTextBox.Name = "filterTextBox";
-            this.filterTextBox.Size = new System.Drawing.Size(531, 20);
-            this.filterTextBox.TabIndex = 1;
-            this.filterTextBox.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.filterTextBox.TextChanged += new System.EventHandler(this.FilterTextChanged);
+            this.infoLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // openButton
             // 
-            this.openButton.Location = new System.Drawing.Point(369, 12);
+            this.openButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            this.saveButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.openButton.Location = new System.Drawing.Point(279, 381);
             this.openButton.Name = "openButton";
             this.openButton.Size = new System.Drawing.Size(100, 23);
+            this.openButton.TabIndex = 3;
             this.openButton.UseVisualStyleBackColor = true;
-            this.openButton.Click += new System.EventHandler(SelectCustomShortcut);
+            this.openButton.Click += new System.EventHandler(this.SelectCustomShortcut);
             // 
             // saveButton
             // 
-            this.saveButton.Location = new System.Drawing.Point(475, 12);
+            this.saveButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            this.saveButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.saveButton.Location = new System.Drawing.Point(382, 381);
             this.saveButton.Name = "saveButton";
             this.saveButton.Size = new System.Drawing.Size(100, 23);
+            this.saveButton.TabIndex = 4;
             this.saveButton.UseVisualStyleBackColor = true;
-            this.saveButton.Click += new System.EventHandler(SaveCustomShortcut);
+            this.saveButton.Click += new System.EventHandler(this.SaveCustomShortcut);
+            // 
+            // closeButton
+            // 
+            this.closeButton.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            this.closeButton.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.closeButton.Location = new System.Drawing.Point(485, 381);
+            this.closeButton.Name = "closeButton";
+            this.closeButton.Size = new System.Drawing.Size(90, 23);
+            this.closeButton.TabIndex = 5;
+            this.closeButton.Text = "Close";
+            this.closeButton.UseVisualStyleBackColor = true;
+            this.closeButton.Click += new System.EventHandler(this.CloseButtonClick);
             // 
             // ShortcutDialog
             // 
@@ -186,20 +190,20 @@ namespace FlashDevelop.Dialogs
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(586, 416);
             this.MinimumSize = new System.Drawing.Size(400, 250);
-            this.Controls.Add(this.saveButton);
-            this.Controls.Add(this.openButton);
+            this.Controls.Add(this.searchLabel);
             this.Controls.Add(this.filterTextBox);
             this.Controls.Add(this.clearButton);
-            this.Controls.Add(this.infoLabel);
-            this.Controls.Add(this.pictureBox);
-            this.Controls.Add(this.closeButton);
             this.Controls.Add(this.listView);
-            this.Controls.Add(this.searchLabel);
+            this.Controls.Add(this.pictureBox);
+            this.Controls.Add(this.infoLabel);
+            this.Controls.Add(this.openButton);
+            this.Controls.Add(this.saveButton);
+            this.Controls.Add(this.closeButton);
             this.FormClosing += new FormClosingEventHandler(this.DialogClosing);
             this.FormClosed += new FormClosedEventHandler(this.DialogClosed);
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)this.pictureBox).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
         }

--- a/PluginCore/PluginCore/Resources/de_DE.resX
+++ b/PluginCore/PluginCore/Resources/de_DE.resX
@@ -5984,4 +5984,8 @@ Eigene Sprachumgebungen müssen eine Erweiterung der Standard-Sprachumgebung sei
     <value>&amp;Import</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Label.ShortcutSearch" xml:space="preserve">
+    <value>Search: (Tip: Start the filter with * to view custom only, and ? to view conflicts only.)</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/de_DE.resX
+++ b/PluginCore/PluginCore/Resources/de_DE.resX
@@ -5976,4 +5976,12 @@ Eigene Sprachumgebungen müssen eine Erweiterung der Standard-Sprachumgebung sei
     <value>Move...</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Label.Export" xml:space="preserve">
+    <value>&amp;Export</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
+  <data name="FlashDevelop.Label.Import" xml:space="preserve">
+    <value>&amp;Import</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -5990,4 +5990,12 @@ Custom locales must be an extension of a default locale, e.g. en-US.</value>
     <value>Move...</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Label.Export" xml:space="preserve">
+    <value>&amp;Export</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
+  <data name="FlashDevelop.Label.Import" xml:space="preserve">
+    <value>&amp;Import</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -5998,4 +5998,8 @@ Custom locales must be an extension of a default locale, e.g. en-US.</value>
     <value>&amp;Import</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Label.ShortcutSearch" xml:space="preserve">
+    <value>Search: (Tip: Start the filter with * to view custom only, and ? to view conflicts only.)</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/eu_ES.resX
+++ b/PluginCore/PluginCore/Resources/eu_ES.resX
@@ -5981,4 +5981,8 @@ Lokalizazio pertsonalizatuek lehenetsiaren luzapen bat izan behar dute, adb. en-
     <value>&amp;Import</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Label.ShortcutSearch" xml:space="preserve">
+    <value>Search: (Tip: Start the filter with * to view custom only, and ? to view conflicts only.)</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/eu_ES.resX
+++ b/PluginCore/PluginCore/Resources/eu_ES.resX
@@ -5973,4 +5973,12 @@ Lokalizazio pertsonalizatuek lehenetsiaren luzapen bat izan behar dute, adb. en-
     <value>Move...</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Label.Export" xml:space="preserve">
+    <value>&amp;Export</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
+  <data name="FlashDevelop.Label.Import" xml:space="preserve">
+    <value>&amp;Import</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/ja_JP.resX
+++ b/PluginCore/PluginCore/Resources/ja_JP.resX
@@ -6042,4 +6042,8 @@ UseData:"</value>
     <value>&amp;Import</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Label.ShortcutSearch" xml:space="preserve">
+    <value>Search: (Tip: Start the filter with * to view custom only, and ? to view conflicts only.)</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/ja_JP.resX
+++ b/PluginCore/PluginCore/Resources/ja_JP.resX
@@ -6034,4 +6034,12 @@ UseData:"</value>
     <value>Move...</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Label.Export" xml:space="preserve">
+    <value>&amp;Export</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
+  <data name="FlashDevelop.Label.Import" xml:space="preserve">
+    <value>&amp;Import</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/ko_KR.resX
+++ b/PluginCore/PluginCore/Resources/ko_KR.resX
@@ -6001,4 +6001,8 @@ Complete: 현재 파일, 프로젝트 파일 및 수동 새로 고침.</value>
     <value>불러오기 (&amp;I)</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Label.ShortcutSearch" xml:space="preserve">
+    <value>검색: (Tip: 필터를 *로 시작하면 수정된 항목만, ?로 시작하면 충돌하는 항목만 검색할 수 있습니다.)</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/ko_KR.resX
+++ b/PluginCore/PluginCore/Resources/ko_KR.resX
@@ -5993,4 +5993,12 @@ Complete: 현재 파일, 프로젝트 파일 및 수동 새로 고침.</value>
     <value>Move...</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Label.Export" xml:space="preserve">
+    <value>내보내기 (&amp;E)</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
+  <data name="FlashDevelop.Label.Import" xml:space="preserve">
+    <value>불러오기 (&amp;I)</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/zh_CN.resx
+++ b/PluginCore/PluginCore/Resources/zh_CN.resx
@@ -5986,4 +5986,12 @@
     <value>Move...</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Label.Export" xml:space="preserve">
+    <value>&amp;Export</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
+  <data name="FlashDevelop.Label.Import" xml:space="preserve">
+    <value>&amp;Import</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/zh_CN.resx
+++ b/PluginCore/PluginCore/Resources/zh_CN.resx
@@ -5994,4 +5994,8 @@
     <value>&amp;Import</value>
     <comment>Added after 5.0.2</comment>
   </data>
+  <data name="FlashDevelop.Label.ShortcutSearch" xml:space="preserve">
+    <value>Search: (Tip: Start the filter with * to view custom only, and ? to view conflicts only.)</value>
+    <comment>Added after 5.0.2</comment>
+  </data>
 </root>


### PR DESCRIPTION
- Reordered controls inside ShortcutDialog.
- Removed hardcoded strings as they will be overridden by localisation.
- Use FindImage16() for the images.
- Open, Save As -> Import, Export
- Use string.StartsWith(char) extension method.
- Conflicts warning does not show on dialog load.
- Revert All To Default does not trigger conflicts warning to show up (althought imho there should be no conflicts among the default shortcuts).
- Conflicts warning shows up after the listview is updated when custom shortcuts are imported.
- Added a tip to the search label.
![image](https://cloud.githubusercontent.com/assets/13545633/12805387/d62c4bae-cb5f-11e5-98b5-9bc9f533d050.png)
