### PR TITLE
Custom method to compact the text of document tabs with long filenames

### DIFF
--- a/PluginCore/DockPanelSuite/Customization/VS2005DockPaneStrip.cs
+++ b/PluginCore/DockPanelSuite/Customization/VS2005DockPaneStrip.cs
@@ -328,8 +328,7 @@ namespace WeifenLuo.WinFormsUI.Docking
         {
             get
             {   
-                 TextFormatFlags textFormat = TextFormatFlags.PathEllipsis |
-                    TextFormatFlags.SingleLine |
+                 TextFormatFlags textFormat = TextFormatFlags.SingleLine |
                     TextFormatFlags.VerticalCenter |
                     TextFormatFlags.PreserveGraphicsClipping |
                     TextFormatFlags.HorizontalCenter;
@@ -1282,6 +1281,8 @@ namespace WeifenLuo.WinFormsUI.Docking
                 if (temp != Color.Empty) stripColor = temp;
             }
 
+            string tabText = tab.MaxWidth >= rect.Width ? PathHelper.Ellipsis.Compact(tab.Content.DockHandler.TabText, BoldFont, rectText.Width,
+                PathHelper.Ellipsis.EllipsisFormat.Path | PathHelper.Ellipsis.EllipsisFormat.Middle) : tab.Content.DockHandler.TabText;
             if (DockPane.ActiveContent == tab.Content)
             {
                 if (tabStyle == "Rect") g.FillRectangle(BrushDocumentActiveBackground, rectTab);
@@ -1324,9 +1325,9 @@ namespace WeifenLuo.WinFormsUI.Docking
 
                 if (DockPane.IsActiveDocumentPane)
                 {
-                    TextRenderer.DrawText(g, tab.Content.DockHandler.TabText, BoldFont, rectText, ColorDocumentActiveText, DocumentTextFormat);
+                    TextRenderer.DrawText(g, tabText, BoldFont, rectText, ColorDocumentActiveText, DocumentTextFormat);
                 }
-                else TextRenderer.DrawText(g, tab.Content.DockHandler.TabText, Font, rectText, ColorDocumentInactiveText, DocumentTextFormat);
+                else TextRenderer.DrawText(g, tabText, Font, rectText, ColorDocumentInactiveText, DocumentTextFormat);
             }
             else
             {
@@ -1356,7 +1357,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                 if (tabStyle == "Rect") g.DrawRectangle(PenDocumentTabInactiveBorder, rectTab);
                 else g.DrawPath(PenDocumentTabInactiveBorder, path);
 
-                TextRenderer.DrawText(g, tab.Content.DockHandler.TabText, Font, rectText, ColorDocumentInactiveText, DocumentTextFormat);
+                TextRenderer.DrawText(g, tabText, Font, rectText, ColorDocumentInactiveText, DocumentTextFormat);
             }
 
             if (rectTab.Contains(rectIcon) && DockPane.DockPanel.ShowDocumentIcon)

--- a/PluginCore/PluginCore/Helpers/PathHelper.cs
+++ b/PluginCore/PluginCore/Helpers/PathHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Drawing;
 using System.IO;
 using System.Security.AccessControl;
 using System.Security.Principal;
@@ -418,6 +419,195 @@ namespace PluginCore.Helpers
             }
         }
 
