### PR TITLE
Implemented CodePeek on Ctrl+Hover

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -4046,6 +4046,52 @@ namespace ASCompletion.Completion
         #endregion
 
         #region tooltips formatting
+        static public string GetCodeTipCode(ASResult result)
+        {
+            if (result.Member == null)
+            {
+                return null;
+            }
+
+            var file = GetFileContents(result.InFile);
+            if (string.IsNullOrEmpty(file))
+            {
+                return null;
+            }
+
+            var lines = file.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            var code = new StringBuilder();
+            for (var index = result.Member.LineFrom; index < result.Member.LineTo; index++)
+            {
+                code.AppendLine(lines[index]);
+            }
+            code.Append(lines[result.Member.LineTo]);
+            return code.ToString();
+        }
+
+        static string GetFileContents(FileModel model)
+        {
+            if (model.FileName.Length > 0 && File.Exists(model.FileName))
+            {
+                foreach (ITabbedDocument doc in PluginBase.MainForm.Documents)
+                {
+                    if (doc.IsEditable && doc.FileName.ToUpper() == model.FileName.ToUpper())
+                    {
+                        return doc.SciControl.Text;
+                    }
+                }
+                var info = FileHelper.GetEncodingFileInfo(model.FileName);
+                return info != null ? info.Contents : null;
+            }
+            else
+            {
+                model.Members.Sort();
+                foreach (ClassModel aClass in model.Classes) aClass.Members.Sort();
+                string src = "//\n// " + model.FileName + "\n//\n" + model.GenerateIntrinsic(false);
+                return src;
+            }
+        }
+
         static public string GetToolTipText(ASResult result)
         {
             if (result.Member != null && result.InClass != null)

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -4053,30 +4053,10 @@ namespace ASCompletion.Completion
                 return result.Type != null ? result.Type.ToString() : null;
             }
 
-            if (result.InFile == null)
-            {
-                return null; // Could do something similar to MemberToolTip
-            }
-
             var file = GetFileContents(result.InFile);
             if (string.IsNullOrEmpty(file))
             {
-                return null;
-            }
-
-            if (result.Member.LineFrom == 0 && result.Member.LineTo == 0)
-            {
-                ClassModel inClass = result.InClass ?? result.Type;
-                result.InFile = ASContext.Context.GetCodeModel(file);
-                if (inClass != ClassModel.VoidClass)
-                {
-                    inClass = result.InFile.GetClassByName(inClass.Name);
-                    result.Member = inClass.Members.Search(result.Member.Name, 0, 0);
-                }
-                else
-                {
-                    result.Member = result.InFile.Members.Search(result.Member.Name, 0, 0);
-                }
+                return MemberTooltipText(result.Member, ClassModel.VoidClass);
             }
 
             var lines = file.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
@@ -4089,9 +4069,9 @@ namespace ASCompletion.Completion
             return code.ToString();
         }
 
-        static string GetFileContents(FileModel model)
+        static private string GetFileContents(FileModel model)
         {
-            if (model.FileName.Length > 0 && File.Exists(model.FileName))
+            if (model != null && model.FileName.Length > 0 && File.Exists(model.FileName))
             {
                 foreach (ITabbedDocument doc in PluginBase.MainForm.Documents)
                 {
@@ -4103,13 +4083,7 @@ namespace ASCompletion.Completion
                 var info = FileHelper.GetEncodingFileInfo(model.FileName);
                 return info != null ? info.Contents : null;
             }
-            else
-            {
-                model.Members.Sort();
-                foreach (ClassModel aClass in model.Classes) aClass.Members.Sort();
-                string src = "//\r\n// " + model.FileName + "\r\n//\r\n" + model.GenerateIntrinsic(false);
-                return src;
-            }
+            return null;
         }
 
         static public string GetToolTipText(ASResult result)

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -4059,6 +4059,14 @@ namespace ASCompletion.Completion
                 return null;
             }
 
+            if (result.Member.LineFrom == 0 && result.Member.LineTo == 0)
+            {
+                ClassModel inClass = result.InClass ?? result.Type;
+                result.InFile = ASContext.Context.GetCodeModel(file);
+                inClass = result.InFile.GetClassByName(inClass.Name);
+                result.Member = inClass.Members.Search(result.Member.Name, 0, 0);
+            }
+
             var lines = file.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
             var code = new StringBuilder();
             for (var index = result.Member.LineFrom; index < result.Member.LineTo; index++)
