### PR TITLE
Fixed project saving

### DIFF
--- a/External/Plugins/ProjectManager/Projects/ProjectWriter.cs
+++ b/External/Plugins/ProjectManager/Projects/ProjectWriter.cs
@@ -10,7 +10,8 @@ namespace ProjectManager.Projects
     {
         Project project;
 
-        public ProjectWriter(Project project, string filename) : base(new FileStream(filename,FileMode.OpenOrCreate),Encoding.UTF8)
+        public ProjectWriter(Project project, string filename)
+            : base(new FileStream(filename, File.Exists(filename) ? FileMode.Truncate : FileMode.CreateNew), Encoding.UTF8)
         {
             this.project = project;
             this.Formatting = Formatting.Indented;


### PR DESCRIPTION
Use FileMode.Truncate/FileMode.CreateNew instead of FileMode.OpenOrCeate when saving project files. (fixes #1330)