### PR TITLE
[CodeRefactor MoveDialog] Аdds the ability to use a package name syntax.

### DIFF
--- a/External/Plugins/CodeRefactor/Controls/MoveDialog.cs
+++ b/External/Plugins/CodeRefactor/Controls/MoveDialog.cs
@@ -102,7 +102,7 @@ namespace CodeRefactor.Controls
             if (search.Length > 0)
             {
                 char separator = Path.DirectorySeparatorChar;
-                string searchWord = search.Replace('\\', separator).Replace('/', separator);
+                string searchWord = search.Replace('\\', separator).Replace('/', separator).Replace('.', separator);
                 int searchLength = search.Length;
                 classpaths = classpaths.FindAll(path =>
                 {


### PR DESCRIPTION
Аdds the ability to use a package name syntax to quickly select the path where the class will be moved.