@@ -4087,7 +4095,7 @@ namespace ASCompletion.Completion
             {
                 model.Members.Sort();
                 foreach (ClassModel aClass in model.Classes) aClass.Members.Sort();
-                string src = "//\n// " + model.FileName + "\n//\n" + model.GenerateIntrinsic(false);
+                string src = "//\r\n// " + model.FileName + "\r\n//\r\n" + model.GenerateIntrinsic(false);
                 return src;
             }
         }

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -4050,7 +4050,12 @@ namespace ASCompletion.Completion
         {
             if (result.Member == null)
             {
-                return null;
+                return result.Type != null ? result.Type.ToString() : null;
+            }
+
+            if (result.InFile == null)
+            {
+                return null; // Could do something similar to MemberToolTip
             }
 
             var file = GetFileContents(result.InFile);
@@ -4063,8 +4068,15 @@ namespace ASCompletion.Completion
             {
                 ClassModel inClass = result.InClass ?? result.Type;
                 result.InFile = ASContext.Context.GetCodeModel(file);
-                inClass = result.InFile.GetClassByName(inClass.Name);
-                result.Member = inClass.Members.Search(result.Member.Name, 0, 0);
+                if (inClass.Name != "void")
+                {
+                    inClass = result.InFile.GetClassByName(inClass.Name);
+                    result.Member = inClass.Members.Search(result.Member.Name, 0, 0);
+                }
+                else
+                {
+                    result.Member = result.InFile.Members.Search(result.Member.Name, 0, 0);
+                }
             }
 
             var lines = file.Split(new[] { Environment.NewLine }, StringSplitOptions.None);

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -4068,7 +4068,7 @@ namespace ASCompletion.Completion
             {
                 ClassModel inClass = result.InClass ?? result.Type;
                 result.InFile = ASContext.Context.GetCodeModel(file);
-                if (inClass.Name != "void")
+                if (inClass != ClassModel.VoidClass)
                 {
                     inClass = result.InFile.GetClassByName(inClass.Name);
                     result.Member = inClass.Members.Search(result.Member.Name, 0, 0);

--- a/External/Plugins/ASCompletion/PluginMain.cs
+++ b/External/Plugins/ASCompletion/PluginMain.cs
@@ -912,10 +912,8 @@ namespace ASCompletion
                 if (Control.ModifierKeys == Keys.Control)
                 {
                     var code = ASComplete.GetCodeTipCode(result);
-                    if (!string.IsNullOrEmpty(code))
-                    {
-                        UITools.CodeTip.Show(sci, position - result.Path.Length, code);
-                    }
+                    if (code == null) return;
+                    UITools.CodeTip.Show(sci, position - result.Path.Length, code);
                 }
                 else
                 {

--- a/External/Plugins/ASCompletion/PluginMain.cs
+++ b/External/Plugins/ASCompletion/PluginMain.cs
@@ -909,10 +909,21 @@ namespace ASCompletion
             // set tooltip
             if (!result.IsNull())
             {
-                string text = ASComplete.GetToolTipText(result);
-                if (text == null) return;
-                // show tooltip
-                UITools.Tip.ShowAtMouseLocation(text);
+                if (Control.ModifierKeys == Keys.Control)
+                {
+                    var code = ASComplete.GetCodeTipCode(result);
+                    if (!string.IsNullOrEmpty(code))
+                    {
+                        UITools.CodeTip.Show(sci, position - result.Path.Length, code);
+                    }
+                }
+                else
+                {
+                    string text = ASComplete.GetToolTipText(result);
+                    if (text == null) return;
+                    // show tooltip
+                    UITools.Tip.ShowAtMouseLocation(text);
+                }
             }
         }
 

--- a/PluginCore/PluginCore.csproj
+++ b/PluginCore/PluginCore.csproj
@@ -310,6 +310,7 @@
     </Compile>
     <Compile Include="Ookii.Dialogs\VistaFolderNameEditor.cs" />
     <Compile Include="PluginCore\Bridge\IBridgeSettings.cs" />
+    <Compile Include="PluginCore\Controls\CodeTip.cs" />
     <Compile Include="PluginCore\Controls\Common.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/PluginCore/PluginCore/Controls/CodeTip.cs
+++ b/PluginCore/PluginCore/Controls/CodeTip.cs
@@ -135,14 +135,18 @@ namespace PluginCore.Controls
         void PositionEditor(ScintillaControl sci, int position)
         {
             Point p = new Point(sci.PointXFromPosition(position), sci.PointYFromPosition(position));
-            p = ((Form)PluginBase.MainForm).PointToClient(sci.PointToScreen(p));
+            Form mainForm = ((Form)PluginBase.MainForm);
+            p = mainForm.PointToClient(sci.PointToScreen(p));
 
             if (p.Y > codeTip.Height)
                 codeTip.Top = p.Y - codeTip.Height;
             else
                 codeTip.Top = p.Y + rowHeight;
 
-            codeTip.Left = p.X;
+            if (p.X + codeTip.Width < mainForm.ClientSize.Width)
+                codeTip.Left = p.X;
+            else
+                codeTip.Left = mainForm.ClientSize.Width - codeTip.Width;
         }
 
         Language GetLanguage(string name)

--- a/PluginCore/PluginCore/Controls/CodeTip.cs
+++ b/PluginCore/PluginCore/Controls/CodeTip.cs
@@ -1,0 +1,157 @@
+﻿using PluginCore.Helpers;
+using PluginCore.Utilities;
+using ScintillaNet;
+using ScintillaNet.Configuration;
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace PluginCore.Controls
+{
+    public class CodeTip
+    {
+        ScintillaControl editor;
+        Panel codeTip;
+        int columnWidth;
+        int rowHeight;
+
+        public CodeTip(IMainForm mainForm)
+        {
+            editor = new ScintillaControl();
+            editor.Enabled = false;
+            editor.IsUseTabs = false;
+            codeTip = new Panel();
+            codeTip.BorderStyle = BorderStyle.FixedSingle;
+            codeTip.Controls.Add(editor);
+            codeTip.Visible = false;
+            mainForm.Controls.Add(codeTip);
+        }
+
+        public void Show(ScintillaControl sci, int position, string code)
+        {
+            ConfigureEditor(sci, code);
+            ReduceIndentation();
+            SizeEditor();
+            PositionEditor(sci, position);
+
+            codeTip.Visible = true;
+            codeTip.BringToFront();
+        }
+
+        public void Hide()
+        {
+            codeTip.Visible = false;
+        }
+
+        void ConfigureEditor(ScintillaControl sci, string code)
+        {
+            editor.SetMarginWidthN(1, 0);
+
+            editor.ConfigurationLanguage = sci.ConfigurationLanguage;
+
+            editor.Text = "  ";
+            columnWidth = editor.PointXFromPosition(1) - editor.PointXFromPosition(0);
+            rowHeight = editor.TextHeight(0);
+
+            editor.TabWidth = sci.TabWidth;
+            editor.Text = code;
+
+            editor.SetProperty("lexer.cpp.track.preprocessor", "0");
+
+            Language language = GetLanguage(editor.ConfigurationLanguage);
+            if (language == null)
+                return;
+
+            UseStyle defaultStyle = null;
+            foreach (var useStyle in language.usestyles)
+            {
+                if (useStyle.name == "default")
+                {
+                    defaultStyle = useStyle;
+                    break;
+                }
+            }
+
+            if (defaultStyle == null)
+                return;
+
+            codeTip.BackColor = DataConverter.BGRToColor(defaultStyle.BackgroundColor);
+        }
+
+        void ReduceIndentation()
+        {
+            editor.StripTrailingSpaces();
+
+            int minIndentation = int.MaxValue;
+            for (var index = 0; index < editor.LineCount; index++)
+            {
+                var indentation = editor.GetLineIndentation(index);
+                if (indentation == 0)
+                {
+                    continue;
+                }
+
+                minIndentation = Math.Min(minIndentation, indentation);
+            }
+
+            if (minIndentation < int.MaxValue)
+            {
+                for (var index = 0; index < editor.LineCount; index++)
+                {
+                    var indentation = editor.GetLineIndentation(index);
+                    if (indentation == 0)
+                    {
+                        continue;
+                    }
+
+                    editor.SetLineIndentation(index, indentation - minIndentation);
+                }
+            }
+        }
+
+        void SizeEditor()
+        {
+            var targetHeight = editor.LineCount * rowHeight;
+            int targetWidth = 0;
+            for (var index = 0; index < editor.LineCount; index++)
+                targetWidth = Math.Max(targetWidth, editor.LineLength(index) * columnWidth);
+
+            var editorHeight = Math.Min(ScaleHelper.Scale(500), targetHeight);
+            var editorWidth = Math.Min(ScaleHelper.Scale(800), targetWidth);
+
+            var padding = ScaleHelper.Scale(8);
+            codeTip.Height = editorHeight + (padding * 2);
+            codeTip.Width = editorWidth + (padding * 2);
+
+            editor.Top = padding;
+            editor.Left = padding;
+            editor.Height = editorHeight;
+            editor.Width = editorWidth;
+
+            editor.IsHScrollBar = false; // editorWidth < targetWidth;
+            editor.IsVScrollBar = false; // editorHeight < targetHeight;
+        }
+
+        void PositionEditor(ScintillaControl sci, int position)
+        {
+            Point p = new Point(sci.PointXFromPosition(position), sci.PointYFromPosition(position));
+            p = ((Form)PluginBase.MainForm).PointToClient(sci.PointToScreen(p));
+
+            if (p.Y > codeTip.Height)
+                codeTip.Top = p.Y - codeTip.Height;
+            else
+                codeTip.Top = p.Y + rowHeight;
+
+            codeTip.Left = p.X;
+        }
+
+        Language GetLanguage(string name)
+        {
+            if (PluginBase.MainForm == null || PluginBase.MainForm.SciConfig == null)
+                return null;
+
+            Language language = PluginBase.MainForm.SciConfig.GetLanguage(name);
+            return language;
+        }
+    }
+}

--- a/PluginCore/PluginCore/Controls/UITools.cs
+++ b/PluginCore/PluginCore/Controls/UITools.cs
@@ -29,6 +29,11 @@ namespace PluginCore.Controls
             }
         }
 
+        static public CodeTip CodeTip
+        {
+            get { return manager.codeTip; }
+        }
+
         static public RichToolTip Tip
         {
             get { return manager.simpleTip; }
@@ -77,6 +82,7 @@ namespace PluginCore.Controls
             EventType.Command | 
             EventType.FileSwitch;
 
+        private CodeTip codeTip;
         private RichToolTip simpleTip;
         private MethodCallTip callTip;
 
@@ -92,6 +98,7 @@ namespace PluginCore.Controls
             try
             {
                 CompletionList.CreateControl(PluginBase.MainForm);
+                codeTip = new CodeTip(PluginBase.MainForm);
                 simpleTip = new RichToolTip(PluginBase.MainForm);
                 callTip = new MethodCallTip(PluginBase.MainForm);
             }
@@ -307,6 +314,7 @@ namespace PluginCore.Controls
                 if (CompletionList.Active && CompletionList.CheckPosition(position)) return;
                 if (callTip.CallTipActive && callTip.CheckPosition(position)) return;
             }
+            codeTip.Hide();
             callTip.Hide();
             CompletionList.Hide();
             simpleTip.Hide();
@@ -334,6 +342,7 @@ namespace PluginCore.Controls
             if (lockedSciControl != null && lockedSciControl.IsAlive) sci = (ScintillaControl)lockedSciControl.Target;
             else
             {
+                codeTip.Hide();
                 callTip.Hide();
                 CompletionList.Hide();
                 SendChar(sci, value);
@@ -363,6 +372,7 @@ namespace PluginCore.Controls
                 {
                     UnlockControl();
                     CompletionList.Hide();
+                    codeTip.Hide();
                     callTip.Hide();
                 }*/
                 // offer to handle the shortcut
@@ -398,6 +408,7 @@ namespace PluginCore.Controls
                     return false; // let text copy in tip
                 UnlockControl();
                 CompletionList.Hide((char)27);
+                codeTip.Hide();
                 callTip.Hide();
                 return false;
             }

--- a/PluginCore/PluginCore/Utilities/DataConverter.cs
+++ b/PluginCore/PluginCore/Utilities/DataConverter.cs
@@ -108,7 +108,7 @@ namespace PluginCore.Utilities
         /// <summary>
         /// Converts a integer (BGR order) to a color
         /// </summary>
-        private static Color BGRToColor(Int32 bgr)
+        public static Color BGRToColor(Int32 bgr)
         {
             return Color.FromArgb((bgr >> 0) & 0xff, (bgr >> 8) & 0xff, (bgr >> 16) & 0xff);
         }


### PR DESCRIPTION
resolves #1019 

When hovering over a member with the control key pressed a CodeTip will popup displaying the lines of code where the member is defined.

![codepeek1](https://cloud.githubusercontent.com/assets/611219/18420453/061a7082-7841-11e6-8d52-45a2d72a6386.jpg)

![codepeek2](https://cloud.githubusercontent.com/assets/611219/18420454/09c6dc0c-7841-11e6-9260-868d0bd36957.jpg)

