### PR TITLE
Fix NRE if the position service returns an error.

### DIFF
--- a/External/Plugins/HaXeContext/Completion/HaxeComplete.cs
+++ b/External/Plugins/HaXeContext/Completion/HaxeComplete.cs
@@ -67,7 +67,7 @@ namespace HaXeContext
 
         public void GetPosition(HaxeCompleteResultHandler<HaxePositionResult> callback)
         {
-            StartThread(callback, () => positionResults.Count > 0 ? positionResults[0] : null);
+            StartThread(callback, () => positionResults != null && positionResults.Count > 0 ? positionResults[0] : null);
         }
 
         public void GetUsages(HaxeCompleteResultHandler<List<HaxePositionResult>> callback)


### PR DESCRIPTION
If the position service returns an error positionResults is not initialized and later throws an error, and since the error is in a thread, FlashDevelop completely crashes.