### PR TITLE
Do not refresh locale

### DIFF
--- a/PluginCore/PluginCore/Localization/TextHelper.cs
+++ b/PluginCore/PluginCore/Localization/TextHelper.cs
@@ -114,7 +114,7 @@ namespace PluginCore.Localization
         /// </summary>
         static String GetStringInternal(String key, Assembly assembly)
         {
-            if (!RefreshStoredLocale()) return key ?? String.Empty;
+            if (!ValidateStoredLocale()) return key ?? String.Empty;
             String prefix = assembly.GetName().Name;
             // On different distro we need to use FlashDevelop prefix
             if (prefix == DistroConfig.DISTRIBUTION_NAME) prefix = "FlashDevelop";
@@ -139,16 +139,15 @@ namespace PluginCore.Localization
         }
 
         /// <summary>
-        /// Checks and updates the stored locale and resource manager if necessary.
+        /// Validates the stored locale and resource manager if necessary.
         /// Returns whether the operation succeeded (<code>true</code>) or failed (<code>false</code>).
         /// </summary>
-        static bool RefreshStoredLocale()
+        static bool ValidateStoredLocale()
         {
-            if (PluginBase.MainForm == null || PluginBase.MainForm.Settings == null) return false;
-            LocaleVersion localeSetting = PluginBase.MainForm.Settings.LocaleVersion;
-            if (localeSetting != storedLocale)
+            if (storedLocale == LocaleVersion.Invalid)
             {
-                storedLocale = localeSetting;
+                if (PluginBase.MainForm == null || PluginBase.MainForm.Settings == null) return false;
+                storedLocale = PluginBase.MainForm.Settings.LocaleVersion;
                 String path = "PluginCore.PluginCore.Resources." + storedLocale;
                 resourceManager = new ResourceManager(path, Assembly.GetExecutingAssembly());
             }


### PR DESCRIPTION
Changing the locale using the `Tools>Program Settings...` should require a restart to take effect.
Since some texts are retrieved on load, and some texts are retrieved as they are needed, allowing a refresh of the locale every time text is retrieved can produce something like this:
![image](https://cloud.githubusercontent.com/assets/13545633/14097601/cda056ce-f5ad-11e5-8067-1035cd56c555.png)
