### PR TITLE
Clear current member at the final } if it's a method

### DIFF
--- a/External/Plugins/ASCompletion/Model/ASFileParser.cs
+++ b/External/Plugins/ASCompletion/Model/ASFileParser.cs
@@ -952,6 +952,7 @@ namespace ASCompletion.Model
                         braceCount--;
                         if (braceCount == 0 && curMethod != null)
                         {
+                            if (curMember.Equals(curMethod)) curMember = null;
                             curMethod.LineTo = line;
                             curMethod = null;
                         }

--- a/External/Plugins/ASCompletion/Model/ASFileParser.cs
+++ b/External/Plugins/ASCompletion/Model/ASFileParser.cs
@@ -952,7 +952,7 @@ namespace ASCompletion.Model
                         braceCount--;
                         if (braceCount == 0 && curMethod != null)
                         {
-                            if (curMember.Equals(curMethod)) curMember = null;
+                            if (curMethod.Equals(curMember)) curMember = null;
                             curMethod.LineTo = line;
                             curMethod = null;
                         }

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -111,6 +111,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <EmbeddedResource Include="Test Files\parser\haxe\WrongSyntaxCompilerMetaAfterMethodWithNoType.hx" />
     <Compile Include="TestUtils\ContextExtensions.cs" />
     <Compile Include="TestUtils\TestFile.cs" />
   </ItemGroup>

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -168,6 +168,7 @@
     <EmbeddedResource Include="Test Files\parser\as3\IdentifiersWithUnicodeCharsTest.as" />
     <EmbeddedResource Include="Test Files\parser\haxe\MetadataTest.hx" />
     <EmbeddedResource Include="Test Files\parser\haxe\MethodAfterGenericReturnTest.hx" />
+    <EmbeddedResource Include="Test Files\parser\haxe\WrongSyntaxCompilerMetaAfterVarWithNoType.hx" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">

--- a/Tests/External/Plugins/ASCompletion.Tests/Model/ASFileParserTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Model/ASFileParserTests.cs
@@ -1745,6 +1745,36 @@ namespace ASCompletion.Model
                     Assert.AreEqual("TemplateBuilder.build('\r\n    <div class=\"mycomponent\"></div>')", classModel.MetaDatas[1].Params["Default"]);
                 }
             }
+
+            [Test]
+            public void ParseFile_WrongSyntaxCompilerMetaAfterMethodWithNoType()
+            {
+                using (var resourceFile = new TestFile("ASCompletion.Test_Files.parser.haxe.WrongSyntaxCompilerMetaAfterMethodWithNoType.hx"))
+                {
+                    var srcModel = new FileModel(resourceFile.DestinationFile);
+                    srcModel.Context = new HaXeContext.Context(new HaXeContext.HaXeSettings());
+                    var model = ASFileParser.ParseFile(srcModel);
+                    var classModel = model.Classes[0];
+                    Assert.AreEqual("WrongSyntaxMetadataTest", classModel.Name);
+                    Assert.AreEqual(FlagType.Class, classModel.Flags & FlagType.Class);
+                    Assert.AreEqual(2, classModel.LineFrom);
+                    //I'd say this should be possible
+                    //Assert.AreEqual(9, classModel.LineTo);
+                    Assert.AreEqual(1, classModel.Members.Count);
+
+                    var memberModel = classModel.Members[0];
+                    Assert.AreEqual("func", memberModel.Name);
+                    Assert.AreEqual(null, memberModel.Type);
+                    var flags = FlagType.Function;
+                    Assert.AreEqual(flags, memberModel.Flags & flags);
+                    Assert.AreEqual(Visibility.Private, memberModel.Access & Visibility.Private);
+                    Assert.AreEqual(6, memberModel.LineFrom);
+                    Assert.AreEqual(8, memberModel.LineTo);
+                    Assert.AreEqual(" Dummy data to make sure this method keeps values at the end of the parsing ", memberModel.Comments);
+                    Assert.AreEqual("dummy", memberModel.MetaDatas[0].Name);
+                }
+            }
+
         }
     }
 }

