### PR TITLE
Fixes generate static variable and generate static function

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -2082,14 +2082,15 @@ namespace ASCompletion.Completion
             // evaluate, if the variable (or constant) should be generated in other class
             ASResult varResult = ASComplete.GetExpressionType(sci, sci.WordEndPosition(sci.CurrentPos, true));
             var memberIsStatic = member != null && (member.Flags & FlagType.Static) > 0;
-            if (ASContext.CommonSettings.GenerateScope && !varResult.Context.Value.Contains(ASContext.Context.Features.dot))
+            var dot = ASContext.Context.Features.dot;
+            if (ASContext.CommonSettings.GenerateScope && !varResult.Context.Value.Contains(dot))
             {
                 position = sci.CurrentPos;
                 var start = sci.WordStartPosition(position, true);
                 var length = sci.MBSafeTextLength(contextToken);
                 sci.SetSel(start, start + length);
                 var scope = memberIsStatic ? inClass.QualifiedName : "this";
-                var text = string.Format("{0}.{1}", scope, contextToken);
+                var text = scope + dot + contextToken;
                 sci.ReplaceSel(text);
                 UpdateLookupPosition(position, text.Length - length);
             }
@@ -2576,14 +2577,15 @@ namespace ASCompletion.Completion
             // evaluate, if the function should be generated in other class
             ASResult funcResult = ASComplete.GetExpressionType(sci, sci.WordEndPosition(sci.CurrentPos, true));
             var memberIsStatic = member != null && (member.Flags & FlagType.Static) > 0;
-            if (ASContext.CommonSettings.GenerateScope && !funcResult.Context.Value.Contains(ASContext.Context.Features.dot))
+            var dot = ASContext.Context.Features.dot;
+            if (ASContext.CommonSettings.GenerateScope && !funcResult.Context.Value.Contains(dot))
             {
                 position = sci.CurrentPos;
                 var start = sci.WordStartPosition(position, true);
                 var length = sci.MBSafeTextLength(contextToken);
                 sci.SetSel(start, start + length);
                 var scope = memberIsStatic ? inClass.QualifiedName : "this";
-                var text = string.Format("{0}.{1}", scope, contextToken);
+                var text = scope + dot + contextToken;
                 sci.ReplaceSel(text);
                 UpdateLookupPosition(position, text.Length - length);
             }

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -238,6 +238,23 @@
     <EmbeddedResource Include="Test Files\generated\as3\BeforeGenerateVariable_forSomeObj2.as" />
     <EmbeddedResource Include="Test Files\generated\as3\BeforeGenerateVariable_forSomeObj3.as" />
     <EmbeddedResource Include="Test Files\generated\as3\AfterGenerateVariable_forSomeObj3.as" />
+    <EmbeddedResource Include="Test Files\generated\haxe\BeforeGenerateStaticVariable.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\AfterGeneratePublicStaticVariable_generateExplicitScopeIsTrue.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\AfterGeneratePublicStaticVariable_generateExplicitScopeIsFalse.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\BeforeGeneratePublicStaticVariable_forSomeType.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\AfterGeneratePublicStaticVariable_forSomeType.hx" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeGenerateStaticVariable_forCurrentType.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterGeneratePublicStaticVariable_forCurrentType.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeGenerateStaticVariable_forSomeType.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterGeneratePublicStaticVariable_forSomeType.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeGenerateStaticFunction.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterGeneratePublicStaticFunction_generateExplicitScopeIsFalse.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeGenerateStaticFunction_forCurrentType.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeGenerateStaticFunction_forSomeType.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterGeneratePublicStaticFunction_forSomeType.as" />
+    <EmbeddedResource Include="Test Files\generated\haxe\BeforeGeneratePublicStaticVariable_forCurrentType.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\AfterGeneratePublicStaticVariable_forCurrentType.hx" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
@@ -836,6 +836,12 @@ namespace ASCompletion.Completion
             [TestFixture]
             public class GenerateFunction : GenerateJob
             {
+                [TestFixtureSetUp]
+                public void GenerateFunctionSetup()
+                {
+                    ASContext.CommonSettings.StartWithModifiers = true;
+                }
+
                 public IEnumerable<TestCaseData> AS3TestCases
                 {
                     get
@@ -844,209 +850,94 @@ namespace ASCompletion.Completion
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction.as"),
-                                false,
                                 GeneratorJobType.Function
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGeneratePrivateFunction_generateExplicitScopeIsFalse.as"))
-                                .SetName("Generate private function if generate explicit scope is false");
+                                .SetName("Generate private function");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction.as"),
-                                true,
-                                GeneratorJobType.Function
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePrivateFunction_generateExplicitScopeIsTrue.as"))
-                                .SetName("Generate private function if generate explicit scope is true");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction.as"),
-                                false,
                                 GeneratorJobType.FunctionPublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicFunction_generateExplicitScopeIsFalse.as"))
-                                .SetName("Generate public function if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction.as"),
-                                true,
-                                GeneratorJobType.FunctionPublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicFunction_generateExplicitScopeIsTrue.as"))
-                                .SetName("Generate public function if generate explicit scope is true");
+                                .SetName("Generate public function");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction_forSomeObj.as"),
-                                false,
                                 GeneratorJobType.FunctionPublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGenerateFunction_forSomeObj.as"))
-                                .SetName("From some.foo|(); if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction_forSomeObj.as"),
-                                true,
-                                GeneratorJobType.FunctionPublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterGenerateFunction_forSomeObj.as"))
-                                .SetName("From some.foo|(); if generate explicit scope is true");
+                                .SetName("From some.foo|();");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction_forSomeObj2.as"),
-                                false,
                                 GeneratorJobType.FunctionPublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGenerateFunction_forSomeObj2.as"))
-                                .SetName("From new Some().foo|(); if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction_forSomeObj2.as"),
-                                true,
-                                GeneratorJobType.FunctionPublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterGenerateFunction_forSomeObj2.as"))
-                                .SetName("From new Some().foo|(); if generate explicit scope is true");
+                                .SetName("From new Some().foo|();");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction_forSomeObj3.as"),
-                                false,
                                 GeneratorJobType.FunctionPublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGenerateFunction_forSomeObj3.as"))
-                                .SetName("From new Some()\n.foo|(); if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction_forSomeObj3.as"),
-                                true,
-                                GeneratorJobType.FunctionPublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterGenerateFunction_forSomeObj3.as"))
-                                .SetName("From new Some()\n.foo|(); if generate explicit scope is true");
+                                .SetName("From new Some()\n.foo|();");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction.as"),
-                                false,
                                 GeneratorJobType.FunctionPublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_generateExplicitScopeIsFalse.as"))
-                                .SetName("Generate public static function if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction.as"),
-                                true,
-                                GeneratorJobType.FunctionPublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as"))
-                                .SetName("Generate public static function if generate explicit scope is true");
+                                .SetName("Generate public static function");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction_forCurrentType.as"),
-                                false,
                                 GeneratorJobType.FunctionPublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as"))
-                                .SetName("From CurrentType.foo| if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction_forCurrentType.as"),
-                                true,
-                                GeneratorJobType.FunctionPublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as"))
-                                .SetName("From CurrentType.foo| if generate explicit scope is true");
+                                .SetName("From CurrentType.foo|");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction_forSomeType.as"),
-                                false,
                                 GeneratorJobType.FunctionPublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_forSomeType.as"))
-                                .SetName("From SomeType.foo| if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction_forSomeType.as"),
-                                true,
-                                GeneratorJobType.FunctionPublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_forSomeType.as"))
-                                .SetName("From SomeType.foo| if generate explicit scope is true");
+                                .SetName("From SomeType.foo|");
                     }
                 }
 
                 [Test, TestCaseSource("AS3TestCases")]
