### PR TITLE
Fixes generate static variable and static function

### DIFF
--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -238,6 +238,23 @@
     <EmbeddedResource Include="Test Files\generated\as3\BeforeGenerateVariable_forSomeObj2.as" />
     <EmbeddedResource Include="Test Files\generated\as3\BeforeGenerateVariable_forSomeObj3.as" />
     <EmbeddedResource Include="Test Files\generated\as3\AfterGenerateVariable_forSomeObj3.as" />
+    <EmbeddedResource Include="Test Files\generated\haxe\BeforeGenerateStaticVariable.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\AfterGeneratePublicStaticVariable_generateExplicitScopeIsTrue.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\AfterGeneratePublicStaticVariable_generateExplicitScopeIsFalse.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\BeforeGeneratePublicStaticVariable_forSomeType.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\AfterGeneratePublicStaticVariable_forSomeType.hx" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeGenerateStaticVariable_forCurrentType.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterGeneratePublicStaticVariable_forCurrentType.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeGenerateStaticVariable_forSomeType.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterGeneratePublicStaticVariable_forSomeType.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeGenerateStaticFunction.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterGeneratePublicStaticFunction_generateExplicitScopeIsFalse.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeGenerateStaticFunction_forCurrentType.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeGenerateStaticFunction_forSomeType.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterGeneratePublicStaticFunction_forSomeType.as" />
+    <EmbeddedResource Include="Test Files\generated\haxe\BeforeGeneratePublicStaticVariable_forCurrentType.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\AfterGeneratePublicStaticVariable_forCurrentType.hx" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
@@ -950,6 +950,72 @@ namespace ASCompletion.Completion
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGenerateFunction_forSomeObj3.as"))
                                 .SetName("From new Some()\n.foo|(); if generate explicit scope is true");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction.as"),
+                                false,
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_generateExplicitScopeIsFalse.as"))
+                                .SetName("Generate public static function if generate explicit scope is false");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction.as"),
+                                true,
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as"))
+                                .SetName("Generate public static function if generate explicit scope is true");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction_forCurrentType.as"),
+                                false,
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as"))
+                                .SetName("From CurrentType.foo| if generate explicit scope is false");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction_forCurrentType.as"),
+                                true,
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as"))
+                                .SetName("From CurrentType.foo| if generate explicit scope is true");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction_forSomeType.as"),
+                                false,
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_forSomeType.as"))
+                                .SetName("From SomeType.foo| if generate explicit scope is false");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction_forSomeType.as"),
+                                true,
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_forSomeType.as"))
+                                .SetName("From SomeType.foo| if generate explicit scope is true");
                     }
                 }
 
@@ -961,6 +1027,7 @@ namespace ASCompletion.Completion
                     SnippetHelper.PostProcessSnippets(sci, 0);
                     ASContext.Context.SetAs3Features();
                     ASContext.CommonSettings.GenerateScope = generateExplicitScope;
+                    ASContext.CommonSettings.StartWithModifiers = true;
                     var currentModel = new FileModel {Context = ASContext.Context};
                     new ASFileParser().ParseSrc(currentModel, sci.Text);
                     var currentClass = currentModel.Classes[0];
@@ -1179,6 +1246,28 @@ namespace ASCompletion.Completion
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGenerateVariable_forSomeObj3.as"))
                                 .SetName("From new Some()\n.foo| if generate explicit scope is true");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticVariable_forCurrentType.as"),
+                                false,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticVariable_forCurrentType.as"))
+                                .SetName("From CurrentType.foo|");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticVariable_forSomeType.as"),
+                                false,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticVariable_forSomeType.as"))
+                                .SetName("From SomeType.foo|");
                     }
                 }
 
@@ -1190,6 +1279,7 @@ namespace ASCompletion.Completion
                     SnippetHelper.PostProcessSnippets(sci, 0);
                     ASContext.Context.SetAs3Features();
                     ASContext.CommonSettings.GenerateScope = generateExplicitScope;
+                    ASContext.CommonSettings.StartWithModifiers = true;
                     var currentModel = new FileModel {Context = ASContext.Context};
                     new ASFileParser().ParseSrc(currentModel, sci.Text);
                     var currentClass = currentModel.Classes[0];
@@ -1259,6 +1349,72 @@ namespace ASCompletion.Completion
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicVariable_generateExplicitScopeIsTrue.hx"))
                                 .SetName("Generate public variable if generate explicit scope is true");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateStaticVariable.hx"),
+                                false,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_generateExplicitScopeIsFalse.hx"))
+                                .SetName("Generate public static variable if generate explicit scope is false");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateStaticVariable.hx"),
+                                true,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_generateExplicitScopeIsTrue.hx"))
+                                .SetName("Generate public static variable if generate explicit scope is true");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGeneratePublicStaticVariable_forSomeType.hx"),
+                                false,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_forSomeType.hx"))
+                                .SetName("From SomeType.foo| variable if generate explicit scope is false");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGeneratePublicStaticVariable_forSomeType.hx"),
+                                true,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_forSomeType.hx"))
+                                .SetName("From SomeType.foo| variable if generate explicit scope is true");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGeneratePublicStaticVariable_forCurrentType.hx"),
+                                false,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_forCurrentType.hx"))
+                                .SetName("From CurrentType.foo| variable if generate explicit scope is false");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGeneratePublicStaticVariable_forCurrentType.hx"),
+                                true,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_forCurrentType.hx"))
+                                .SetName("From CurrentType.foo| variable if generate explicit scope is true");
                     }
                 }
 
