### PR TITLE
Don't fail if we don't have a CurrentModel when calling Context.GetAllProjectClasses()

### DIFF
--- a/External/Plugins/AS3Context/Context.cs
+++ b/External/Plugins/AS3Context/Context.cs
@@ -747,7 +747,7 @@ namespace AS3Context
             ClassModel aClass;
             MemberModel item;
             // public & internal classes
-            string package = CurrentModel.Package;
+            string package = CurrentModel?.Package;
             foreach (PathModel aPath in classPath) if (aPath.IsValid && !aPath.Updating)
             {
                 aPath.ForeachFile((aFile) =>

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -638,7 +638,7 @@ namespace HaXeContext
             MemberList fullList = new MemberList();
             MemberModel item;
             // public & internal classes
-            string package = CurrentModel.Package;
+            string package = CurrentModel?.Package;
             foreach (PathModel aPath in classPath) if (aPath.IsValid && !aPath.Updating)
             {
                 aPath.ForeachFile((aFile) =>


### PR DESCRIPTION
Useful for plugins and some other cases.