### PR TITLE
Removed line break before else branch of conditional in C#, Java run.bat templates.

### DIFF
--- a/FlashDevelop/Bin/Debug/Projects/365 Haxe - C# Project/run.bat.template
+++ b/FlashDevelop/Bin/Debug/Projects/365 Haxe - C# Project/run.bat.template
@@ -3,8 +3,7 @@ cd bin/bin
 if "%1"=="debug" (
   :: run debug
   $(ProjectID)-Debug.exe
-)
-else (
+) else (
   :: run release
   $(ProjectID).exe
 )

--- a/FlashDevelop/Bin/Debug/Projects/370 Haxe - Java Project/run.bat.template
+++ b/FlashDevelop/Bin/Debug/Projects/370 Haxe - Java Project/run.bat.template
@@ -3,8 +3,7 @@ cd bin
 if "%1"=="debug" (
   :: run debug
   java -jar $(ProjectID)-Debug.jar
-)
-else (
+) else (
   :: run release
   java -jar $(ProjectID).jar
 )


### PR DESCRIPTION
Hello,

The line break was, uh, _breaking_ the script. Couldn't find any mention of this among open issues or pull requests, so I went ahead and fixed it.