### PR TITLE
Scale the max width of the CompletionList

### DIFF
--- a/PluginCore/PluginCore/Controls/CompletionList.cs
+++ b/PluginCore/PluginCore/Controls/CompletionList.cs
@@ -260,7 +260,7 @@ namespace PluginCore.Controls
                 needResize = false;
                 Graphics g = cl.CreateGraphics();
                 SizeF size = g.MeasureString(widestLabel, cl.Font);
-                cl.Width = (int)Math.Min(Math.Max(size.Width + 40, 100), 400) + ScaleHelper.Scale(10);
+                cl.Width = (int)Math.Min(Math.Max(size.Width + 40, 100), ScaleHelper.Scale(400)) + ScaleHelper.Scale(10);
             }
             int newHeight = Math.Min(cl.Items.Count, 10) * cl.ItemHeight + 4;
             if (newHeight != cl.Height) cl.Height = newHeight;


### PR DESCRIPTION
Resolves #1138

There was a max width defined for the completion list of 400 pixels regardless of scaling. Changed to use ScaleHelper.Scale so that this max width will be larger on HiDPI displays. Since there is a max width, there is still the chance that long namespaces will cause suggestions to be cut off, however the completion list should render consistently despite different DPIs.