### PR TITLE
Parsing improvements

### DIFF
--- a/External/Plugins/ASCompletion/ASCompletion.csproj
+++ b/External/Plugins/ASCompletion/ASCompletion.csproj
@@ -84,7 +84,9 @@
     <Compile Include="Completion\ASDocumentation.cs" />
     <Compile Include="Completion\ContextFeatures.cs" />
     <Compile Include="Context\IASContext.cs" />
-    <Compile Include="CustomControls\StateSavingTreeView.cs" />
+    <Compile Include="CustomControls\StateSavingTreeView.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="CustomControls\ModelsExplorer.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/External/Plugins/ASCompletion/Model/ASFileParser.cs
+++ b/External/Plugins/ASCompletion/Model/ASFileParser.cs
@@ -1081,7 +1081,7 @@ namespace ASCompletion.Model
                         else if (valueError && c1 == ')') inValue = false;
                         else if (inType && inGeneric && (c1 == '<' || c1 == '.')) continue;
                         else if (inAnonType) continue;
-                        hadWS = true;
+                        else if (c1 != '_') hadWS = true;
                     }
                 }
 
@@ -1223,7 +1223,7 @@ namespace ASCompletion.Model
                             {
                                 if (!inValue && i > 2 && length > 1 && i < len - 3
                                     && char.IsLetterOrDigit(ba[i - 3]) && (char.IsLetter(ba[i]) || (haXe && ba[i] == '{'))
-                                    && (char.IsLetter(buffer[0]) || buffer[0] == '_'))
+                                    && (char.IsLetter(buffer[0]) || buffer[0] == '_' || inType && buffer[0] == '('))
                                 {
                                     if (curMember == null)
                                     {
@@ -1266,7 +1266,7 @@ namespace ASCompletion.Model
                                 if (!inValue)
                                 {
                                     addChar = true;
-                                    if (c1 == '>' && inGeneric)
+                                    if (c1 == '>')
                                     {
                                         if (paramTempCount > 0) paramTempCount--;
                                         if (paramTempCount == 0 && paramBraceCount == 0
@@ -1280,7 +1280,14 @@ namespace ASCompletion.Model
                                 {
                                     paramParCount--;
                                     addChar = true;
-                                }// else inType = false, error? it may depend on the context
+                                }
+                                else if (paramParCount == 0 && paramTempCount == 0 && paramBraceCount == 0
+                                    && paramSqCount == 0)
+                                {
+                                    inType = false;
+                                    shortcut = false;
+                                    evalToken = 1;
+                                }
                             }
                             else if (c1 == '(' && haXe && inType)
                             {

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -169,6 +169,8 @@
     <EmbeddedResource Include="Test Files\parser\haxe\MetadataTest.hx" />
     <EmbeddedResource Include="Test Files\parser\haxe\MethodAfterGenericReturnTest.hx" />
     <EmbeddedResource Include="Test Files\parser\haxe\WrongSyntaxCompilerMetaAfterVarWithNoType.hx" />
+    <EmbeddedResource Include="Test Files\parser\haxe\FunctionTypesAsArgumentsTest.hx" />
+    <EmbeddedResource Include="Test Files\parser\haxe\KeywordAndUnderscoreInNameTest.hx" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">

--- a/Tests/External/Plugins/ASCompletion.Tests/Model/ASFileParserTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Model/ASFileParserTests.cs
@@ -1591,6 +1591,97 @@ namespace ASCompletion.Model
                 }
             }
 
+            [Test(Description = "Issue 1125")]
+            public void ParseFile_FunctionTypesAsArguments()
+            {
+                using (var resourceFile = new TestFile("ASCompletion.Test_Files.parser.haxe.FunctionTypesAsArgumentsTest.hx"))
+                {
+                    var srcModel = new FileModel(resourceFile.DestinationFile);
+                    srcModel.Context = new HaXeContext.Context(new HaXeContext.HaXeSettings());
+                    var model = ASFileParser.ParseFile(srcModel);
+                    var classModel = model.Classes[0];
+                    Assert.AreEqual("Test", classModel.Name);
+                    Assert.AreEqual(FlagType.Class, classModel.Flags & FlagType.Class);
+                    Assert.AreEqual(2, classModel.LineFrom);
+                    Assert.AreEqual(15, classModel.LineTo);
+                    Assert.AreEqual(3, classModel.Members.Count);
+
+                    var memberModel = classModel.Members[0];
+                    Assert.AreEqual("func1", memberModel.Name);
+                    Assert.AreEqual("Array<Dynamic>", memberModel.Type);
+                    var flags = FlagType.Function;
+                    Assert.AreEqual(flags, memberModel.Flags & flags);
+                    Assert.AreEqual(Visibility.Private, memberModel.Access);
+                    Assert.AreEqual(4, memberModel.LineFrom);
+                    Assert.AreEqual(6, memberModel.LineTo);
+                    Assert.AreEqual(1, memberModel.Parameters.Count);
+                    Assert.AreEqual("arg", memberModel.Parameters[0].Name);
+                    Assert.AreEqual("(Float->Int)->(Int->Array<Dynamic>)", memberModel.Parameters[0].Type);
+
+                    memberModel = classModel.Members[1];
+                    Assert.AreEqual("func2", memberModel.Name);
+                    Assert.AreEqual(null, memberModel.Type);
+                    flags = FlagType.Function;
+                    Assert.AreEqual(flags, memberModel.Flags & flags);
+                    Assert.AreEqual(Visibility.Public, memberModel.Access);
+                    Assert.AreEqual(8, memberModel.LineFrom);
+                    Assert.AreEqual(10, memberModel.LineTo);
+                    Assert.AreEqual(2, memberModel.Parameters.Count);
+                    Assert.AreEqual("arg1", memberModel.Parameters[0].Name);
+                    Assert.AreEqual("Int->Void", memberModel.Parameters[0].Type);
+                    Assert.AreEqual("arg2", memberModel.Parameters[1].Name);
+                    Assert.AreEqual("Dynamic", memberModel.Parameters[1].Type);
+
+                    memberModel = classModel.Members[2];
+                    Assert.AreEqual("func3", memberModel.Name);
+                    Assert.AreEqual("Int", memberModel.Type);
+                    flags = FlagType.Function;
+                    Assert.AreEqual(flags, memberModel.Flags & flags);
+                    Assert.AreEqual(Visibility.Private, memberModel.Access);
+                    Assert.AreEqual(12, memberModel.LineFrom);
+                    Assert.AreEqual(14, memberModel.LineTo);
+                    Assert.AreEqual(1, memberModel.Parameters.Count);
+                    Assert.AreEqual("arg", memberModel.Parameters[0].Name);
+                    Assert.AreEqual("Float", memberModel.Parameters[0].Type);
+                }
+            }
+
+            [Test(Description = "Issue 1141")]
+            public void ParseFile_KeywordAndUnderscoreInName()
+            {
+                using (var resourceFile = new TestFile("ASCompletion.Test_Files.parser.haxe.KeywordAndUnderscoreInNameTest.hx"))
+                {
+                    var srcModel = new FileModel(resourceFile.DestinationFile);
+                    srcModel.Context = new HaXeContext.Context(new HaXeContext.HaXeSettings());
+                    var model = ASFileParser.ParseFile(srcModel);
+                    var classModel = model.Classes[0];
+                    Assert.AreEqual(1, model.Classes.Count);
+                    Assert.AreEqual("Test", classModel.Name);
+                    Assert.AreEqual(FlagType.Class, classModel.Flags & FlagType.Class);
+                    Assert.AreEqual(2, classModel.LineFrom);
+                    Assert.AreEqual(6, classModel.LineTo);
+                    Assert.AreEqual(2, classModel.Members.Count);
+
+                    var memberModel = classModel.Members[0];
+                    Assert.AreEqual("var_1244", memberModel.Name);
+                    Assert.AreEqual("Int", memberModel.Type);
+                    var flags = FlagType.Variable | FlagType.Static;
+                    Assert.AreEqual(flags, memberModel.Flags & flags);
+                    Assert.AreEqual(Visibility.Public, memberModel.Access & Visibility.Public);
+                    Assert.AreEqual(4, memberModel.LineFrom);
+                    Assert.AreEqual(4, memberModel.LineTo);
+
+                    memberModel = classModel.Members[1];
+                    Assert.AreEqual("ERR_LOGINFAILED", memberModel.Name);
+                    Assert.AreEqual("Int", memberModel.Type);
+                    flags = FlagType.Variable | FlagType.Static;
+                    Assert.AreEqual(flags, memberModel.Flags & flags);
+                    Assert.AreEqual(Visibility.Public, memberModel.Access & Visibility.Public);
+                    Assert.AreEqual(5, memberModel.LineFrom);
+                    Assert.AreEqual(5, memberModel.LineTo);
+                }
+            }
+
             [Test]
             public void ParseFile_IdentifiersWithUnicodeChars()
             {

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/parser/haxe/FunctionTypesAsArgumentsTest.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/parser/haxe/FunctionTypesAsArgumentsTest.hx
@@ -1,0 +1,16 @@
+package test.test;
+
+class Test
+{
+    function func1(arg:(Float->Int)->(Int->Array<Dynamic>)):Array<Dynamic>
+	{
+	}
+
+    public function func2(arg1:Int->Void, arg2:Dynamic)
+	{
+	}
+	
+    private function func3(arg:Float):Int
+	{
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/parser/haxe/KeywordAndUnderscoreInNameTest.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/parser/haxe/KeywordAndUnderscoreInNameTest.hx
@@ -1,0 +1,7 @@
+package test.test;
+
+class Test
+{
+	public static var var_1244:Int = class_12.method_2017();
+	public static var ERR_LOGINFAILED:Int = -1;
+}


### PR DESCRIPTION
* Do not treat _ in an identifier as a separator, this causes unneeded extra parsing, but also problems if a subpart of the name happens to be a keyword.
* Finalize correctly function types when they are arguments.
* Detect when a generic is inside a function type, that starts with a subtype.

This fixes issue #1141, fixes issue #1125 and an extra problem.