### PR TITLE
Notify Restart Required on Settings Change

### DIFF
--- a/FlashDevelop/Dialogs/SettingDialog.cs
+++ b/FlashDevelop/Dialogs/SettingDialog.cs
@@ -46,6 +46,7 @@ namespace FlashDevelop.Dialogs
             this.InitializeContextMenu();
             this.PopulatePluginList(itemName, filter);
             this.ApplyLocalizedTexts();
+            this.UpdateInfo();
         }
 
         #region Windows Form Designer Generated Code
@@ -257,13 +258,13 @@ namespace FlashDevelop.Dialogs
         {
             ImageList imageList = new ImageList();
             imageList.ColorDepth = ColorDepth.Depth32Bit;
+            imageList.ImageSize = ScaleHelper.Scale(new Size(16, 16));
             imageList.Images.Add(Globals.MainForm.FindImage("341", false));
             imageList.Images.Add(Globals.MainForm.FindImage("342", false));
             imageList.Images.Add(Globals.MainForm.FindImage("50", false));
             imageList.Images.Add(Globals.MainForm.FindImage("153", false)); // clear
-            this.infoPictureBox.Image = Globals.MainForm.FindImage("229", false);
+            //this.infoPictureBox.Image = Globals.MainForm.FindImage("229", false);
             this.itemListView.SmallImageList = imageList;
-            this.itemListView.SmallImageList.ImageSize = ScaleHelper.Scale(new Size(16, 16));
             this.clearFilterButton.ImageList = imageList;
             this.clearFilterButton.ImageIndex = 3;
         }
@@ -276,7 +277,7 @@ namespace FlashDevelop.Dialogs
             this.helpLabel.Text = TextHelper.GetString("Info.Help");
             this.Text = " " + TextHelper.GetString("Title.SettingDialog");
             this.disableCheckBox.Text = " " + TextHelper.GetString("Info.Disable");
-            this.infoLabel.Text = TextHelper.GetString("Info.SettingsTakeEffect");
+            //this.infoLabel.Text = TextHelper.GetString("Info.SettingsTakeEffect");
             this.filterLabel.Text = TextHelper.GetString("Info.FilterSettings");
             this.nameLabel.Text = TextHelper.GetString("Info.NoItemSelected");
             this.closeButton.Text = TextHelper.GetString("Label.Close");
@@ -500,6 +501,7 @@ namespace FlashDevelop.Dialogs
 
                 if (changedItem.PropertyDescriptor.Attributes.Matches(new RequiresRestartAttribute()))
                 {
+                    bool previous = requireRestart.Count > 0;
                     if (requireRestart.Contains(settingId))
                     {
                         if (requireRestart[settingId].Equals(changedItem.Value))
@@ -508,18 +510,22 @@ namespace FlashDevelop.Dialogs
                         }
                     }
                     else requireRestart.Add(settingId, e.OldValue);
-
-                    if (requireRestart.Count > 0)
-                    {
-                        this.infoLabel.Text = TextHelper.GetString("Info.RequiresRestart");
-                        this.infoPictureBox.Image = Globals.MainForm.FindImage("196", false);
-                    }
-                    else
-                    {
-                        this.infoLabel.Text = TextHelper.GetString("Info.SettingsTakeEffect");
-                        this.infoPictureBox.Image = Globals.MainForm.FindImage("229", false);
-                    }
+                    if (requireRestart.Count > 0 != previous)  UpdateInfo();
                 }
+            }
+        }
+
+        private void UpdateInfo()
+        {
+            if (requireRestart.Count > 0)
+            {
+                this.infoLabel.Text = TextHelper.GetString("Info.RequiresRestart");
+                this.infoPictureBox.Image = Globals.MainForm.FindImage("196", false);
+            }
+            else
+            {
+                this.infoLabel.Text = TextHelper.GetString("Info.SettingsTakeEffect");
+                this.infoPictureBox.Image = Globals.MainForm.FindImage("229", false);
             }
         }
 
@@ -596,8 +602,7 @@ namespace FlashDevelop.Dialogs
             if (sdkContext != null) sdkContext.Dispose();
             Globals.MainForm.ApplyAllSettings();
             Globals.MainForm.SaveSettings();
-            if (requireRestart.Count > 0) Globals.MainForm.RestartRequired();
-            else Globals.MainForm.CancelRestartRequired();
+            if (requireRestart.Count > 0 && !Globals.MainForm.RequiresRestart) Globals.MainForm.RestartRequired();
         }
 
         /// <summary>

--- a/FlashDevelop/Dialogs/SettingDialog.cs
+++ b/FlashDevelop/Dialogs/SettingDialog.cs
@@ -501,18 +501,23 @@ namespace FlashDevelop.Dialogs
 
                 if (changedItem.PropertyDescriptor.Attributes.Matches(new RequiresRestartAttribute()))
                 {
-                    bool previous = requireRestart.Count > 0;
-                    if (requireRestart.Contains(settingId))
-                    {
-                        if (requireRestart[settingId].Equals(changedItem.Value))
-                        {
-                            requireRestart.Remove(settingId);
-                        }
-                    }
-                    else requireRestart.Add(settingId, e.OldValue);
-                    if (requireRestart.Count > 0 != previous)  UpdateInfo();
+                    UpdateRestartRequired(settingId, e.OldValue, changedItem.Value);
                 }
             }
