### PR TITLE
Fixes when using hxml

### DIFF
--- a/External/Plugins/HaXeContext/Completion/HaxeComplete.cs
+++ b/External/Plugins/HaXeContext/Completion/HaxeComplete.cs
@@ -21,7 +21,7 @@ namespace HaXeContext
     internal class HaxeComplete
     {
         static readonly Regex reArg =
-            new Regex("^(-cp|-resource)\\s*([^\"'].*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            new Regex("^(-cp|-resource|-cmd)\\s*([^\"'].*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         static readonly Regex reMacro =
             new Regex("^(--macro)\\s*([^\"'].*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         static readonly Regex reQuote =

--- a/External/Plugins/HaXeContext/ExternalToolchain.cs
+++ b/External/Plugins/HaXeContext/ExternalToolchain.cs
@@ -297,7 +297,7 @@ namespace HaXeContext
             else
             {
                 hxml = hxml.Replace("--macro keep", "#--macro keep"); // TODO remove this hack
-                hxml = Regex.Replace(hxml, "(-[a-z0-9-]+)\\s*[\r\n]+([^-])", "$1 $2", RegexOptions.IgnoreCase);
+                hxml = Regex.Replace(hxml, "(-[a-z0-9-]+)\\s*[\r\n]+([^-#])", "$1 $2", RegexOptions.IgnoreCase);
                 hxproj.RawHXML = Regex.Split(hxml, "[\r\n]+");
 
                 args = GetCommand(hxproj, "build", false);


### PR DESCRIPTION
- Parse hxml files used inside other hxml files. Doing this results in better project support: classpaths, finding --next statements inside other hxml, etc. I know the code is not very nice because of the method signature, but it's private code, so it's not harmful.
- When parsing the hxml file don't count next lines starting with # as the parameter of a previous command. For example having this inside the hxml could lead to wrong compiler service calling:
```
-debug
#comment
```
- When constructing the compiler command line from the project properties also quote lines for -cmd commands. Having something like -cmd bin/test.bat could break compiler service calling. Maybe we should also quote -x commands. Another option could be maybe to remove these commands, but I don't know if removing them could result in compiler cache problems or something else?