### PR TITLE
[Fix crashes] Disable "Find all references" for files that are not saved to disk.

### DIFF
--- a/External/Plugins/CodeRefactor/PluginMain.cs
+++ b/External/Plugins/CodeRefactor/PluginMain.cs
@@ -332,6 +332,8 @@ namespace CodeRefactor
         {
             try
             {
+                var document = PluginBase.MainForm.CurrentDocument;
+                var curFileName = document != null ? document.FileName : string.Empty;
                 this.refactorMainMenu.DelegateMenuItem.Enabled = false;
                 this.refactorContextMenu.DelegateMenuItem.Enabled = false;
                 bool langIsValid = RefactoringHelper.GetLanguageIsValid();
@@ -346,9 +348,9 @@ namespace CodeRefactor
                         || result.IsPackage;
                     this.refactorContextMenu.RenameMenuItem.Enabled = isRenameable;
                     this.refactorMainMenu.RenameMenuItem.Enabled = isRenameable;
-                    bool isNotPackage = !result.IsPackage;
-                    this.editorReferencesItem.Enabled = isNotPackage;
-                    this.viewReferencesItem.Enabled = isNotPackage;
+                    var enabled = !result.IsPackage && (File.Exists(curFileName) || curFileName.Contains("[model]"));
+                    this.editorReferencesItem.Enabled = enabled;
+                    this.viewReferencesItem.Enabled = enabled;
                     if (result.Member != null && result.Type != null && result.InClass != null && result.InFile != null)
                     {
                         FlagType flags = result.Member.Flags;
@@ -383,10 +385,9 @@ namespace CodeRefactor
                 this.refactorContextMenu.ExtractMethodMenuItem.Enabled = false;
                 this.refactorMainMenu.ExtractLocalVariableMenuItem.Enabled = false;
                 this.refactorContextMenu.ExtractLocalVariableMenuItem.Enabled = false;
-                ITabbedDocument document = PluginBase.MainForm.CurrentDocument;
                 if (document != null && document.IsEditable && langIsValid)
                 {
-                    bool isValidFile = IsValidFile(document.FileName);
+                    bool isValidFile = IsValidFile(curFileName);
                     refactorMainMenu.MoveMenuItem.Enabled = isValidFile;
                     refactorContextMenu.MoveMenuItem.Enabled = isValidFile;
                     var sci = document.SciControl;
@@ -399,13 +400,16 @@ namespace CodeRefactor
                             this.refactorMainMenu.ExtractMethodMenuItem.Enabled = true;
                             this.refactorContextMenu.ExtractMethodMenuItem.Enabled = true;
                         }
-                        var declAtSelStart = context.GetDeclarationAtLine(sci.LineFromPosition(sci.SelectionStart));
-                        var declAtSelEnd = context.GetDeclarationAtLine(sci.LineFromPosition(sci.SelectionEnd));
-                        if (declAtSelStart != null && declAtSelStart.Member != null && (declAtSelStart.Member.Flags & FlagType.Function) > 0
-                            && declAtSelEnd != null && declAtSelStart.Member.Equals(declAtSelEnd.Member))
+                        if (context != null)
                         {
-                            this.refactorMainMenu.ExtractLocalVariableMenuItem.Enabled = true;
-                            this.refactorContextMenu.ExtractLocalVariableMenuItem.Enabled = true;
+                            var declAtSelStart = context.GetDeclarationAtLine(sci.LineFromPosition(sci.SelectionStart));
+                            var declAtSelEnd = context.GetDeclarationAtLine(sci.LineFromPosition(sci.SelectionEnd));
+                            if (declAtSelStart != null && declAtSelStart.Member != null && (declAtSelStart.Member.Flags & FlagType.Function) > 0
+                                && declAtSelEnd != null && declAtSelStart.Member.Equals(declAtSelEnd.Member))
+                            {
+                                this.refactorMainMenu.ExtractLocalVariableMenuItem.Enabled = true;
+                                this.refactorContextMenu.ExtractLocalVariableMenuItem.Enabled = true;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fox example:
Create new document.
Paste code.
Execute "Find all references".
Result: 
![](http://service.crazypanda.ru/v/clip2net/B/n/80qMFsiubM.png)

