### PR TITLE
Fixes existing files not truncated on save.

### DIFF
--- a/PluginCore/PluginCore/Helpers/FileHelper.cs
+++ b/PluginCore/PluginCore/Helpers/FileHelper.cs
@@ -81,7 +81,7 @@ namespace PluginCore.Helpers
         {
             Boolean useSkipBomWriter = (encoding == Encoding.UTF8 && !saveBOM);
             if (encoding == Encoding.UTF7) encoding = new UTF7EncodingFixed();
-            using (FileStream fs = new FileStream(file, FileMode.OpenOrCreate))
+            using (FileStream fs = new FileStream(file, File.Exists(file) ? FileMode.Truncate : FileMode.CreateNew))
             using (StreamWriter sw = useSkipBomWriter ? new StreamWriter(fs) : new StreamWriter(fs, encoding))
             {
                 sw.Write(text);


### PR DESCRIPTION
`File.Exists(file) ? FileMode.Truncate : FileMode.CreateNew` is exactly how `FileMode.Create` is supposed to perform, but `FileMode.Create` fails on hidden files. More details in #1266.

Closes #1270 

Tested with hidden files -> saves without error.
Tested saving after deleting content then reloading -> file is correctly saved.