### PR TITLE
Parsing fix

### DIFF
--- a/External/Plugins/ASCompletion/Model/ASFileParser.cs
+++ b/External/Plugins/ASCompletion/Model/ASFileParser.cs
@@ -1124,6 +1124,7 @@ namespace ASCompletion.Model
                         }
                         curMember.Type = param;
                         length = 0;
+                        inType = false;
                     }
                     // AS3 const or method parameter's default value 
                     else if (version > 2 && (curMember.Flags & FlagType.Variable) > 0)

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -166,6 +166,7 @@
     <EmbeddedResource Include="Test Files\generated\as3\BeforeFieldFromParameterWithWrongSuperConstructor.as" />
     <EmbeddedResource Include="Test Files\parser\as3\IdentifiersWithUnicodeCharsTest.as" />
     <EmbeddedResource Include="Test Files\parser\haxe\MetadataTest.hx" />
+    <EmbeddedResource Include="Test Files\parser\haxe\MethodAfterGenericReturnTest.hx" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">

--- a/Tests/External/Plugins/ASCompletion.Tests/Model/ASFileParserTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Model/ASFileParserTests.cs
@@ -1530,6 +1530,67 @@ namespace ASCompletion.Model
                 }
             }
 
+            [Test(Description="Issue 1075")]
+            public void ParseFile_MethodAfterGenericReturn()
+            {
+                using (var resourceFile = new TestFile("ASCompletion.Test_Files.parser.haxe.MethodAfterGenericReturnTest.hx"))
+                {
+                    var srcModel = new FileModel(resourceFile.DestinationFile);
+                    srcModel.Context = new HaXeContext.Context(new HaXeContext.HaXeSettings());
+                    var model = ASFileParser.ParseFile(srcModel);
+                    var classModel = model.Classes[0];
+                    Assert.AreEqual("Test", classModel.Name);
+                    Assert.AreEqual(FlagType.Class, classModel.Flags & FlagType.Class);
+                    Assert.AreEqual(2, classModel.LineFrom);
+                    Assert.AreEqual(19, classModel.LineTo);
+                    Assert.AreEqual(4, classModel.Members.Count);
+
+                    var memberModel = classModel.Members[0];
+                    Assert.AreEqual("retMethod", memberModel.Name);
+                    Assert.AreEqual("Array<Dynamic>", memberModel.Type);
+                    var flags = FlagType.Function;
+                    Assert.AreEqual(flags, memberModel.Flags & flags);
+                    Assert.AreEqual(4, memberModel.LineFrom);
+                    Assert.AreEqual(6, memberModel.LineTo);
+
+                    memberModel = classModel.Members[1];
+                    Assert.AreEqual("func", memberModel.Name);
+                    Assert.AreEqual("Void", memberModel.Type);
+                    flags = FlagType.Function;
+                    Assert.AreEqual(flags, memberModel.Flags & flags);
+                    Assert.AreEqual(8, memberModel.LineFrom);
+                    Assert.AreEqual(10, memberModel.LineTo);
+                    Assert.AreEqual(1, memberModel.Parameters.Count);
+                    Assert.AreEqual("arg", memberModel.Parameters[0].Name);
+                    Assert.AreEqual("String", memberModel.Parameters[0].Type);
+
+                    memberModel = classModel.Members[2];
+                    Assert.AreEqual("retMethod2", memberModel.Name);
+                    Assert.AreEqual("{x:Int, y:Int}", memberModel.Type);
+                    flags = FlagType.Function;
+                    Assert.AreEqual(flags, memberModel.Flags & flags);
+                    Assert.AreEqual(12, memberModel.LineFrom);
+                    Assert.AreEqual(14, memberModel.LineTo);
+                    Assert.IsNull(memberModel.Parameters);
+
+                    memberModel = classModel.Members[3];
+                    Assert.AreEqual("func2", memberModel.Name);
+                    Assert.AreEqual("Void", memberModel.Type);
+                    flags = FlagType.Function;
+                    Assert.AreEqual(flags, memberModel.Flags & flags);
+                    Assert.AreEqual(16, memberModel.LineFrom);
+                    Assert.AreEqual(18, memberModel.LineTo);
+                    Assert.AreEqual(3, memberModel.Parameters.Count);
+                    Assert.AreEqual("arg", memberModel.Parameters[0].Name);
+                    Assert.AreEqual("Array<Dynamic>", memberModel.Parameters[0].Type);
+                    Assert.AreEqual("arg2", memberModel.Parameters[1].Name);
+                    Assert.AreEqual("Array<String>", memberModel.Parameters[1].Type);
+                    Assert.AreEqual("null", memberModel.Parameters[1].Value);
+                    Assert.AreEqual("arg3", memberModel.Parameters[2].Name);
+                    Assert.AreEqual("String", memberModel.Parameters[2].Type);
+                }
+            }
+
             [Test]
             public void ParseFile_IdentifiersWithUnicodeChars()
             {

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/parser/haxe/MethodAfterGenericReturnTest.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/parser/haxe/MethodAfterGenericReturnTest.hx
@@ -1,0 +1,20 @@
+package test.test;
+
+class Test
+{
+	function retMethod():Array<Dynamic>
+	{
+	}
+
+	function func(arg:String):Void
+	{
+	}
+	
+	function retMethod2():{x:Int, y:Int}
+	{
+	}
+
+	function func2(arg:Array<Dynamic>, arg2:Array<String> = null, arg3:String):Void
+	{
+	}
+}


### PR DESCRIPTION
Fixes #1075. This only happened if the following member was missing any accessor, and could also happen with anonymous types under the same conditions.