### PR TITLE
Add metadata to the current class, not the file model.

### DIFF
--- a/External/Plugins/AS3Context/AbcConverter.cs
+++ b/External/Plugins/AS3Context/AbcConverter.cs
@@ -150,7 +150,7 @@ namespace AS3Context
                         {
                             ASDocItem doc = thisDocs[docPath];
                             applyASDoc(doc, type);
-                            if (doc.Meta != null) model.MetaDatas = doc.Meta;
+                            if (doc.Meta != null) type.MetaDatas = doc.Meta;
                         }
                         if (model.Package.Length == 0) docPath = type.Name;
                     }
@@ -985,6 +985,8 @@ namespace AS3Context
                     ReadPrologMetadataApiVersion(doc);
                 else if (Name == "styles")
                     ReadPrologMetadataStyles(doc);
+                else if (Name == "DefaultProperty")
+                    ReadPrologMetadataDefaultProperty(doc);
                 Read();
             }
         }
@@ -1050,6 +1052,23 @@ namespace AS3Context
                     ReadStyleMeta(doc);
                 Read();
             }
+        }
+
+        private void ReadPrologMetadataDefaultProperty(ASDocItem doc)
+        {
+            ASMetaData meta = new ASMetaData("DefaultProperty");
+            meta.Kind = ASMetaKind.DefaultProperty;
+            meta.Comments = "";
+
+            meta.Params = new Dictionary<string, string>();
+
+            string defValue = GetAttribute("name");
+            meta.Params["default"] = defValue;
+
+            meta.RawParams = string.Format("\"{0}\"", defValue);
+
+            if (doc.Meta == null) doc.Meta = new List<ASMetaData>();
+            doc.Meta.Add(meta);
         }
 
         private void ReadPrologCustoms(ASDocItem doc, string terminationNode)

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -1696,10 +1696,9 @@ namespace ASCompletion.Completion
             List<ASMetaData> events = new List<ASMetaData>();
             while (ofClass != null && !ofClass.IsVoid())
             {
-                FileModel inFile = ofClass.InFile;
-                if (inFile.MetaDatas != null)
+                if (ofClass.MetaDatas != null)
                 {
-                    foreach (ASMetaData meta in inFile.MetaDatas)
+                    foreach (ASMetaData meta in ofClass.MetaDatas)
                         if (meta.Kind == ASMetaKind.Event) events.Add(meta);
                 }
                 ofClass = ofClass.Extends;

--- a/External/Plugins/ASCompletion/Model/ASFileParser.cs
+++ b/External/Plugins/ASCompletion/Model/ASFileParser.cs
@@ -722,10 +722,18 @@ namespace ASCompletion.Model
                                 if (token == "include")
                                 {
                                     string inc = ba.Substring(tokPos, i - tokPos);
-                                    if (model.MetaDatas == null) model.MetaDatas = new List<ASMetaData>();
                                     ASMetaData meta = new ASMetaData("Include");
                                     meta.ParseParams(inc);
-                                    model.MetaDatas.Add(meta);
+                                    if (curClass == null)
+                                    {
+                                        if (carriedMetaData == null) carriedMetaData = new List<ASMetaData>();
+                                        carriedMetaData.Add(meta);
+                                    }
+                                    else
+                                    {
+                                        if (curClass.MetaDatas == null) curClass.MetaDatas = new List<ASMetaData>();
+                                        curClass.MetaDatas.Add(meta);
+                                    }
                                 }
                             }
                         }
@@ -2272,10 +2280,10 @@ namespace ASCompletion.Model
                         }
                         if (carriedMetaData != null)
                         {
-                            if (model.MetaDatas == null)
-                                model.MetaDatas = carriedMetaData;
+                            if (curClass.MetaDatas == null)
+                                curClass.MetaDatas = carriedMetaData;
                             else
-                                foreach (var meta in carriedMetaData) model.MetaDatas.Add(meta);
+                                foreach (var meta in carriedMetaData) curClass.MetaDatas.Add(meta);
 
                             carriedMetaData = null;
                         }

--- a/External/Plugins/ASCompletion/Model/ClassModel.cs
+++ b/External/Plugins/ASCompletion/Model/ClassModel.cs
@@ -322,7 +322,10 @@ namespace ASCompletion.Model
                     return sb.ToString();
                 }
             }*/
-
+            
+            // META
+            ASMetaData.GenerateIntrinsic(MetaDatas, sb, nl, tab0);
+            
             // CLASS
             sb.Append(CommentDeclaration(Comments, tab0)).Append(tab0);
             if (!caching && InFile.Version != 3 && (this.Flags & (FlagType.Intrinsic | FlagType.Interface)) == 0)


### PR DESCRIPTION
This is more correct as metadata is part of the class, not the file, and you may have multiple classes with independent metadatas, before this wouldn't work at all.

For the sake of completeness, added "Default" metadata parsing from SWC files.