+        public class Ellipsis
+        {
+            /// <summary>
+            /// Specifies ellipsis format and alignment.
+            /// </summary>
+            [Flags]
+            public enum EllipsisFormat
+            {
+                /// <summary>
+                /// Text is not modified.
+                /// </summary>
+                None = 0,
+                /// <summary>
+                /// Text is trimmed at the end of the string. An ellipsis (...) is drawn in place of remaining text.
+                /// </summary>
+                End = 1,
+                /// <summary>
+                /// Text is trimmed at the begining of the string. An ellipsis (...) is drawn in place of remaining text. 
+                /// </summary>
+                Start = 2,
+                /// <summary>
+                /// Text is trimmed in the middle of the string. An ellipsis (...) is drawn in place of remaining text.
+                /// </summary>
+                Middle = 3,
+                /// <summary>
+                /// Preserve as much as possible of the drive and filename information. Must be combined with alignment information.
+                /// </summary>
+                Path = 4,
+                /// <summary>
+                /// Text is trimmed at a word boundary. Must be combined with alignment information.
+                /// </summary>
+                Word = 8
+            }
+
+            /// <summary>
+            /// String used as a place holder for trimmed text.
+            /// </summary>
+            public const string EllipsisChars = "...";
+
+            private static Regex prevWord = new Regex(@"\W*\w*$", RegexOptions.Compiled);
+            private static Regex nextWord = new Regex(@"\w*\W*", RegexOptions.Compiled);
+
+            /// <summary>
+            /// Truncates a text string to fit within a given width by replacing trimmed text with ellipses. 
+            /// </summary>
+            /// <param name="text">String to be trimmed.</param>
+            /// <param name="font">Font to be used to measure the text.</param>
+            /// <param name="proposedWidth">The target width to accomodate the text.</param>
+            /// <param name="options">Format and alignment of ellipsis.</param>
+            /// <returns>This function returns text trimmed to the specified witdh.</returns>
+            public static string Compact(string text, Font font, int proposedWidth, EllipsisFormat options)
+            {
+                if (string.IsNullOrEmpty(text))
+                    return text;
+
+                // no aligment information
+                if (((EllipsisFormat.Path | EllipsisFormat.Start | EllipsisFormat.End | EllipsisFormat.Middle) & options) == 0)
+                    return text;
+
+                if (font == null)
+                    throw new ArgumentNullException("font");
+
+                Size s = TextRenderer.MeasureText(text, font);
+
+                // control is large enough to display the whole text
+                if (s.Width <= proposedWidth)
+                    return text;
+
+                string pre = "";
+                string mid = text;
+                string post = "";
+
+                bool isPath = (EllipsisFormat.Path & options) != 0;
+
+                // split path string into <drive><directory><filename>
+                if (isPath)
+                {
+                    pre = Path.GetPathRoot(text);
+                    mid = Path.GetDirectoryName(text).Substring(pre.Length);
+                    post = Path.GetFileName(text);
+                }
+
+                int len = 0;
+                int seg = mid.Length;
+                string fit = "";
+
+                // find the longest string that fits into 
+                // the control boundaries using bisection method
+                while (seg > 1)
+                {
+                    seg -= seg / 2;
+
+                    int left = len + seg;
+                    int right = mid.Length;
+
+                    if (left > right)
+                        continue;
+
+                    if ((EllipsisFormat.Middle & options) == EllipsisFormat.Middle)
+                    {
+                        right -= left / 2;
+                        left -= left / 2;
+                    }
+                    else if ((EllipsisFormat.Start & options) != 0)
+                    {
+                        right -= left;
+                        left = 0;
+                    }
+
+                    // trim at a word boundary using regular expressions
+                    if ((EllipsisFormat.Word & options) != 0)
+                    {
+                        if ((EllipsisFormat.End & options) != 0)
+                        {
+                            left -= prevWord.Match(mid, 0, left).Length;
+                        }
+                        if ((EllipsisFormat.Start & options) != 0)
+                        {
+                            right += nextWord.Match(mid, right).Length;
+                        }
+                    }
+
+                    // build and measure a candidate string with ellipsis
+                    string tst = mid.Substring(0, left) + EllipsisChars + mid.Substring(right);
+
+                    // restore path with <drive> and <filename>
+                    if (isPath)
+                    {
+                        tst = Path.Combine(Path.Combine(pre, tst), post);
+                    }
+                    s = TextRenderer.MeasureText(tst, font);
+
+                    // candidate string fits into control boundaries, try a longer string
+                    // stop when seg <= 1
+                    if (s.Width <= proposedWidth)
+                    {
+                        len += seg;
+                        fit = tst;
+                    }
+                }
+
+                if (len == 0) // string can't fit into control
+                {
+                    // "path" mode is off, just return ellipsis characters
+                    if (!isPath)
+                        return EllipsisChars;
+
+                    // <directory> is empty
+                    if (mid.Length == 0)
+                    {
+                        // <drive> is empty, return compacted <filename>
+                        if (pre.Length == 0)
+                            return Compact(text, font, proposedWidth, options & ~EllipsisFormat.Path);
+
+                        // we compare ellipsis and <drive> to get the shorter
+                        string testEllipsis = Path.Combine(EllipsisChars, ".");
+                        testEllipsis = testEllipsis.Substring(0, testEllipsis.Length - 1);
+                        if (TextRenderer.MeasureText(testEllipsis, font).Width < TextRenderer.MeasureText(pre, font).Width)
+                            pre = EllipsisChars;
+                    }
+                    else
+                    {
+                        // "C:\...\filename.ext" No need to check for drive, but generates extra check
+                        if (pre.Length > 0)
+                        {
+                            fit = Path.Combine(Path.Combine(pre, EllipsisChars), post);
+
+                            s = TextRenderer.MeasureText(fit, font);
+
+                            if (s.Width <= proposedWidth) return fit;
+                        }
+
+                        pre = EllipsisChars;
+                    }
+
+                    // Try "...\filename.ext" or "c:\filename.ext"
+                    fit = Path.Combine(pre, post);
+
+                    s = TextRenderer.MeasureText(fit, font);
+
+                    // if still not fit then return "...\f...e.ext"
+                    if (s.Width > proposedWidth)
+                    {
+                        fit = Path.Combine(pre, Compact(post, font, proposedWidth - TextRenderer.MeasureText(fit.Substring(0, fit.Length - post.Length), font).Width, options & ~EllipsisFormat.Path));
+                    }
+                }
+                return fit;
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Current rendering method is a sh*t:

![current](https://cloud.githubusercontent.com/assets/2273861/17984474/960b86b4-6b11-11e6-89c5-0955e204c506.jpg)

The problem is that in order to draw the text in the tabs the code is using TextRenderer with TextFormatFlags.PathEllipsis, and it only removes full path parts, nothing else... which is useless with long filenames... Because of that latest DockPanelSuite releases modified it to use TextFormatFlags.EndEllipsis, which results in this:

![newdps](https://cloud.githubusercontent.com/assets/2273861/17984521/d90d230a-6b11-11e6-83d8-0071b9e74e05.jpg)

Which is not very nice either, it's not uncommon to have multiple files with similar starts of filenames, or the same filenames but different extensions. Hence I decided to play a bit with different things to come up with this one which I think it's better for everyone:

![new](https://cloud.githubusercontent.com/assets/2273861/17984588/2c33ee60-6b12-11e6-9257-936c7484efd1.jpg)

StringTrimming.PathEllipsis used with Graphics.DrawString is able to render this case in a similar way to this custom implementation... but if you google you will find tons of posts from people discouraging to use it and keep TextRenderer, so I decided to use [this code](http://www.codeproject.com/Articles/37503/Auto-Ellipsis) (license fully compatible, of course), but I made further improvements to the path ellipsis behavior, because before it was still behaving in a similar way to TextRenderer, plus I "relaxed the requirements" the method needed.

The class works with a Font object and a width value, but it could be easily made to work with a max number of chars too, why I say this? Because I think the result is better than PathCompact for some cases (as detailed in the article), it's fully managed code, *and*, the managed version present in FD of PathCompact for when not using Win32 seems to be completely broken. But replacing one implementation with another could come later and by anyone else.

I could add in the future unit tests if you want.