--- a/Tests/External/Plugins/ASCompletion.Tests/Model/ASFileParserTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Model/ASFileParserTests.cs
@@ -1760,7 +1760,7 @@ namespace ASCompletion.Model
                     Assert.AreEqual(2, classModel.LineFrom);
                     //I'd say this should be possible
                     //Assert.AreEqual(9, classModel.LineTo);
-                    Assert.AreEqual(1, classModel.Members.Count);
+                    Assert.AreEqual(2, classModel.Members.Count);
 
                     var memberModel = classModel.Members[0];
                     Assert.AreEqual("func", memberModel.Name);
@@ -1775,6 +1775,35 @@ namespace ASCompletion.Model
                 }
             }
 
+            [Test]
+            [Ignore("Not working for now")]
+            public void ParseFile_WrongSyntaxCompilerMetaAfterVarWithNoType()
+            {
+                using (var resourceFile = new TestFile("ASCompletion.Test_Files.parser.haxe.WrongSyntaxCompilerMetaAfterVarWithNoType.hx"))
+                {
+                    var srcModel = new FileModel(resourceFile.DestinationFile);
+                    srcModel.Context = new HaXeContext.Context(new HaXeContext.HaXeSettings());
+                    var model = ASFileParser.ParseFile(srcModel);
+                    var classModel = model.Classes[0];
+                    Assert.AreEqual("WrongSyntaxMetadataTest", classModel.Name);
+                    Assert.AreEqual(FlagType.Class, classModel.Flags & FlagType.Class);
+                    Assert.AreEqual(2, classModel.LineFrom);
+                    //I'd say this should be possible
+                    //Assert.AreEqual(9, classModel.LineTo);
+                    Assert.AreEqual(2, classModel.Members.Count);
+
+                    var memberModel = classModel.Members[0];
+                    Assert.AreEqual("func", memberModel.Name);
+                    Assert.AreEqual(null, memberModel.Type);
+                    var flags = FlagType.Variable;
+                    Assert.AreEqual(flags, memberModel.Flags & flags);
+                    Assert.AreEqual(Visibility.Private, memberModel.Access & Visibility.Private);
+                    Assert.AreEqual(6, memberModel.LineFrom);
+                    Assert.AreEqual(6, memberModel.LineTo);
+                    Assert.AreEqual(" Dummy data to make sure this method keeps values at the end of the parsing ", memberModel.Comments);
+                    Assert.AreEqual("dummy", memberModel.MetaDatas[0].Name);
+                }
+            }
         }
     }
 }

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/parser/haxe/WrongSyntaxCompilerMetaAfterMethodWithNoType.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/parser/haxe/WrongSyntaxCompilerMetaAfterMethodWithNoType.hx
@@ -1,0 +1,12 @@
+﻿package test.test;
+
+class WrongSyntaxMetadataTest
+{
+	/** Dummy data to make sure this method keeps values at the end of the parsing **/
+    @dummy
+    private function func()
+    {
+    }
+
+    @:allow(flixel
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/parser/haxe/WrongSyntaxCompilerMetaAfterVarWithNoType.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/parser/haxe/WrongSyntaxCompilerMetaAfterVarWithNoType.hx
@@ -4,9 +4,7 @@ class WrongSyntaxMetadataTest
 {
 	/** Dummy data to make sure this method keeps values at the end of the parsing **/
     @dummy
-    private function func()
-    {
-    }
+    private var func = 13;
 
     @:allow(flixel
     private function dummyFunction()


### PR DESCRIPTION
This fixes methods setting some compiler metadata as its type if the meta has arguments and they are not fully written yet.

Fixes issue #372 (last Gama11's comment). EDIT: Fixed only after a function with no type. If it's a var it's not working right yet.