### PR TITLE
[Haxe] Fixed generation of override of property.

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -3840,7 +3840,7 @@ namespace ASCompletion.Completion
             List<MemberModel> members = new List<MemberModel>();
             curClass.ResolveExtends(); // Resolve inheritance chain
 
-            // explore function or getters or setters
+            // explore getters or setters
             FlagType mask = FlagType.Function | FlagType.Getter | FlagType.Setter;
             ClassModel tmpClass = curClass.Extends;
             Visibility acc = ctx.TypesAffinity(curClass, tmpClass);
@@ -3858,9 +3858,16 @@ namespace ASCompletion.Completion
                 else
                 {
                     foreach (MemberModel member in tmpClass.Members)
+                    {
+                        var parameters = member.Parameters;
                         if ((member.Flags & FlagType.Dynamic) > 0
-                            && (member.Flags & mask) > 0
-                            && (member.Access & acc) > 0) members.Add(member);
+                            && (member.Access & acc) > 0
+                            && ((member.Flags & FlagType.Function) > 0 
+                                || ((member.Flags & mask) > 0 && (!IsHaxe || parameters[0].Name == "get" || parameters[1].Name == "set"))))
+                        {
+                            members.Add(member);
+                        }
+                    }
 
                     tmpClass = tmpClass.Extends;
                     // members visibility