@@ -1270,6 +1426,7 @@ namespace ASCompletion.Completion
                     SnippetHelper.PostProcessSnippets(sci, 0);
                     ASContext.Context.SetHaxeFeatures();
                     ASContext.CommonSettings.GenerateScope = generateExplicitScope;
+                    ASContext.CommonSettings.StartWithModifiers = true;
                     var currentModel = new FileModel {haXe = true, Context = ASContext.Context};
                     new ASFileParser().ParseSrc(currentModel, sci.Text);
                     var currentClass = currentModel.Classes[0];
@@ -1319,7 +1476,7 @@ namespace ASCompletion.Completion
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGenerateEventHandler_withAutoRemove.as"))
-                                .SetName("Generate event handler with auto remove");
+                                .SetName("Generate event handler with auto remove if generate explicit scope is false");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticFunction_forSomeType.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticFunction_forSomeType.as
@@ -1,0 +1,16 @@
+﻿package {
+	public class Main {
+		public static function main():void {
+			Some.foo();
+		}
+		
+		public function Main() {
+		}
+	}
+}
+
+class Some {
+	public static function foo():void {
+		
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticFunction_generateExplicitScopeIsFalse.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticFunction_generateExplicitScopeIsFalse.as
@@ -1,0 +1,14 @@
+﻿package {
+	public class Main {
+		public static function main():void {
+			foo();
+		}
+		
+		public static function foo():void {
+			
+		}
+		
+		public function Main() {
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as
@@ -1,0 +1,14 @@
+﻿package {
+	public class Main {
+		public static function main():void {
+			Main.foo();
+		}
+		
+		public static function foo():void {
+			
+		}
+		
+		public function Main() {
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticVariable_forCurrentType.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticVariable_forCurrentType.as
@@ -1,0 +1,8 @@
+﻿package {
+	public class Main {
+		public static var test;
+		public function Main() {
+			Main.test;
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticVariable_forSomeType.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticVariable_forSomeType.as
@@ -1,0 +1,11 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			Some.test;
+		}
+	}
+}
+
+class Some {
+	public static var test;
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticFunction.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticFunction.as
@@ -1,0 +1,10 @@
+﻿package {
+	public class Main {
+		public static function main():void {
+			foo$(EntryPoint)();
+		}
+		
+		public function Main() {
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticFunction_forCurrentType.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticFunction_forCurrentType.as
@@ -1,0 +1,10 @@
+﻿package {
+	public class Main {
+		public static function main():void {
+			Main.foo$(EntryPoint)();
+		}
+		
+		public function Main() {
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticFunction_forSomeType.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticFunction_forSomeType.as
@@ -1,0 +1,13 @@
+﻿package {
+	public class Main {
+		public static function main():void {
+			Some.foo$(EntryPoint)();
+		}
+		
+		public function Main() {
+		}
+	}
+}
+
+class Some {
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticVariable_forCurrentType.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticVariable_forCurrentType.as
@@ -1,0 +1,7 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			Main.test$(EntryPoint);
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticVariable_forSomeType.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticVariable_forSomeType.as
@@ -1,0 +1,10 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			Some.test$(EntryPoint);
+		}
+	}
+}
+
+class Some {
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_forCurrentType.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_forCurrentType.hx
@@ -1,0 +1,7 @@
+﻿package;
+public class Main {
+	public static var test;
+	public static function main() {
+		Main.test;
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_forSomeType.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_forSomeType.hx
@@ -1,0 +1,10 @@
+﻿package;
+public class Main {
+	public static function main() {
+		Some.test;
+	}
+}
+
+public class Some {
+	public static var test;
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_generateExplicitScopeIsFalse.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_generateExplicitScopeIsFalse.hx
@@ -1,0 +1,7 @@
+﻿package;
+public class Main {
+	public static var test;
+	public static function main() {
+		test;
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_generateExplicitScopeIsTrue.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_generateExplicitScopeIsTrue.hx
@@ -1,0 +1,7 @@
+﻿package;
+public class Main {
+	public static var test;
+	public static function main() {
+		Main.test;
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeGeneratePublicStaticVariable_forCurrentType.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeGeneratePublicStaticVariable_forCurrentType.hx
@@ -1,0 +1,6 @@
+﻿package;
+public class Main {
+	public static function main() {
+		Main.test$(EntryPoint);
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeGeneratePublicStaticVariable_forSomeType.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeGeneratePublicStaticVariable_forSomeType.hx
@@ -1,0 +1,9 @@
+﻿package;
+public class Main {
+	public static function main() {
+		Some.test$(EntryPoint);
+	}
+}
+
+public class Some {
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeGenerateStaticVariable.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeGenerateStaticVariable.hx
@@ -1,0 +1,6 @@
+﻿package;
+public class Main {
+	public static function main() {
+		test$(EntryPoint);
+	}
+}


### PR DESCRIPTION
BUG in release 5.1.1, code for example:
```
package {
	public class Main {
		public function Main() {
			Main.test|;
		}
	}
}
```
result after generating variable:
```
package {
	public class Main {
		private var test;//must be private static var test;
		public function Main() {
			Main.test;
		}
	}
}
```

BUG in developmnet version if setting generate explicit scope is true, code for example:
```
package;
public class Main {
	public static function main() {
		test|;
	}
}
```
result after generating variable:
```
package;
public class Main {
	static private var test;
	public static function main() {
		this.test;//must be Main.test
	}
}
```