### PR TITLE
HaxeComplete: fix position / usage positions for Haxe 3.3.0

### DIFF
--- a/External/Plugins/HaXeContext/Completion/HaxeComplete.cs
+++ b/External/Plugins/HaXeContext/Completion/HaxeComplete.cs
@@ -12,6 +12,7 @@ using System.Xml;
 using ASCompletion.Model;
 using PluginCore.Helpers;
 using System.Windows.Forms;
+using PluginCore.Utilities;
 
 namespace HaXeContext
 {
@@ -45,8 +46,9 @@ namespace HaXeContext
 
         readonly IHaxeCompletionHandler handler;
         readonly string FileName;
+        private readonly SemVer haxeVersion;
 
-        public HaxeComplete(ScintillaControl sci, ASExpr expr, bool autoHide, IHaxeCompletionHandler completionHandler, HaxeCompilerService compilerService)
+        public HaxeComplete(ScintillaControl sci, ASExpr expr, bool autoHide, IHaxeCompletionHandler completionHandler, HaxeCompilerService compilerService, SemVer haxeVersion)
         {
             Sci = sci;
             Expr = expr;
@@ -56,6 +58,7 @@ namespace HaXeContext
             CompilerService = compilerService;
             Status = HaxeCompleteStatus.NONE;
             FileName = PluginBase.MainForm.CurrentDocument.FileName;
+            this.haxeVersion = haxeVersion;
         }
 
         /* EXECUTION */
@@ -207,7 +210,9 @@ namespace HaXeContext
 
                 case HaxeCompilerService.POSITION:
                 case HaxeCompilerService.USAGE:
-                    pos = Sci.WordEndPosition(Sci.CurrentPos, true) + 1;
+                    pos = Sci.WordEndPosition(Sci.CurrentPos, true);
+                    // necessary to get results with older versions due to a compiler bug
+                    if (haxeVersion.IsOlderThan(new SemVer("3.3.0"))) pos++;
                     break;
             }
             

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -1200,7 +1200,7 @@ namespace HaXeContext
             if (expression.Value != "")
             {
                 // async processing
-                var hc = new HaxeComplete(sci, expression, autoHide, completionModeHandler, HaxeCompilerService.COMPLETION);
+                var hc = new HaxeComplete(sci, expression, autoHide, completionModeHandler, HaxeCompilerService.COMPLETION, GetCurrentSDKVersion());
                 hc.GetList(OnDotCompletionResult);
                 resolvingDot = true;
             }
@@ -1378,7 +1378,7 @@ namespace HaXeContext
                 return null;
 
             expression.Position++;
-            var hc = new HaxeComplete(sci, expression, autoHide, completionModeHandler, HaxeCompilerService.COMPLETION);
+            var hc = new HaxeComplete(sci, expression, autoHide, completionModeHandler, HaxeCompilerService.COMPLETION, GetCurrentSDKVersion());
             hc.GetList(OnFunctionCompletionResult);
 
             resolvingFunction = true;
@@ -1407,7 +1407,7 @@ namespace HaXeContext
             if (hxsettings.CompletionMode == HaxeCompletionModeEnum.FlashDevelop || GetCurrentSDKVersion().IsOlderThan(new SemVer("3.2.0")))
                 return false;
 
-            var hc = new HaxeComplete(sci, expression, false, completionModeHandler, HaxeCompilerService.POSITION);
+            var hc = new HaxeComplete(sci, expression, false, completionModeHandler, HaxeCompilerService.POSITION, GetCurrentSDKVersion());
             hc.GetPosition(OnPositionResult);
             return true;
         }
@@ -1467,7 +1467,7 @@ namespace HaXeContext
             if (hxsettings.CompletionMode == HaxeCompletionModeEnum.FlashDevelop || PluginBase.MainForm.CurrentDocument.IsUntitled) return;
 
             EventManager.DispatchEvent(this, new NotifyEvent(EventType.ProcessStart));
-            var hc = new HaxeComplete(ASContext.CurSciControl, new ASExpr(), false, completionModeHandler, HaxeCompilerService.COMPLETION);
+            var hc = new HaxeComplete(ASContext.CurSciControl, new ASExpr(), false, completionModeHandler, HaxeCompilerService.COMPLETION, GetCurrentSDKVersion());
             hc.GetList(OnCheckSyntaxResult);
         }
 


### PR DESCRIPTION
The +1 that was required here previously was actually a Haxe debug fixed recently on the dev branch, which now leads to incorrect results without the version check.
Sci.WordEndPosition() is technically not required on latest Haxe anymore either.