### PR TITLE
Get Haxe libraries from project CompilerOptions instead of building virtual HXML

### DIFF
--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -409,10 +409,10 @@ namespace HaXeContext
             // add haxe libraries
             if (proj != null)
             {
-                foreach (string param in proj.BuildHXML(new string[0], "", false))
-                    if (!string.IsNullOrEmpty(param) && param.IndexOfOrdinal("-lib ") == 0)
+                foreach (string library in proj.CompilerOptions.Libraries)
+                    if (!string.IsNullOrEmpty(library.Trim()))
                     {
-                        List<string> libPaths = LookupLibrary(param.Substring(5));
+                        List<string> libPaths = LookupLibrary(library);
                         if (libPaths != null)
                         {
                             foreach (string path in libPaths)


### PR DESCRIPTION
Building a virtual HXML is a problem, because if rawHxml is set it will return that, and if libs are defined in HXMLs inside other HXMLs this info gets lost, causing some FD features to not work properly.

I don't know why we'd want to return a virtual HXML, I checked and it's quite old code, so maybe it was needed back in the day... nowadays I don't see a need for doing it that way?