-                public string AS3(string sourceText, bool generateExplicitScope, GeneratorJobType job)
+                public string AS3(string sourceText, GeneratorJobType job)
                 {
-                    sci.Text = sourceText;
                     sci.ConfigurationLanguage = "as3";
-                    SnippetHelper.PostProcessSnippets(sci, 0);
                     ASContext.Context.SetAs3Features();
-                    ASContext.CommonSettings.GenerateScope = generateExplicitScope;
-                    ASContext.CommonSettings.StartWithModifiers = true;
-                    var currentModel = new FileModel {Context = ASContext.Context};
-                    new ASFileParser().ParseSrc(currentModel, sci.Text);
-                    var currentClass = currentModel.Classes[0];
-                    ASContext.Context.CurrentClass.Returns(currentClass);
-                    ASContext.Context.CurrentModel.Returns(currentModel);
-                    var currentMember = currentClass.Members[0];
-                    ASContext.Context.CurrentMember.Returns(currentMember);
+                    ASContext.Context.CurrentModel.Returns(new FileModel {Context = ASContext.Context});
                     var context = new AS3Context.Context(new AS3Settings());
                     context.BuildClassPath();
-                    ASContext.Context.GetVisibleExternalElements().Returns(x => context.GetVisibleExternalElements());
-                    ASContext.Context.GetCodeModel(null).ReturnsForAnyArgs(x =>
-                    {
-                        var src = x[0] as string;
-                        return string.IsNullOrEmpty(src) ? null : context.GetCodeModel(src);
-                    });
-                    ASContext.Context.ResolveType(null, null).ReturnsForAnyArgs(x => context.ResolveType(x.ArgAt<string>(0), x.ArgAt<FileModel>(1)));
-                    ASGenerator.contextToken = sci.GetWordFromPosition(sci.CurrentPos);
-                    ASGenerator.GenerateJob(job, currentMember, currentClass, null, null);
-                    return sci.Text;
+                    return Generate(sourceText, job, context);
                 }
 
                 public IEnumerable<TestCaseData> HaxeTestCases
@@ -1057,65 +948,211 @@ namespace ASCompletion.Completion
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.haxe.BeforeGenerateFunction.hx"),
-                                false,
                                 GeneratorJobType.Function
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.haxe.AfterGeneratePrivateFunction_generateExplicitScopeIsFalse.hx"))
-                                .SetName("Generate private function if generate explicit scope is false");
+                                .SetName("Generate private function");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.haxe.BeforeGenerateFunction.hx"),
-                                true,
-                                GeneratorJobType.Function
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePrivateFunction_generateExplicitScopeIsTrue.hx"))
-                                .SetName("Generate private function if generate explicit scope is true");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateFunction.hx"),
-                                false,
                                 GeneratorJobType.FunctionPublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicFunction_generateExplicitScopeIsFalse.hx"))
