### PR TITLE
[HXML] Fixed parsing of lines that are not arguments with '-' in the middle.

### DIFF
--- a/External/Plugins/ProjectManager/Projects/Haxe/HaxeProject.cs
+++ b/External/Plugins/ProjectManager/Projects/Haxe/HaxeProject.cs
@@ -387,7 +387,7 @@ namespace ProjectManager.Projects.Haxe
 
         private void ParseHxmlEntries(string[] lines, List<string> defs, List<string> cps, List<string> libs, List<string> add, ref string target, ref string haxeTarget, ref string output)
         {
-            Regex reHxOp = new Regex("-([a-z0-9-]+)\\s*(.*)", RegexOptions.IgnoreCase);
+            Regex reHxOp = new Regex("^-([a-z0-9-]+)\\s*(.*)", RegexOptions.IgnoreCase);
             foreach (string line in lines)
             {
                 if (line == null) break;


### PR DESCRIPTION
For example having inside a hxml lines like:

#Comment -js
Would set the -js target.

Or having:
./build--next.hxml

Would interpret the line as a --next argument and stop parsing the current file.