@@ -3926,13 +3933,14 @@ namespace ASCompletion.Completion
             {
                 string type = member.Type;
                 string name = member.Name;
-                if (member.Parameters != null && member.Parameters.Count == 1)
-                    type = member.Parameters[0].Type;
+                var parameters = member.Parameters;
+                if (parameters != null && parameters.Count == 1)
+                    type = parameters[0].Type;
                 type = FormatType(type);
                 if (type == null && !features.hasInference) type = features.objectKey;
 
-                bool genGetter = ofClass.Members.Search(name, FlagType.Getter, 0) != null;
-                bool genSetter = ofClass.Members.Search(name, FlagType.Setter, 0) != null;
+                bool genGetter = ofClass.Members.Search(name, FlagType.Getter, 0) != null && (!IsHaxe || parameters[0].Name == "get");
+                bool genSetter = ofClass.Members.Search(name, FlagType.Setter, 0) != null && (!IsHaxe || parameters[1].Name == "set");
 
                 if (IsHaxe)
                 {

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -255,6 +255,12 @@
     <EmbeddedResource Include="Test Files\generated\as3\AfterGeneratePublicStaticFunction_forSomeType.as" />
     <EmbeddedResource Include="Test Files\generated\haxe\BeforeGeneratePublicStaticVariable_forCurrentType.hx" />
     <EmbeddedResource Include="Test Files\generated\haxe\AfterGeneratePublicStaticVariable_forCurrentType.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\BeforeOverrideGetNull.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\AfterOverrideGetNull.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\BeforeOverrideNullSet.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\AfterOverrideNullSet.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\BeforeOverrideGetSet.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\AfterOverrideGetSet.hx" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
@@ -548,176 +548,6 @@ namespace ASCompletion.Completion
             }
 
             [TestFixture]
-            public class GenerateExtractVariable : GenerateJob
-            {
-                public IEnumerable<TestCaseData> GenerateExtractVariableHaxeTestCases
-                {
-                    get
-                    {
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.haxe.BeforeGenerateExtractVariableGeneric.hx"),
-                                    new MemberModel("main", null, FlagType.Static | FlagType.Function, 0)
-                                    {
-                                        LineFrom = 2,
-                                        LineTo = 4
-                                    },
-                                    "newVar"
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.haxe.AfterGenerateExtractVariableGeneric.hx"))
-                                .SetName("GenerateExtractVariable");
-
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.haxe.BeforeExtractLocalVariable_fromString.hx"),
-                                    new MemberModel("extractLocalVariable", null, FlagType.Function, Visibility.Public)
-                                    {
-                                        LineFrom = 4,
-                                        LineTo = 7
-                                    },
-                                    "newVar"
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.haxe.AfterExtractLocalVariable_fromString.hx"))
-                                .SetName("ExtractLocaleVariable from String");
-
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.haxe.BeforeExtractLocalVariable_fromNumber.hx"),
-                                    new MemberModel("extractLocalVariable", null, FlagType.Function, Visibility.Public)
-                                    {
-                                        LineFrom = 4,
-                                        LineTo = 7
-                                    },
-                                    "newVar"
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.haxe.AfterExtractLocalVariable_fromNumber.hx"))
-                                .SetName("ExtractLocaleVariable from Number");
-
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.haxe.BeforeExtractLocalVariable_inSinglelineMethod.hx"),
-                                    new MemberModel("extractLocalVariable", null, FlagType.Function, Visibility.Public)
-                                    {
-                                        LineFrom = 4,
-                                        LineTo = 5
-                                    },
-                                    "newVar"
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.haxe.AfterExtractLocalVariable_inSinglelineMethod.hx"))
-                                .SetName("ExtractLocaleVariable in single line method");
-                    }
-                }
-
-                [Test, TestCaseSource("GenerateExtractVariableHaxeTestCases")]
-                public string Haxe(string sourceText, MemberModel currentMember, string newName)
-                {
-                    ASContext.Context.SetHaxeFeatures();
-                    ASContext.Context.CurrentModel.Returns(new FileModel {haXe = true, Context = ASContext.Context});
-                    ASContext.Context.CurrentMember.Returns(currentMember);
-                    sci.Text = sourceText;
-                    sci.ConfigurationLanguage = "haxe";
-                    SnippetHelper.PostProcessSnippets(sci, 0);
-                    ASGenerator.GenerateExtractVariable(sci, newName);
-                    return sci.Text;
-                }
-
-                public IEnumerable<TestCaseData> GenerateExtractVariableAS3TestCases
-                {
-                    get
-                    {
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeExtractLocalVariable.as"),
-                                    new MemberModel("ExtractLocalVariable", null, FlagType.Constructor | FlagType.Function, 0)
-                                    {
-                                        LineFrom = 4,
-                                        LineTo = 7
-                                    },
-                                    "newVar"
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterExtractLocalVariable.as"))
-                                .SetName("ExtractLocaleVariable");
-
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeExtractLocalVariable_fromString.as"),
-                                    new MemberModel("ExtractLocalVariable", null, FlagType.Constructor | FlagType.Function, 0)
-                                    {
-                                        LineFrom = 4,
-                                        LineTo = 7
-                                    },
-                                    "newVar"
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterExtractLocalVariable_fromString.as"))
-                                .SetName("ExtractLocaleVariable from String");
-
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeExtractLocalVariable_fromNumber.as"),
-                                    new MemberModel("ExtractLocalVariable", null, FlagType.Constructor | FlagType.Function, 0)
-                                    {
-                                        LineFrom = 4,
-                                        LineTo = 7
-                                    },
-                                    "newVar"
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterExtractLocalVariable_fromNumber.as"))
-                                .SetName("ExtractLocaleVariable from Number");
-
-                        yield return
-                            new TestCaseData(
-                                TestFile.ReadAllText(
-                                    "ASCompletion.Test_Files.generated.as3.BeforeExtractLocalVariable_forCheckingThePositionOfNewVar.as"),
-                                    new MemberModel("extractLocalVariable", null, FlagType.Function, Visibility.Public)
-                                    {
-                                        LineFrom = 4,
-                                        LineTo = 10
-                                    },
-                                    "newVar"
-                                )
-                                .Returns(
-                                    TestFile.ReadAllText(
-                                        "ASCompletion.Test_Files.generated.as3.AfterExtractLocalVariable_forCheckingThePositionOfNewVar.as"))
-                                .SetName("ExtractLocaleVariable with checking the position of a new variable");
-                    }
-                }
-
-                [Test, TestCaseSource("GenerateExtractVariableAS3TestCases")]
-                public string AS3(string sourceText, MemberModel currentMember, string newName)
-                {
-                    ASContext.Context.SetAs3Features();
-                    ASContext.Context.CurrentModel.Returns(new FileModel { Context = ASContext.Context });
-                    ASContext.Context.CurrentMember.Returns(currentMember);
-                    sci.Text = sourceText;
-                    sci.ConfigurationLanguage = "as3";
-                    SnippetHelper.PostProcessSnippets(sci, 0);
-                    ASGenerator.GenerateExtractVariable(sci, newName);
-                    return sci.Text;
-                }
-            }
-
-            [TestFixture]
             public class PromoteLocal : GenerateJob
             {
                 public IEnumerable<TestCaseData> AS3TestCases
@@ -885,7 +715,7 @@ namespace ASCompletion.Completion
                 [TestFixtureSetUp]
                 public void GenerateFunctionSetup()
                 {
-                    ASContext.CommonSettings.StartWithModifiers = true;
+                    ASContext.CommonSettings.DeclarationModifierOrder = new[] {"public", "protected", "internal", "private", "static", "override"};
                 }
 
                 public IEnumerable<TestCaseData> AS3TestCases
@@ -1051,7 +881,7 @@ namespace ASCompletion.Completion
                 [TestFixtureSetUp]
                 public void GenerateFunctionWithExplicitScopeSetup()
                 {
-                    ASContext.CommonSettings.StartWithModifiers = true;
+                    ASContext.CommonSettings.DeclarationModifierOrder = new[] { "public", "protected", "internal", "private", "static", "override" };
                     ASContext.CommonSettings.GenerateScope = true;
                 }
 
@@ -1218,7 +1048,7 @@ namespace ASCompletion.Completion
                 [TestFixtureSetUp]
                 public void GenerateVariableSetup()
                 {
-                    ASContext.CommonSettings.StartWithModifiers = true;
+                    ASContext.CommonSettings.DeclarationModifierOrder = new[] { "public", "protected", "internal", "private", "static", "override" };
                 }
 
                 public IEnumerable<TestCaseData> AS3TestCases
@@ -1405,7 +1235,7 @@ namespace ASCompletion.Completion
                 [TestFixtureSetUp]
                 public void GenerateVariableWithExplicitScopeSetup()
                 {
-                    ASContext.CommonSettings.StartWithModifiers = true;
+                    ASContext.CommonSettings.DeclarationModifierOrder = new[] { "public", "protected", "internal", "private", "static", "override" };
                     ASContext.CommonSettings.GenerateScope = true;
                 }
 
@@ -1851,6 +1681,63 @@ namespace ASCompletion.Completion
                     ASContext.Context.CurrentClass.Returns(currentClass);
                     ASContext.Context.CurrentMember.Returns(currentMember);
                     ASGenerator.GenerateJob(GeneratorJobType.GetterSetter, currentMember, ASContext.Context.CurrentClass, null, null);
+                    return sci.Text;
+                }
+            }
+
+            [TestFixture]
+            public class GenerateOverride : GenerateJob
+            {
+                public IEnumerable<TestCaseData> HaxeTestCases
+                {
+                    get
+                    {
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeOverrideGetNull.hx"),
+                                "Foo",
+                                "foo")
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterOverrideGetNull.hx"))
+                                .SetName("Override var foo(get, null)");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeOverrideNullSet.hx"),
+                                "Foo",
+                                "foo")
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterOverrideNullSet.hx"))
+                                .SetName("Override var foo(null, set)");
+                        yield return
+                            new TestCaseData(
+                                TestFile.ReadAllText(
+                                    "ASCompletion.Test_Files.generated.haxe.BeforeOverrideGetSet.hx"),
+                                "Foo",
+                                "foo")
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "ASCompletion.Test_Files.generated.haxe.AfterOverrideGetSet.hx"))
+                                .SetName("Override var foo(get, set)");
+                    }
+                }
+
+                [Test, TestCaseSource("HaxeTestCases")]
+                public string Haxe(string sourceText, string ofClassName, string memberName)
+                {
+                    sci.ConfigurationLanguage = "haxe";
+                    ASContext.Context.SetHaxeFeatures();
+                    ASContext.Context.CurrentModel.Returns(new FileModel {haXe = true, Context = ASContext.Context});
+                    sci.Text = sourceText;
+                    SnippetHelper.PostProcessSnippets(sci, 0);
+                    var currentModel = ASContext.Context.CurrentModel;
+                    new ASFileParser().ParseSrc(currentModel, sci.Text);
+                    var ofClass = currentModel.Classes.Find(model => model.Name == ofClassName);
+                    var member = ofClass.Members.Search(memberName, FlagType.Getter | FlagType.Setter, 0);
+                    ASGenerator.GenerateOverride(sci, ofClass, member, sci.CurrentPos);
                     return sci.Text;
                 }
             }

