### PR TITLE
Fixed wrong cast causing iOS UIBackgroundModes in AIR descriptor file to not be filled correctly.

### DIFF
--- a/External/Plugins/AirProperties/Forms/AirWizard.cs
+++ b/External/Plugins/AirProperties/Forms/AirWizard.cs
@@ -1313,7 +1313,7 @@ namespace AirProperties
 
         private void FilliPhoneAdditionsFields()
         {
-            WizardHelper.SetControlValue(iPhoneAdditions.ValueOrNull("UIBackgroundModes") as string,
+            WizardHelper.SetControlValue(iPhoneAdditions.ValueOrNull("UIBackgroundModes") as IEnumerable, 
                                          IPhoneBGModesCombo);
             WizardHelper.SetControlValue(iPhoneAdditions.ValueOrNull("UIDeviceFamily") as IEnumerable,
                                          IPhoneDeviceCombo);


### PR DESCRIPTION
Closes issue 1301