### PR TITLE
Use FIPS 140-2 compliant algorithm if available when required

### DIFF
--- a/FlashDevelop/Dialogs/HashDialog.cs
+++ b/FlashDevelop/Dialogs/HashDialog.cs
@@ -233,23 +233,30 @@ namespace FlashDevelop.Dialogs
         private void InputTextBoxChanged(Object sender, EventArgs e)
         {
             Byte[] plainBytes = Encoding.UTF8.GetBytes(this.inputTextBox.Text);
-            if (this.hashComboBox.SelectedIndex == 1) 
+            try
             {
-                this.OutputHash(MD5.Compute(plainBytes));
+                if (this.hashComboBox.SelectedIndex == 1)
+                {
+                    this.OutputHash(MD5.Compute(plainBytes));
+                }
+                else if (this.hashComboBox.SelectedIndex == 2)
+                {
+                    this.OutputHash(SHA1.Compute(plainBytes));
+                }
+                else if (this.hashComboBox.SelectedIndex == 3)
+                {
+                    this.OutputHash(SHA256.Compute(plainBytes));
+                }
+                else if (this.hashComboBox.SelectedIndex == 4)
+                {
+                    this.OutputHash(RMD160.Compute(plainBytes));
+                }
+                else this.OutputHash(plainBytes);
             }
-            else if (this.hashComboBox.SelectedIndex == 2) 
+            catch (InvalidOperationException)
             {
-                this.OutputHash(SHA1.Compute(plainBytes));
+                this.outputTextBox.Text = "[ERROR: FIPS 140-2 compliance]";
             }
-            else if (this.hashComboBox.SelectedIndex == 3)
-            {
-                this.OutputHash(SHA256.Compute(plainBytes));
-            }
-            else if (this.hashComboBox.SelectedIndex == 4)
-            {
-                this.OutputHash(RMD160.Compute(plainBytes));
-            }
-            else this.OutputHash(plainBytes);
         }
 
         /// <summary>

--- a/PluginCore/PluginCore/Utilities/CryptoClasses.cs
+++ b/PluginCore/PluginCore/Utilities/CryptoClasses.cs
@@ -78,12 +78,28 @@ namespace PluginCore.Utilities
 
     public class SHA1
     {
+        static bool fipsComplianceRequired;
+
         /// <summary>
         /// Computes the SHA-1 checksum for the bytes.
         /// </summary>
         public static Byte[] Compute(Byte[] bytes)
         {
-            SHA1Managed sha1 = new SHA1Managed();
+            if (fipsComplianceRequired) return ComputeFIPS(bytes);
+            try
+            {
+                SHA1Managed sha1 = new SHA1Managed();
+                return sha1.ComputeHash(bytes);
+            }
+            catch (InvalidOperationException)
+            {
+                fipsComplianceRequired = true;
+                return ComputeFIPS(bytes);
+            }
+        }
+        static Byte[] ComputeFIPS(Byte[] bytes)
+        {
+            SHA1Cng sha1 = new SHA1Cng();
             return sha1.ComputeHash(bytes);
         }
 
@@ -100,12 +116,28 @@ namespace PluginCore.Utilities
 
     public class SHA256
     {
+        static bool fipsComplianceRequired;
+
         /// <summary>
         /// Computes the SHA-256 checksum for the bytes.
         /// </summary>
         public static Byte[] Compute(Byte[] bytes)
         {
-            SHA256Managed sha256 = new SHA256Managed();
+            if (fipsComplianceRequired) return ComputeFIPS(bytes);
+            try
+            {
+                SHA256Managed sha256 = new SHA256Managed();
+                return sha256.ComputeHash(bytes);
+            }
+            catch (InvalidOperationException)
+            {
+                fipsComplianceRequired = true;
+                return ComputeFIPS(bytes);
+            }
+        }
+        static Byte[] ComputeFIPS(Byte[] bytes)
+        {
+            SHA256Cng sha256 = new SHA256Cng();
             return sha256.ComputeHash(bytes);
         }
 


### PR DESCRIPTION
After installing Cisco VPN client, FlashDevelop stopped working because it's using non FIPS compliant  algorithms.