### PR TITLE
[FDBuild] Fix project building on Linux when directory path contains %2f

### DIFF
--- a/External/Plugins/ProjectManager/Projects/ProjectReader.cs
+++ b/External/Plugins/ProjectManager/Projects/ProjectReader.cs
@@ -12,7 +12,7 @@ namespace ProjectManager.Projects
         Project project;
         protected int version;
 
-        public ProjectReader(string filename, Project project) : base(filename)
+        public ProjectReader(string filename, Project project) : base(new FileStream(filename,FileMode.Open))
         {
             this.project = project;
             WhitespaceHandling = WhitespaceHandling.None;

--- a/External/Plugins/ProjectManager/Projects/ProjectWriter.cs
+++ b/External/Plugins/ProjectManager/Projects/ProjectWriter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.IO;
 using System.Text;
 using System.Xml;
 
@@ -9,7 +10,7 @@ namespace ProjectManager.Projects
     {
         Project project;
 
-        public ProjectWriter(Project project, string filename) : base(filename,Encoding.UTF8)
+        public ProjectWriter(Project project, string filename) : base(new FileStream(filename,FileMode.OpenOrCreate),Encoding.UTF8)
         {
             this.project = project;
             this.Formatting = Formatting.Indented;


### PR DESCRIPTION
Fix project building on Linux when directory path contains "%2f" (escaped forward slash symbol)