### PR TITLE
Adding extension SwcBuild

### DIFF
--- a/appman.xml
+++ b/appman.xml
@@ -560,6 +560,19 @@
 			<Url>https://github.com/CamWiseOwl/flashdevelop-wakatime/releases/download/1.1.1/WakaTime.fdz</Url>
 		</Urls>
 	</Entry>
+	<Entry>
+		<Id>swcbuild</Id>
+		<Name>SwcBuild</Name>
+		<Version>1.5.0</Version>
+		<Build>36162</Build>
+		<Checksum>F42A2992F97EE8D5D706453DFAAF054F</Checksum>
+		<Desc>ActionScript Component Compiler Tool for FlashDevelop Projects</Desc>
+		<Group>Extensions</Group>
+		<Info>http://www.flashdevelop.org/community/viewtopic.php?f=4&t=12458</Info>
+		<Urls>
+			<Url>https://github.com/wise0704/SwcBuild/releases/download/v1.5.0/swcbuild.fdz</Url>
+		</Urls>
+	</Entry>
 	FD5-->
 	<!--Haxelib
 	<Entry>


### PR DESCRIPTION
I posted this extension to the [forum](http://www.flashdevelop.org/community/viewtopic.php?f=4&t=12458) a while ago, and I kinda forgot about it until now, kek.

I wasn't sure on which group to put this on, as it's not a plugin, but it's not quite a compiler either. So I put it in a new group as Extension. 

By the way, wouldn't it be easier if AppMan's Config.xml file refer to https://raw.githubusercontent.com/fdorg/flashdevelop/development/appman.xml rather than http://www.flashdevelop.org/appman.xml?