-                                .SetName("Generate public function if generate explicit scope is false");
+                                .SetName("Generate public function");
+                    }
+                }
+
+                [Test, TestCaseSource("HaxeTestCases")]
+                public string Haxe(string sourceText, GeneratorJobType job)
+                {
+                    sci.ConfigurationLanguage = "haxe";
+                    ASContext.Context.SetHaxeFeatures();
+                    ASContext.Context.CurrentModel.Returns(new FileModel {haXe = true, Context = ASContext.Context});
+                    return Generate(sourceText, job, new HaXeContext.Context(new HaXeSettings()));
+                }
+
+                string Generate(string sourceText, GeneratorJobType job, IASContext context)
+                {
+                    sci.Text = sourceText;
+                    SnippetHelper.PostProcessSnippets(sci, 0);
+                    var currentModel = ASContext.Context.CurrentModel;
+                    new ASFileParser().ParseSrc(currentModel, sci.Text);
+                    var currentClass = currentModel.Classes[0];
+                    ASContext.Context.CurrentClass.Returns(currentClass);
+                    var currentMember = currentClass.Members[0];
+                    ASContext.Context.CurrentMember.Returns(currentMember);
+                    ASContext.Context.GetVisibleExternalElements().Returns(x => context.GetVisibleExternalElements());
+                    ASContext.Context.GetCodeModel(null).ReturnsForAnyArgs(x =>
+                    {
+                        var src = x[0] as string;
+                        return string.IsNullOrEmpty(src) ? null : context.GetCodeModel(src);
+                    });
+                    ASContext.Context.ResolveType(null, null).ReturnsForAnyArgs(x => context.ResolveType(x.ArgAt<string>(0), x.ArgAt<FileModel>(1)));
+                    ASGenerator.contextToken = sci.GetWordFromPosition(sci.CurrentPos);
+                    ASGenerator.GenerateJob(job, currentMember, ASContext.Context.CurrentClass, null, null);
+                    return sci.Text;
+                }
+            }
+
+            [TestFixture]
+            public class GenerateFunctionWithExplicitScope : GenerateJob
+            {
+                [TestFixtureSetUp]
+                public void GenerateFunctionWithExplicitScopeSetup()
+                {
+                    ASContext.CommonSettings.StartWithModifiers = true;
+                    ASContext.CommonSettings.GenerateScope = true;
+                }
+
+                public IEnumerable<TestCaseData> AS3TestCases
+                {
+                    get
+                    {
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction.as"),
+                                GeneratorJobType.Function
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePrivateFunction_generateExplicitScopeIsTrue.as"))
+                                .SetName("Generate private function");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction.as"),
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicFunction_generateExplicitScopeIsTrue.as"))
+                                .SetName("Generate public function");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction_forSomeObj.as"),
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGenerateFunction_forSomeObj.as"))
+                                .SetName("From some.foo|();");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction_forSomeObj2.as"),
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGenerateFunction_forSomeObj2.as"))
+                                .SetName("From new Some().foo|();");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateFunction_forSomeObj3.as"),
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGenerateFunction_forSomeObj3.as"))
+                                .SetName("From new Some()\n.foo|();");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction.as"),
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as"))
+                                .SetName("Generate public static function");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction_forCurrentType.as"),
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as"))
+                                .SetName("From CurrentType.foo|");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction_forSomeType.as"),
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_forSomeType.as"))
+                                .SetName("From SomeType.foo|");
+                    }
+                }
+
+                [Test, TestCaseSource("AS3TestCases")]
+                public string AS3(string sourceText, GeneratorJobType job)
+                {
+                    sci.ConfigurationLanguage = "as3";
+                    ASContext.Context.SetAs3Features();
+                    ASContext.Context.CurrentModel.Returns(new FileModel { Context = ASContext.Context });
+                    var context = new AS3Context.Context(new AS3Settings());
+                    context.BuildClassPath();
+                    return Generate(sourceText, job, context);
+                }
+
+                public IEnumerable<TestCaseData> HaxeTestCases
+                {
+                    get
+                    {
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.haxe.BeforeGenerateFunction.hx"),
-                                true,
+                                GeneratorJobType.Function
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePrivateFunction_generateExplicitScopeIsTrue.hx"))
+                                .SetName("Generate private function");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateFunction.hx"),
                                 GeneratorJobType.FunctionPublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicFunction_generateExplicitScopeIsTrue.hx"))
-                                .SetName("Generate public function if generate explicit scope is true");
+                                .SetName("Generate public function");
                     }
                 }
 
                 [Test, TestCaseSource("HaxeTestCases")]
-                public string Haxe(string sourceText, bool generateExplicitScope, GeneratorJobType job)
+                public string Haxe(string sourceText, GeneratorJobType job)
+                {
+                    sci.ConfigurationLanguage = "haxe";
+                    ASContext.Context.SetHaxeFeatures();
+                    ASContext.Context.CurrentModel.Returns(new FileModel {haXe = true, Context = ASContext.Context});
+                    return Generate(sourceText, job, new HaXeContext.Context(new HaXeSettings()));
+                }
+
+                string Generate(string sourceText, GeneratorJobType job, IASContext context)
                 {
                     sci.Text = sourceText;
-                    sci.ConfigurationLanguage = "haxe";
                     SnippetHelper.PostProcessSnippets(sci, 0);
-                    ASContext.Context.SetHaxeFeatures();
-                    ASContext.CommonSettings.GenerateScope = generateExplicitScope;
-                    var currentModel = new FileModel {haXe = true, Context = ASContext.Context};
+                    var currentModel = ASContext.Context.CurrentModel;
                     new ASFileParser().ParseSrc(currentModel, sci.Text);
                     var currentClass = currentModel.Classes[0];
                     ASContext.Context.CurrentClass.Returns(currentClass);
-                    ASContext.Context.CurrentModel.Returns(currentModel);
                     var currentMember = currentClass.Members[0];
                     ASContext.Context.CurrentMember.Returns(currentMember);
-                    var context = new HaXeContext.Context(new HaXeSettings());
                     ASContext.Context.GetVisibleExternalElements().Returns(x => context.GetVisibleExternalElements());
                     ASContext.Context.GetCodeModel(null).ReturnsForAnyArgs(x =>
                     {
@@ -1132,6 +1169,12 @@ namespace ASCompletion.Completion
             [TestFixture]
             public class GenerateVariable : GenerateJob
             {
+                [TestFixtureSetUp]
+                public void GenerateVariableSetup()
+                {
+                    ASContext.CommonSettings.StartWithModifiers = true;
+                }
+
                 public IEnumerable<TestCaseData> AS3TestCases
                 {
                     get
@@ -1140,117 +1183,56 @@ namespace ASCompletion.Completion
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable.as"),
-                                false,
                                 GeneratorJobType.Variable
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGeneratePrivateVariable_generateExplicitScopeIsFalse.as"))
-                                .SetName("Generate private variable if generate explicit scope is false");
+                                .SetName("Generate private variable");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable.as"),
-                                true,
-                                GeneratorJobType.Variable
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePrivateVariable_generateExplicitScopeIsTrue.as"))
-                                .SetName("Generate private variable if generate explicit scope is true");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable.as"),
-                                false,
                                 GeneratorJobType.VariablePublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicVariable_generateExplicitScopeIsFalse.as"))
-                                .SetName("Generate public variable if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable.as"),
-                                true,
-                                GeneratorJobType.VariablePublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicVariable_generateExplicitScopeIsTrue.as"))
-                                .SetName("Generate public variable if generate explicit scope is true");
+                                .SetName("Generate public variable");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable_forSomeObj.as"),
-                                false,
                                 GeneratorJobType.VariablePublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGenerateVariable_forSomeObj.as"))
-                                .SetName("From some.foo| if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable_forSomeObj.as"),
-                                true,
-                                GeneratorJobType.VariablePublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterGenerateVariable_forSomeObj.as"))
-                                .SetName("From some.foo| if generate explicit scope is true");
+                                .SetName("From some.foo|");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable_forSomeObj2.as"),
-                                false,
                                 GeneratorJobType.VariablePublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGenerateVariable_forSomeObj2.as"))
-                                .SetName("From new Some().foo| if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable_forSomeObj2.as"),
-                                true,
-                                GeneratorJobType.VariablePublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterGenerateVariable_forSomeObj2.as"))
-                                .SetName("From new Some().foo| if generate explicit scope is true");
+                                .SetName("From new Some().foo|");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable_forSomeObj3.as"),
-                                false,
                                 GeneratorJobType.VariablePublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGenerateVariable_forSomeObj3.as"))
-                                .SetName("From new Some()\n.foo| if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable_forSomeObj3.as"),
-                                true,
-                                GeneratorJobType.VariablePublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterGenerateVariable_forSomeObj3.as"))
-                                .SetName("From new Some()\n.foo| if generate explicit scope is true");
+                                .SetName("From new Some()\n.foo|");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticVariable_forCurrentType.as"),
-                                false,
                                 GeneratorJobType.VariablePublic
                                 )
                                 .Returns(
@@ -1261,7 +1243,6 @@ namespace ASCompletion.Completion
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticVariable_forSomeType.as"),
-                                false,
                                 GeneratorJobType.VariablePublic
                                 )
                                 .Returns(
@@ -1272,23 +1253,93 @@ namespace ASCompletion.Completion
                 }
 
                 [Test, TestCaseSource("AS3TestCases")]
-                public string AS3(string sourceText, bool generateExplicitScope, GeneratorJobType job)
+                public string AS3(string sourceText, GeneratorJobType job)
+                {
+                    sci.ConfigurationLanguage = "as3";
+                    ASContext.Context.SetAs3Features();
+                    ASContext.Context.CurrentModel.Returns(new FileModel {Context = ASContext.Context});
+                    var context = new AS3Context.Context(new AS3Settings());
+                    context.BuildClassPath();
+                    return Generate(sourceText, job, context);
+                }
+
+                public IEnumerable<TestCaseData> HaxeTestCases
+                {
+                    get
+                    {
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateVariable.hx"),
+                                GeneratorJobType.Variable
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePrivateVariable_generateExplicitScopeIsFalse.hx"))
+                                .SetName("Generate private variable");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateVariable.hx"),
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicVariable_generateExplicitScopeIsFalse.hx"))
+                                .SetName("Generate public variable");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateStaticVariable.hx"),
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_generateExplicitScopeIsFalse.hx"))
+                                .SetName("Generate public static variable");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGeneratePublicStaticVariable_forSomeType.hx"),
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_forSomeType.hx"))
+                                .SetName("From SomeType.foo|");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGeneratePublicStaticVariable_forCurrentType.hx"),
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_forCurrentType.hx"))
+                                .SetName("From CurrentType.foo|");
+                    }
+                }
+
+                [Test, TestCaseSource("HaxeTestCases")]
+                public string Haxe(string sourceText, GeneratorJobType job)
+                {
+                    sci.ConfigurationLanguage = "haxe";
+                    ASContext.Context.SetHaxeFeatures();
+                    ASContext.Context.CurrentModel.Returns(new FileModel {haXe = true, Context = ASContext.Context});
+                    return Generate(sourceText, job, new HaXeContext.Context(new HaXeSettings()));
+                }
+
+                string Generate(string sourceText, GeneratorJobType job, IASContext context)
                 {
                     sci.Text = sourceText;
-                    sci.ConfigurationLanguage = "as3";
                     SnippetHelper.PostProcessSnippets(sci, 0);
-                    ASContext.Context.SetAs3Features();
-                    ASContext.CommonSettings.GenerateScope = generateExplicitScope;
-                    ASContext.CommonSettings.StartWithModifiers = true;
-                    var currentModel = new FileModel {Context = ASContext.Context};
+                    var currentModel = ASContext.Context.CurrentModel;
                     new ASFileParser().ParseSrc(currentModel, sci.Text);
                     var currentClass = currentModel.Classes[0];
                     ASContext.Context.CurrentClass.Returns(currentClass);
                     ASContext.Context.CurrentModel.Returns(currentModel);
                     var currentMember = currentClass.Members[0];
                     ASContext.Context.CurrentMember.Returns(currentMember);
-                    var context = new AS3Context.Context(new AS3Settings());
-                    context.BuildClassPath();
                     ASContext.Context.GetVisibleExternalElements().Returns(x => context.GetVisibleExternalElements());
                     ASContext.Context.GetCodeModel(null).ReturnsForAnyArgs(x =>
                     {
@@ -1300,6 +1351,85 @@ namespace ASCompletion.Completion
                     ASGenerator.GenerateJob(job, currentMember, ASContext.Context.CurrentClass, null, null);
                     return sci.Text;
                 }
+            }
+
+            [TestFixture]
+            public class GenerateVariableWithExplicitScope : GenerateJob
+            {
+                [TestFixtureSetUp]
+                public void GenerateVariableWithExplicitScopeSetup()
+                {
+                    ASContext.CommonSettings.StartWithModifiers = true;
+                    ASContext.CommonSettings.GenerateScope = true;
+                }
+
+                public IEnumerable<TestCaseData> AS3TestCases
+                {
+                    get
+                    {
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable.as"),
+                                GeneratorJobType.Variable
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePrivateVariable_generateExplicitScopeIsTrue.as"))
+                                .SetName("Generate private variable");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable.as"),
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicVariable_generateExplicitScopeIsTrue.as"))
+                                .SetName("Generate public variable");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable_forSomeObj.as"),
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGenerateVariable_forSomeObj.as"))
+                                .SetName("From some.foo|");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable_forSomeObj2.as"),
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGenerateVariable_forSomeObj2.as"))
+                                .SetName("From new Some().foo|");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateVariable_forSomeObj3.as"),
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGenerateVariable_forSomeObj3.as"))
+                                .SetName("From new Some()\n.foo|");
+                    }
+                }
+
+                [Test, TestCaseSource("AS3TestCases")]
+                public string AS3(string sourceText, GeneratorJobType job)
+                {
+                    sci.ConfigurationLanguage = "as3";
+                    ASContext.Context.SetAs3Features();
+                    ASContext.Context.CurrentModel.Returns(new FileModel {Context = ASContext.Context});
+                    var context = new AS3Context.Context(new AS3Settings());
+                    context.BuildClassPath();
+                    return Generate(sourceText, job, context);
+                }
 
                 public IEnumerable<TestCaseData> HaxeTestCases
                 {
@@ -1309,132 +1439,75 @@ namespace ASCompletion.Completion
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.haxe.BeforeGenerateVariable.hx"),
-                                false,
-                                GeneratorJobType.Variable
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePrivateVariable_generateExplicitScopeIsFalse.hx"))
-                                .SetName("Generate private variable if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateVariable.hx"),
-                                true,
                                 GeneratorJobType.Variable
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.haxe.AfterGeneratePrivateVariable_generateExplicitScopeIsTrue.hx"))
-                                .SetName("Generate private variable if generate explicit scope is true");
+                                .SetName("Generate private variable");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.haxe.BeforeGenerateVariable.hx"),
-                                false,
-                                GeneratorJobType.VariablePublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicVariable_generateExplicitScopeIsFalse.hx"))
-                                .SetName("Generate public variable if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateVariable.hx"),
-                                true,
                                 GeneratorJobType.VariablePublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicVariable_generateExplicitScopeIsTrue.hx"))
-                                .SetName("Generate public variable if generate explicit scope is true");
+                                .SetName("Generate public variable");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.haxe.BeforeGenerateStaticVariable.hx"),
-                                false,
-                                GeneratorJobType.VariablePublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_generateExplicitScopeIsFalse.hx"))
-                                .SetName("Generate public static variable if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateStaticVariable.hx"),
-                                true,
                                 GeneratorJobType.VariablePublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_generateExplicitScopeIsTrue.hx"))
-                                .SetName("Generate public static variable if generate explicit scope is true");
+                                .SetName("Generate public static variable");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.haxe.BeforeGeneratePublicStaticVariable_forSomeType.hx"),
-                                false,
                                 GeneratorJobType.VariablePublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_forSomeType.hx"))
-                                .SetName("From SomeType.foo| variable if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.haxe.BeforeGeneratePublicStaticVariable_forSomeType.hx"),
-                                true,
-                                GeneratorJobType.VariablePublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_forSomeType.hx"))
-                                .SetName("From SomeType.foo| variable if generate explicit scope is true");
+                                .SetName("From SomeType.foo| variable");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.haxe.BeforeGeneratePublicStaticVariable_forCurrentType.hx"),
-                                false,
                                 GeneratorJobType.VariablePublic
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_forCurrentType.hx"))
-                                .SetName("From CurrentType.foo| variable if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.haxe.BeforeGeneratePublicStaticVariable_forCurrentType.hx"),
-                                true,
-                                GeneratorJobType.VariablePublic
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_forCurrentType.hx"))
-                                .SetName("From CurrentType.foo| variable if generate explicit scope is true");
+                                .SetName("From CurrentType.foo| variable");
                     }
                 }
 
                 [Test, TestCaseSource("HaxeTestCases")]
-                public string Haxe(string sourceText, bool generateExplicitScope, GeneratorJobType job)
+                public string Haxe(string sourceText, GeneratorJobType job)
+                {
+                    sci.ConfigurationLanguage = "haxe";
+                    ASContext.Context.SetHaxeFeatures();
+                    ASContext.Context.CurrentModel.Returns(new FileModel {haXe = true, Context = ASContext.Context});
+                    return Generate(sourceText, job, new HaXeContext.Context(new HaXeSettings()));
+                }
+
+                string Generate(string sourceText, GeneratorJobType job, IASContext context)
                 {
                     sci.Text = sourceText;
-                    sci.ConfigurationLanguage = "haxe";
                     SnippetHelper.PostProcessSnippets(sci, 0);
-                    ASContext.Context.SetHaxeFeatures();
-                    ASContext.CommonSettings.GenerateScope = generateExplicitScope;
-                    ASContext.CommonSettings.StartWithModifiers = true;
-                    var currentModel = new FileModel {haXe = true, Context = ASContext.Context};
+                    var currentModel = ASContext.Context.CurrentModel;
                     new ASFileParser().ParseSrc(currentModel, sci.Text);
                     var currentClass = currentModel.Classes[0];
                     ASContext.Context.CurrentClass.Returns(currentClass);
                     ASContext.Context.CurrentModel.Returns(currentModel);
                     var currentMember = currentClass.Members[0];
                     ASContext.Context.CurrentMember.Returns(currentMember);
-                    var context = new HaXeContext.Context(new HaXeSettings());
                     ASContext.Context.GetVisibleExternalElements().Returns(x => context.GetVisibleExternalElements());
                     ASContext.Context.GetCodeModel(null).ReturnsForAnyArgs(x =>
                     {
@@ -1671,15 +1744,15 @@ namespace ASCompletion.Completion
                 [Test, TestCaseSource("HaxeTestCases")]
                 public string Haxe(string sourceText)
                 {
-                    sci.Text = sourceText;
                     sci.ConfigurationLanguage = "haxe";
-                    SnippetHelper.PostProcessSnippets(sci, 0);
                     ASContext.Context.SetHaxeFeatures();
-                    var currentModel = new FileModel {haXe = true, Context = ASContext.Context};
+                    ASContext.Context.CurrentModel.Returns(new FileModel {haXe = true, Context = ASContext.Context});
+                    sci.Text = sourceText;
+                    SnippetHelper.PostProcessSnippets(sci, 0);
+                    var currentModel = ASContext.Context.CurrentModel;
                     new ASFileParser().ParseSrc(currentModel, sci.Text);
                     var currentClass = currentModel.Classes[0];
                     var currentMember = currentClass.Members[0];
-                    ASContext.Context.CurrentModel.Returns(currentModel);
                     ASContext.Context.CurrentClass.Returns(currentClass);
                     ASContext.Context.CurrentMember.Returns(currentMember);
                     ASGenerator.GenerateJob(GeneratorJobType.GetterSetter, currentMember, ASContext.Context.CurrentClass, null, null);
@@ -1720,13 +1793,13 @@ namespace ASCompletion.Completion
                 [Test, TestCaseSource("AS3TestCases")]
                 public string AS3(string sourceText)
                 {
-                    sci.Text = sourceText;
                     sci.ConfigurationLanguage = "as3";
-                    SnippetHelper.PostProcessSnippets(sci, 0);
                     ASContext.Context.SetAs3Features();
-                    var currentModel = new FileModel {Context = ASContext.Context};
+                    ASContext.Context.CurrentModel.Returns(new FileModel {Context = ASContext.Context});
+                    sci.Text = sourceText;
+                    SnippetHelper.PostProcessSnippets(sci, 0);
+                    var currentModel = ASContext.Context.CurrentModel;
                     new ASFileParser().ParseSrc(currentModel, sci.Text);
-                    ASContext.Context.CurrentModel.Returns(currentModel);
                     var currentClass = currentModel.Classes[0];
                     var currentMember = currentClass.Members[0];
                     ASContext.Context.CurrentClass.Returns(currentClass);

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
@@ -1459,8 +1459,7 @@ namespace ASCompletion.Completion
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateEventHandler.as"),
-                                new string[0],
-                                false
+                                new string[0]
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
@@ -1470,44 +1469,71 @@ namespace ASCompletion.Completion
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.as3.BeforeGenerateEventHandler.as"),
-                                new[] {"Event.ADDED", "Event.REMOVED"},
-                                false
+                                new[] {"Event.ADDED", "Event.REMOVED"}
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGenerateEventHandler_withAutoRemove.as"))
-                                .SetName("Generate event handler with auto remove if generate explicit scope is false");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateEventHandler.as"),
-                                new[] {"Event.ADDED", "Event.REMOVED"},
-                                true
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterGenerateEventHandler_withAutoRemove_generateExplicitScopeIsTrue.as"))
-                                .SetName("Generate event handler with auto remove if generate explicit scope is true");
+                                .SetName("Generate event handler with auto remove");
                     }
                 }
 
                 [Test, TestCaseSource("AS3TestCases")]
-                public string AS3(string sourceText, string[] autoRemove, bool generateExplicitScope)
+                public string AS3(string sourceText, string[] autoRemove)
+                {
+                    sci.ConfigurationLanguage = "as3";
+                    ASContext.Context.SetAs3Features();
+                    ASContext.Context.CurrentModel.Returns(new FileModel {Context = ASContext.Context});
+                    return Generate(sourceText, autoRemove, new AS3Context.Context(new AS3Settings()));
+                }
+
+                public IEnumerable<TestCaseData> HaxeTestCases
+                {
+                    get
+                    {
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateEventHandler.hx"),
+                                new string[0]
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGenerateEventHandler_withoutAutoRemove.hx"))
+                                .SetName("Generate event handler without auto remove");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateEventHandler.hx"),
+                                new[] {"Event.ADDED", "Event.REMOVED"}
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGenerateEventHandler_withAutoRemove.hx"))
+                                .SetName("Generate event handler with auto remove");
+                    }
+                }
+
+                [Test, TestCaseSource("HaxeTestCases")]
+                public string Haxe(string sourceText, string[] autoRemove)
+                {
+                    sci.ConfigurationLanguage = "haxe";
+                    ASContext.Context.SetHaxeFeatures();
+                    ASContext.Context.CurrentModel.Returns(new FileModel {haXe = true, Context = ASContext.Context});
+                    return Generate(sourceText, autoRemove, new HaXeContext.Context(new HaXeSettings()));
+                }
+
+                string Generate(string sourceText, string[] autoRemove, IASContext context)
                 {
                     sci.Text = sourceText;
-                    sci.ConfigurationLanguage = "as3";
                     SnippetHelper.PostProcessSnippets(sci, 0);
-                    ASContext.Context.SetAs3Features();
                     ASContext.CommonSettings.EventListenersAutoRemove = autoRemove;
-                    ASContext.CommonSettings.GenerateScope = generateExplicitScope;
-                    var currentModel = new FileModel {Context = ASContext.Context};
+                    var currentModel = ASContext.Context.CurrentModel;
                     new ASFileParser().ParseSrc(currentModel, sci.Text);
                     var currentClass = currentModel.Classes[0];
                     ASContext.Context.CurrentClass.Returns(currentClass);
-                    ASContext.Context.CurrentModel.Returns(currentModel);
                     var currentMember = currentClass.Members[0];
                     ASContext.Context.CurrentMember.Returns(currentMember);
-                    var context = new AS3Context.Context(new AS3Settings());
                     ASContext.Context.GetVisibleExternalElements().Returns(x => context.GetVisibleExternalElements());
                     ASContext.Context.GetCodeModel(null).ReturnsForAnyArgs(x =>
                     {
@@ -1524,6 +1550,42 @@ namespace ASCompletion.Completion
                     ASGenerator.GenerateJob(GeneratorJobType.ComplexEvent, currentMember, ASContext.Context.CurrentClass, null, null);
                     return sci.Text;
                 }
+            }
+
+            [TestFixture]
+            public class GenerateEventHandlerWithExplicitScope : GenerateJob
+            {
+                [TestFixtureSetUp]
+                public void GenerateEventHandlerWithExplicitScopeSetup()
+                {
+                    ASContext.CommonSettings.GenerateScope = true;
+                }
+
+                public IEnumerable<TestCaseData> AS3TestCases
+                {
+                    get
+                    {
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateEventHandler.as"),
+                                new[] {"Event.ADDED", "Event.REMOVED"}
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGenerateEventHandler_withAutoRemove_generateExplicitScopeIsTrue.as"))
+                                .SetName("Generate event handler with auto remove");
+                    }
+                }
+
+                [Test, TestCaseSource("AS3TestCases")]
+                public string AS3(string sourceText, string[] autoRemove)
+                {
+                    sci.ConfigurationLanguage = "as3";
+                    ASContext.Context.SetAs3Features();
+                    ASContext.Context.CurrentModel.Returns(new FileModel {Context = ASContext.Context});
+                    return Generate(sourceText, autoRemove, new AS3Context.Context(new AS3Settings()));
+                }
 
                 public IEnumerable<TestCaseData> HaxeTestCases
                 {
@@ -1533,62 +1595,42 @@ namespace ASCompletion.Completion
                             new TestCaseData(
                                 TestFile.ReadAllText(
                                     "ASCompletion.Test_Files.generated.haxe.BeforeGenerateEventHandler.hx"),
-                                new string[0],
-                                false
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.haxe.AfterGenerateEventHandler_withoutAutoRemove.hx"))
-                                .SetName("Generate event handler without auto remove");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateEventHandler.hx"),
-                                new[] { "Event.ADDED", "Event.REMOVED" },
-                                false
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.haxe.AfterGenerateEventHandler_withAutoRemove.hx"))
-                                .SetName("Generate event handler with auto remove");
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateEventHandler.hx"),
-                                new[] {"Event.ADDED", "Event.REMOVED"},
-                                true
+                                new[] {"Event.ADDED", "Event.REMOVED"}
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.haxe.AfterGenerateEventHandler_withAutoRemove_generateExplicitScopeIsTrue.hx"))
-                                .SetName("Generate event handler with auto remove if generate explicit scope is true");
+                                .SetName("Generate event handler with auto remove");
                     }
                 }
 
                 [Test, TestCaseSource("HaxeTestCases")]
-                public string Haxe(string sourceText, string[] autoRemove, bool generateExplicitScope)
+                public string Haxe(string sourceText, string[] autoRemove)
+                {
+                    sci.ConfigurationLanguage = "haxe";
+                    ASContext.Context.SetHaxeFeatures();
+                    ASContext.Context.CurrentModel.Returns(new FileModel {haXe = true, Context = ASContext.Context});
+                    return Generate(sourceText, autoRemove, new HaXeContext.Context(new HaXeSettings()));
+                }
+
+                string Generate(string sourceText, string[] autoRemove, IASContext context)
                 {
                     sci.Text = sourceText;
-                    sci.ConfigurationLanguage = "haxe";
                     SnippetHelper.PostProcessSnippets(sci, 0);
-                    ASContext.Context.SetHaxeFeatures();
                     ASContext.CommonSettings.EventListenersAutoRemove = autoRemove;
-                    ASContext.CommonSettings.GenerateScope = generateExplicitScope;
-                    var currentModel = new FileModel {haXe = true, Context = ASContext.Context};
+                    var currentModel = ASContext.Context.CurrentModel;
                     new ASFileParser().ParseSrc(currentModel, sci.Text);
                     var currentClass = currentModel.Classes[0];
                     ASContext.Context.CurrentClass.Returns(currentClass);
-                    ASContext.Context.CurrentModel.Returns(currentModel);
                     var currentMember = currentClass.Members[0];
                     ASContext.Context.CurrentMember.Returns(currentMember);
-                    var context = new AS3Context.Context(new AS3Settings());
                     ASContext.Context.GetVisibleExternalElements().Returns(x => context.GetVisibleExternalElements());
                     ASContext.Context.GetCodeModel(null).ReturnsForAnyArgs(x =>
                     {
                         var src = x[0] as string;
                         return string.IsNullOrEmpty(src) ? null : context.GetCodeModel(src);
                     });
-                    var eventModel = new ClassModel {Name = "Event", Type = "flash.events.Event"};
+                    var eventModel = new ClassModel { Name = "Event", Type = "flash.events.Event" };
                     ASContext.Context.ResolveType(null, null).ReturnsForAnyArgs(x => eventModel);
                     ASGenerator.contextToken = sci.GetWordFromPosition(sci.CurrentPos);
                     var re = string.Format(ASGenerator.patternEvent, ASGenerator.contextToken);

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
@@ -950,6 +950,72 @@ namespace ASCompletion.Completion
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGenerateFunction_forSomeObj3.as"))
                                 .SetName("From new Some()\n.foo|(); if generate explicit scope is true");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction.as"),
+                                false,
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_generateExplicitScopeIsFalse.as"))
+                                .SetName("Generate public static function if generate explicit scope is false");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction.as"),
+                                true,
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as"))
+                                .SetName("Generate public static function if generate explicit scope is true");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction_forCurrentType.as"),
+                                false,
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as"))
+                                .SetName("From CurrentType.foo| if generate explicit scope is false");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction_forCurrentType.as"),
+                                true,
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as"))
+                                .SetName("From CurrentType.foo| if generate explicit scope is true");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction_forSomeType.as"),
+                                false,
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_forSomeType.as"))
+                                .SetName("From SomeType.foo| if generate explicit scope is false");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticFunction_forSomeType.as"),
+                                true,
+                                GeneratorJobType.FunctionPublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticFunction_forSomeType.as"))
+                                .SetName("From SomeType.foo| if generate explicit scope is true");
                     }
                 }
 
@@ -961,6 +1027,7 @@ namespace ASCompletion.Completion
                     SnippetHelper.PostProcessSnippets(sci, 0);
                     ASContext.Context.SetAs3Features();
                     ASContext.CommonSettings.GenerateScope = generateExplicitScope;
+                    ASContext.CommonSettings.StartWithModifiers = true;
                     var currentModel = new FileModel {Context = ASContext.Context};
                     new ASFileParser().ParseSrc(currentModel, sci.Text);
                     var currentClass = currentModel.Classes[0];
@@ -1179,6 +1246,28 @@ namespace ASCompletion.Completion
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGenerateVariable_forSomeObj3.as"))
                                 .SetName("From new Some()\n.foo| if generate explicit scope is true");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticVariable_forCurrentType.as"),
+                                false,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticVariable_forCurrentType.as"))
+                                .SetName("From CurrentType.foo|");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.as3.BeforeGenerateStaticVariable_forSomeType.as"),
+                                false,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.as3.AfterGeneratePublicStaticVariable_forSomeType.as"))
+                                .SetName("From SomeType.foo|");
                     }
                 }
 
@@ -1190,6 +1279,7 @@ namespace ASCompletion.Completion
                     SnippetHelper.PostProcessSnippets(sci, 0);
                     ASContext.Context.SetAs3Features();
                     ASContext.CommonSettings.GenerateScope = generateExplicitScope;
+                    ASContext.CommonSettings.StartWithModifiers = true;
                     var currentModel = new FileModel {Context = ASContext.Context};
                     new ASFileParser().ParseSrc(currentModel, sci.Text);
                     var currentClass = currentModel.Classes[0];
@@ -1259,6 +1349,72 @@ namespace ASCompletion.Completion
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicVariable_generateExplicitScopeIsTrue.hx"))
                                 .SetName("Generate public variable if generate explicit scope is true");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateStaticVariable.hx"),
+                                false,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_generateExplicitScopeIsFalse.hx"))
+                                .SetName("Generate public static variable if generate explicit scope is false");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateStaticVariable.hx"),
+                                true,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_generateExplicitScopeIsTrue.hx"))
+                                .SetName("Generate public static variable if generate explicit scope is true");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGeneratePublicStaticVariable_forSomeType.hx"),
+                                false,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_forSomeType.hx"))
+                                .SetName("From SomeType.foo| variable if generate explicit scope is false");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGeneratePublicStaticVariable_forSomeType.hx"),
+                                true,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_forSomeType.hx"))
+                                .SetName("From SomeType.foo| variable if generate explicit scope is true");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGeneratePublicStaticVariable_forCurrentType.hx"),
+                                false,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_forCurrentType.hx"))
+                                .SetName("From CurrentType.foo| variable if generate explicit scope is false");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeGeneratePublicStaticVariable_forCurrentType.hx"),
+                                true,
+                                GeneratorJobType.VariablePublic
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterGeneratePublicStaticVariable_forCurrentType.hx"))
+                                .SetName("From CurrentType.foo| variable if generate explicit scope is true");
                     }
                 }
 
@@ -1270,6 +1426,7 @@ namespace ASCompletion.Completion
                     SnippetHelper.PostProcessSnippets(sci, 0);
                     ASContext.Context.SetHaxeFeatures();
                     ASContext.CommonSettings.GenerateScope = generateExplicitScope;
+                    ASContext.CommonSettings.StartWithModifiers = true;
                     var currentModel = new FileModel {haXe = true, Context = ASContext.Context};
                     new ASFileParser().ParseSrc(currentModel, sci.Text);
                     var currentClass = currentModel.Classes[0];
@@ -1319,7 +1476,7 @@ namespace ASCompletion.Completion
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "ASCompletion.Test_Files.generated.as3.AfterGenerateEventHandler_withAutoRemove.as"))
-                                .SetName("Generate event handler with auto remove");
+                                .SetName("Generate event handler with auto remove if generate explicit scope is false");
                         yield return
                             new TestCaseData(
                                 TestFile.ReadAllText(

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticFunction_forSomeType.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticFunction_forSomeType.as
@@ -1,0 +1,16 @@
+﻿package {
+	public class Main {
+		public static function main():void {
+			Some.foo();
+		}
+		
+		public function Main() {
+		}
+	}
+}
+
+class Some {
+	public static function foo():void {
+		
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticFunction_generateExplicitScopeIsFalse.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticFunction_generateExplicitScopeIsFalse.as
@@ -1,0 +1,14 @@
+﻿package {
+	public class Main {
+		public static function main():void {
+			foo();
+		}
+		
+		public static function foo():void {
+			
+		}
+		
+		public function Main() {
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticFunction_generateExplicitScopeIsTrue.as
@@ -1,0 +1,14 @@
+﻿package {
+	public class Main {
+		public static function main():void {
+			Main.foo();
+		}
+		
+		public static function foo():void {
+			
+		}
+		
+		public function Main() {
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticVariable_forCurrentType.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticVariable_forCurrentType.as
@@ -1,0 +1,8 @@
+﻿package {
+	public class Main {
+		public static var test;
+		public function Main() {
+			Main.test;
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticVariable_forSomeType.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterGeneratePublicStaticVariable_forSomeType.as
@@ -1,0 +1,11 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			Some.test;
+		}
+	}
+}
+
+class Some {
+	public static var test;
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticFunction.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticFunction.as
@@ -1,0 +1,10 @@
+﻿package {
+	public class Main {
+		public static function main():void {
+			foo$(EntryPoint)();
+		}
+		
+		public function Main() {
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticFunction_forCurrentType.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticFunction_forCurrentType.as
@@ -1,0 +1,10 @@
+﻿package {
+	public class Main {
+		public static function main():void {
+			Main.foo$(EntryPoint)();
+		}
+		
+		public function Main() {
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticFunction_forSomeType.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticFunction_forSomeType.as
@@ -1,0 +1,13 @@
+﻿package {
+	public class Main {
+		public static function main():void {
+			Some.foo$(EntryPoint)();
+		}
+		
+		public function Main() {
+		}
+	}
+}
+
+class Some {
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticVariable_forCurrentType.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticVariable_forCurrentType.as
@@ -1,0 +1,7 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			Main.test$(EntryPoint);
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticVariable_forSomeType.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeGenerateStaticVariable_forSomeType.as
@@ -1,0 +1,10 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			Some.test$(EntryPoint);
+		}
+	}
+}
+
+class Some {
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_forCurrentType.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_forCurrentType.hx
@@ -1,0 +1,7 @@
+﻿package;
+public class Main {
+	public static var test;
+	public static function main() {
+		Main.test;
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_forSomeType.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_forSomeType.hx
@@ -1,0 +1,10 @@
+﻿package;
+public class Main {
+	public static function main() {
+		Some.test;
+	}
+}
+
+public class Some {
+	public static var test;
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_generateExplicitScopeIsFalse.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_generateExplicitScopeIsFalse.hx
@@ -1,0 +1,7 @@
+﻿package;
+public class Main {
+	public static var test;
+	public static function main() {
+		test;
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_generateExplicitScopeIsTrue.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterGeneratePublicStaticVariable_generateExplicitScopeIsTrue.hx
@@ -1,0 +1,7 @@
+﻿package;
+public class Main {
+	public static var test;
+	public static function main() {
+		Main.test;
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeGeneratePublicStaticVariable_forCurrentType.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeGeneratePublicStaticVariable_forCurrentType.hx
@@ -1,0 +1,6 @@
+﻿package;
+public class Main {
+	public static function main() {
+		Main.test$(EntryPoint);
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeGeneratePublicStaticVariable_forSomeType.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeGeneratePublicStaticVariable_forSomeType.hx
@@ -1,0 +1,9 @@
+﻿package;
+public class Main {
+	public static function main() {
+		Some.test$(EntryPoint);
+	}
+}
+
+public class Some {
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeGenerateStaticVariable.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeGenerateStaticVariable.hx
@@ -1,0 +1,6 @@
+﻿package;
+public class Main {
+	public static function main() {
+		test$(EntryPoint);
+	}
+}


### PR DESCRIPTION
BUG in release 5.1.1, code for example:
```
package {
	public class Main {
		public function Main() {
			Main.test|;
		}
	}
}
```
result after generating variable:
```
package {
	public class Main {
		private var test;//must be private static var test;
		public function Main() {
			Main.test;
		}
	}
}
```

BUG in developmnet version if setting generate explicit scope is true, code for example:
```
package;
public class Main {
	public static function main() {
		test|;
	}
}
```
result after generating variable:
```
package;
public class Main {
	static private var test;
	public static function main() {
		this.test;//must be Main.test
	}
}
```