--- a/Tests/External/Plugins/ASCompletion.Tests/MainForm.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/MainForm.cs
@@ -392,6 +392,8 @@ namespace FlashDevelop
             get { throw new NotImplementedException(); }
         }
 
+        public bool RequiresRestart { get; }
+
         public bool RefreshConfig
         {
             get { throw new NotImplementedException(); }

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterOverrideGetNull.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterOverrideGetNull.hx
@@ -1,0 +1,14 @@
+﻿package;
+class Foo {
+	public function new() {}
+	public var foo(get, null):Int;
+	function get_foo():Int return 1;
+}
+
+
+class Bar extends Foo {
+	//@:getter(foo)
+	override function get_foo():Int {
+		return super.get_foo();
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterOverrideGetSet.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterOverrideGetSet.hx
@@ -1,0 +1,20 @@
+﻿package;
+class Foo {
+	public function new() {}
+	@:isVar public var foo(get, set):Int;
+	function get_foo():Int return 1;
+	function set_foo(value:Int) return foo = value;
+}
+
+
+class Bar extends Foo {
+	//@:getter(foo)
+	override function get_foo():Int {
+		return super.get_foo();
+	}
+	
+	//@:setter(foo)
+	override function set_foo(value:Int):Int {
+		return super.set_foo(value);
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterOverrideNullSet.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterOverrideNullSet.hx
@@ -1,0 +1,16 @@
+﻿package;
+class Foo {
+	public function new() {}
+	public var foo(null, set):Int;
+	function set_foo(value:Int):Int {
+		return foo = value;
+	}
+}
+
+
+class Bar extends Foo {
+	//@:setter(foo)
+	override function set_foo(value:Int):Int {
+		return super.set_foo(value);
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeOverrideGetNull.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeOverrideGetNull.hx
@@ -1,0 +1,11 @@
+﻿package;
+class Foo {
+	public function new() {}
+	public var foo(get, null):Int;
+	function get_foo():Int return 1;
+}
+
+
+class Bar extends Foo {
+	override $(EntryPoint)foo
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeOverrideGetSet.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeOverrideGetSet.hx
@@ -1,0 +1,12 @@
+﻿package;
+class Foo {
+	public function new() {}
+	@:isVar public var foo(get, set):Int;
+	function get_foo():Int return 1;
+	function set_foo(value:Int) return foo = value;
+}
+
+
+class Bar extends Foo {
+	override $(EntryPoint)foo
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeOverrideNullSet.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeOverrideNullSet.hx
@@ -1,0 +1,13 @@
+﻿package;
+class Foo {
+	public function new() {}
+	public var foo(null, set):Int;
+	function set_foo(value:Int):Int {
+		return foo = value;
+	}
+}
+
+
+class Bar extends Foo {
+	override $(EntryPoint)foo
+}


### PR DESCRIPTION
Overriding the property is only valid for accessor methods of reading and / or writing
but the Editor generate override of property without access methods.
code for example:
```haxe
var foo(get, never):T
```
actual result after generate override:
```haxe
//@:getter(foo)
override function get_foo():T
{
    return super.get_foo();
}

//@:setter(foo)
override function set_foo(value:T):T
{
    return super.set_foo(value);
}
```
expected result:
```haxe
//@:getter(foo)
override function get_foo():T
{
    return super.get_foo();
}
```

Fixed generation of override setter, actual:
```haxe
//@:setter(foo)
override function set_foo(value:T):T
{
    return set_foo(value);
}
```
expected:
```haxe
//@:setter(foo)
override function set_foo(value:T):T
{
    return super.set_foo(value);
}
```