### PR TITLE
Theme and Size LiveDataTip

### DIFF
--- a/External/Plugins/FlashDebugger/Controls/DataTipForm.cs
+++ b/External/Plugins/FlashDebugger/Controls/DataTipForm.cs
@@ -26,9 +26,20 @@ namespace FlashDebugger.Controls
             }
         }
 
+        public AutoRowHeightLayout RowLayout
+        {
+            get
+            {
+                return rowLayout;
+            }
+        }
+
+        AutoRowHeightLayout rowLayout;
+
         public DataTipForm()
         {
             InitializeComponent();
+            rowLayout = new AutoRowHeightLayout(Tree, Tree.RowHeight);
             Tree.Cursor = Cursors.Default;
             Tree.ShowLines = false;
             Tree.Expanded += Tree_SizeChanged;
@@ -97,8 +108,8 @@ namespace FlashDebugger.Controls
         {
             Point screenPoint = PointToScreen(new Point(e.X, e.Y));
             Win32.HitTest ht = DoHitTest(e.X, e.Y);
-            if (Win32.ShouldUseWin32()) 
-            { 
+            if (Win32.ShouldUseWin32())
+            {
                 Win32.ReleaseCapture();
                 Win32.SendMessage(Handle, Win32.WM_NCLBUTTONDOWN, (int)ht, (int)(screenPoint.Y << 16 | screenPoint.X));
             }
@@ -161,8 +172,8 @@ namespace FlashDebugger.Controls
         {
             using (Graphics g = Tree.CreateGraphics())
             {
-                int nameMaxW = 0;
-                int valueMaxW = 0;
+                int nameMaxW = TextWidth(g, Tree.Columns[0].Header) + DataTree.Margin.Horizontal;
+                int valueMaxW = TextWidth(g, Tree.Columns[1].Header) + DataTree.Margin.Horizontal;
                 int height = 0;
                 DataTree.Tree.Columns[0].Width = Screen.GetWorkingArea(this).Width;
                 foreach (TreeNodeAdv node in DataTree.Tree.Root.Children)
@@ -180,7 +191,7 @@ namespace FlashDebugger.Controls
                     width = maxWidth;
                 }
                 Width = width;
-                int h = DataTree.Tree.ColumnHeaderHeight + height * DataTree.Tree.RowHeight + Padding.Vertical + SystemInformation.HorizontalScrollBarHeight;
+                int h = DataTree.Tree.ColumnHeaderHeight + height + Padding.Vertical + SystemInformation.HorizontalScrollBarHeight;
                 int maxHeight = parentForm.Height - locationMainForm.Y - Padding.Vertical - 2 * SystemInformation.HorizontalScrollBarHeight;
                 if (h > maxHeight)
                 {
@@ -199,7 +210,7 @@ namespace FlashDebugger.Controls
                     CalcHeightWidth(g, child, ref height, ref widthName, ref widthValue);
                 }
             }
-            height++;
+            height += RowLayout.GetRowBounds(node.Row).Height;
             int nodeWidth = 0;
             foreach (NodeControlInfo nodeInfo in DataTree.Tree.GetNodeControls(node))
             {

--- a/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
+++ b/External/Plugins/FlashDebugger/Controls/DataTreeControl.cs
@@ -67,6 +67,7 @@ namespace FlashDebugger.Controls
             _tree.Expanding += TreeExpanding;
             _tree.NodeMouseDoubleClick += Tree_NodeMouseDoubleClick;
             _tree.LoadOnDemand = true;
+            _tree.AutoHeaderHeight = true;
             _tree.AutoRowHeight = true;
             _tree.HideSelection = true;
 
@@ -77,6 +78,8 @@ namespace FlashDebugger.Controls
             _tree.LineColor = PluginBase.MainForm.GetThemeColor("DataTreeControl.LineColor", SystemColors.ActiveBorder);
             _tree.LineColor2 = PluginBase.MainForm.GetThemeColor("DataTreeControl.LineColor", SystemColors.ActiveBorder);
             _tree.DragDropMarkColor = PluginBase.MainForm.GetThemeColor("DataTreeControl.ForeColor", SystemColors.WindowText);
+            _tree.ForeColor = PluginBase.MainForm.GetThemeColor("TreeViewAdv.ForeColor", SystemColors.ControlText);
+            _tree.BackColor = PluginBase.MainForm.GetThemeColor("TreeViewAdv.BackColor", SystemColors.Control);
 
             NameNodeTextBox.DrawText += NameNodeTextBox_DrawText;
             ValueNodeTextBox.DrawText += ValueNodeTextBox_DrawText;

--- a/External/Plugins/FlashDebugger/Controls/LiveDataTip.cs
+++ b/External/Plugins/FlashDebugger/Controls/LiveDataTip.cs
@@ -19,6 +19,11 @@ namespace FlashDebugger
 
         public LiveDataTip()
         {
+            UITools.Manager.OnMouseHover += new UITools.MouseHoverHandler(Manager_OnMouseHover);
+        }
+
+        private void Initialize()
+        {
             m_ToolTip = new DataTipForm();
             m_ToolTip.Dock = DockStyle.Fill;
             m_ToolTip.Visible = false;
@@ -27,7 +32,6 @@ namespace FlashDebugger
             m_MouseMessageFilter.MouseDownEvent += new MouseDownEventHandler(MouseMessageFilter_MouseDownEvent);
             m_MouseMessageFilter.KeyDownEvent += new EventHandler(MouseMessageFilter_KeyDownEvent);
             Application.AddMessageFilter(m_MouseMessageFilter);
-            UITools.Manager.OnMouseHover += new UITools.MouseHoverHandler(Manager_OnMouseHover);
         }
 
         public void Show(Point point, Variable variable, String path)
@@ -67,6 +71,9 @@ namespace FlashDebugger
 
         private void Manager_OnMouseHover(ScintillaControl sci, Int32 position)
         {
+            if (m_ToolTip == null)
+                Initialize();
+
             DebuggerManager debugManager = PluginMain.debugManager;
             FlashInterface flashInterface = debugManager.FlashInterface;
             if (!PluginBase.MainForm.EditorMenu.Visible && flashInterface != null && flashInterface.isDebuggerStarted && flashInterface.isDebuggerSuspended)


### PR DESCRIPTION
- Delay initializing DataTreeControl in DataTipForm until theming has been loaded
- Apply DataTreeControl ForeColor and BackColor theming
- Size DataTipForm based on AutoHeightRowLayout Bounds height for rows since TreeViewAdv.RowSize doesn't return the value based on AutoHeight being applied
- Default DataTipForm Column widths based on the width of their Header text

Problem:
![LiveDataTip with Dark Themeing Looks Bad](https://ci4.googleusercontent.com/proxy/nDcFHV3PO-fbjOTfhp-LiYFzZhrZE9iJ1960r7jnn9mvqJGVuXUpBn6urYNrOuZrSMlc5Q6X_Fl7yttF_EM7rHuHr5EUqnCSSfEBGofjy0JSfMwqiJ27TMcCTF-BKU6VsslrJgUZyhOW2VbJqcMm5uPO1bz3AvYkaTae=s0-d-e1-ft#https://cloud.githubusercontent.com/assets/12462089/13349969/b8d329c2-dcaf-11e5-8dad-4df381e42170.png)