### PR TITLE
AddClosingBraces small fix

### DIFF
--- a/External/Plugins/ASCompletion/PluginMain.cs
+++ b/External/Plugins/ASCompletion/PluginMain.cs
@@ -753,6 +753,7 @@ namespace ASCompletion
             CompletionList.OnInsert += new InsertedTextHandler(ASComplete.HandleCompletionInsert);
 
             // shortcuts
+            PluginBase.MainForm.IgnoredKeys.Add(Keys.Back);
             PluginBase.MainForm.IgnoredKeys.Add(Keys.Control | Keys.Enter);
             PluginBase.MainForm.IgnoredKeys.Add(Keys.Space | Keys.Control | Keys.Alt); // complete project types
             PluginBase.MainForm.RegisterShortcutItem("Completion.ShowHelp", Keys.F1);


### PR DESCRIPTION
This line was removed after #1245, but after #1316 this is required again.

Note: added in [`aa65d56`](https://github.com/fdorg/flashdevelop/pull/947/commits/aa65d56649d2d801294e7f8ab8e14ef7ab45891c#diff-fa9c2f4eb75fd264db1491c03499a09cR756), removed in [`ef958cf`](https://github.com/fdorg/flashdevelop/pull/947/commits/ef958cf1e64e0d19316d4c7575d9c85eea8c18f3#diff-fa9c2f4eb75fd264db1491c03499a09cL756)