+        }
+
+        private void UpdateRestartRequired(string key, object oldValue, object newValue)
+        {
+            bool previous = requireRestart.Count > 0;
+            if (requireRestart.Contains(key))
+            {
+                if (requireRestart[key].Equals(newValue))
+                {
+                    requireRestart.Remove(key);
+                }
+            }
+            else requireRestart.Add(key, oldValue);
+            if (requireRestart.Count > 0 != previous) UpdateInfo();
         }
 
         private void UpdateInfo()
@@ -560,7 +565,8 @@ namespace FlashDevelop.Dialogs
             if (selectedIndex != 0)
             {
                 IPlugin plugin = PluginServices.AvailablePlugins[selectedIndex - 1].Instance;
-                if (this.disableCheckBox.Checked)
+                bool disabled = this.disableCheckBox.Checked;
+                if (disabled)
                 {
                     this.itemListView.Items[selectedIndex].ImageIndex = 1;
                     Globals.Settings.DisabledPlugins.Add(plugin.Guid);
@@ -570,6 +576,7 @@ namespace FlashDevelop.Dialogs
                     this.itemListView.Items[selectedIndex].ImageIndex = 0;
                     Globals.Settings.DisabledPlugins.Remove(plugin.Guid);
                 }
+                UpdateRestartRequired(nameLabel.Text, !disabled, disabled);
             }
         }
 

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -446,6 +446,15 @@ namespace FlashDevelop
         }
 
         /// <summary>
+        /// Gets whether the application requires a restart to apply changes.
+        /// </summary>
+        public Boolean RequiresRestart
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
         /// Gets or sets the RefreshConfig
         /// </summary>
         public Boolean RefreshConfig
@@ -2011,6 +2020,7 @@ namespace FlashDevelop
         public void RestartRequired()
         {
             if (this.restartButton != null) this.restartButton.Visible = true;
+            this.RequiresRestart = true;
             String message = TextHelper.GetString("Info.RequiresRestart");
             TraceManager.Add(message);
         }

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -2007,6 +2007,14 @@ namespace FlashDevelop
         }
 
         /// <summary>
+        /// Cancel a restart required message.
+        /// </summary>
+        public void CancelRestartRequired()
+        {
+            if (this.restartButton != null) this.restartButton.Visible = false;
+        }
+
+        /// <summary>
         /// Refreshes the main form
         /// </summary>
         public void RefreshUI()

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -2026,14 +2026,6 @@ namespace FlashDevelop
         }
 
         /// <summary>
-        /// Cancel a restart required message.
-        /// </summary>
-        public void CancelRestartRequired()
-        {
-            if (this.restartButton != null) this.restartButton.Visible = false;
-        }
-
-        /// <summary>
         /// Refreshes the main form
         /// </summary>
         public void RefreshUI()

--- a/FlashDevelop/Settings/Accessors.cs
+++ b/FlashDevelop/Settings/Accessors.cs
@@ -360,6 +360,7 @@ namespace FlashDevelop.Settings
         [DefaultValue(LocaleVersion.en_US)]
         [LocalizedCategory("FlashDevelop.Category.Locale")]
         [LocalizedDescription("FlashDevelop.Description.LocaleVersion")]
+        [RequiresRestart]
         public LocaleVersion LocaleVersion
         {
             get { return this.localeVersion; }

--- a/FlashDevelop/Settings/Accessors.cs
+++ b/FlashDevelop/Settings/Accessors.cs
@@ -197,6 +197,7 @@ namespace FlashDevelop.Settings
         [LocalizedCategory("FlashDevelop.Category.Display")]
         [LocalizedDescription("FlashDevelop.Description.DefaultFont")]
         [DefaultValue(typeof(Font), "Tahoma, 8.25pt")]
+        [RequiresRestart]
         public Font DefaultFont
         {
             get { return this.defaultFont; }

--- a/PluginCore/PluginCore/Interfaces.cs
+++ b/PluginCore/PluginCore/Interfaces.cs
@@ -406,6 +406,10 @@ namespace PluginCore
         /// </summary>
         Boolean RestartRequested { get; }
         /// <summary>
+        /// Gets whether the application requires a restart to apply changes.
+        /// </summary>
+        Boolean RequiresRestart { get; }
+        /// <summary>
         /// Gets whether the config should be refreshed.
         /// </summary>
         Boolean RefreshConfig { get; }

--- a/PluginCore/PluginCore/Localization/Attributes.cs
+++ b/PluginCore/PluginCore/Localization/Attributes.cs
@@ -65,4 +65,12 @@ namespace PluginCore.Localization
 
     }
 
+    [AttributeUsage(AttributeTargets.Property)]
+    public class RequiresRestartAttribute : Attribute
+    {
+        public override bool Match(object obj)
+        {
+            return obj is RequiresRestartAttribute;
+        }
+    }
 }


### PR DESCRIPTION
I think it's good to let users know which settings take effect only after a restart. 
Really simple syntax for developers: just add a `[RequiresRestart]` attribute.