### PR TITLE
Fix Results display

### DIFF
--- a/External/Plugins/ResultsPanel/PluginUI.cs
+++ b/External/Plugins/ResultsPanel/PluginUI.cs
@@ -647,7 +647,7 @@ namespace ResultsPanel
             String projectDir = project != null ? Path.GetDirectoryName(project.ProjectPath) : "";
             Boolean limitMode = (count - this.logCount) > 1000;
             this.entriesView.BeginUpdate();
-            for (Int32 i = this.logCount; i < (limitMode ? 1000 : count); i++)
+            for (Int32 i = this.logCount; i < (limitMode ? this.logCount + 1000 : count); i++)
             {
                 entry = TraceManager.TraceLog[i];
                 if (entry.Message != null && entry.Message.Length > 7 && entry.Message.IndexOf(':') > 0)


### PR DESCRIPTION
Fixed case when having more than 1000 entries in one queue and starting offset bigger than 0.

For example: in a project look for some entry with more than 1000 results, and try to look again for it, since the limit is set to 1000, but the tracelog count is well above 1000, the user won't see the right results.