### PR TITLE
Advanced shortcuts fixes

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -234,12 +234,12 @@ namespace ASCompletion.Completion
         /// </summary>
         /// <param name="keys">Test keys</param>
         /// <returns></returns>
-        static public bool OnShortcut(Keys keys, ScintillaControl Sci)
+        static public bool OnShortcut(ShortcutKeys keys, ScintillaControl Sci)
         {
             if (Sci.IsSelectionRectangle) 
                 return false;
 
-            switch (keys)
+            switch ((Keys) keys)
             {
                 case Keys.Control | Keys.Space: // dot complete
                     if (ASContext.HasContext && ASContext.Context.IsFileValid)

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -234,12 +234,12 @@ namespace ASCompletion.Completion
         /// </summary>
         /// <param name="keys">Test keys</param>
         /// <returns></returns>
-        static public bool OnShortcut(ShortcutKeys keys, ScintillaControl Sci)
+        static public bool OnShortcut(Keys keys, ScintillaControl Sci)
         {
             if (Sci.IsSelectionRectangle) 
                 return false;
 
-            switch ((Keys) keys)
+            switch (keys)
             {
                 case Keys.Control | Keys.Space: // dot complete
                     if (ASContext.HasContext && ASContext.Context.IsFileValid)

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -1700,6 +1701,9 @@ namespace FlashDevelop
              */
             else if (ShortcutKeysManager.IsValidExtendedShortcutFirst(keyData) && !appSettings.DisableExtendedShortcutKeys)
             {
+                if (ShortcutManager.AllShortcuts.FirstOrDefault(s => s.First == keyData) == ShortcutKeys.None)
+                    return false;
+
                 StatusLabelText = string.Format(TextHelper.GetString("Info.ShortcutWaiting"), currentKeys);
                 lockStatusLabel = true;
                 return true;
@@ -2223,6 +2227,9 @@ namespace FlashDevelop
                 {
                     if (ShortcutKeysManager.IsValidExtendedShortcutFirst(input) && !appSettings.DisableExtendedShortcutKeys)
                     {
+                        if (ShortcutManager.AllShortcuts.FirstOrDefault(s => s.First == input) == ShortcutKeys.None)
+                            return true;
+
                         StatusLabelText = string.Format(TextHelper.GetString("Info.ShortcutWaiting"), previousKeys);
                     }
                     else if (ShortcutKeysManager.IsValidSimpleShortcutExclDeleteInsert(input))

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -1702,7 +1702,10 @@ namespace FlashDevelop
             else if (ShortcutKeysManager.IsValidExtendedShortcutFirst(keyData) && !appSettings.DisableExtendedShortcutKeys)
             {
                 if (ShortcutManager.AllShortcuts.FirstOrDefault(s => s.First == keyData) == ShortcutKeys.None)
+                {
+                    currentKeys = ShortcutKeys.None;
                     return false;
+                }
 
                 StatusLabelText = string.Format(TextHelper.GetString("Info.ShortcutWaiting"), currentKeys);
                 lockStatusLabel = true;


### PR DESCRIPTION
Check registered shortcuts to check if the pressed key combination is really a valid advanced shortcut, and revert method signature change in ASComplete.

If @wise0704 thinks something should be done in a different way he can later change it. The method signature change in ASComplete makes the show help shortcut to not accept advanced shortcuts, but I think this is really minor at the moment, the way this method is called should be different (through a proxy check maybe) so all the shortcuts like Ctrl+Space, Ctrl+Alt+Space, etc can be customized to solve #1298.