### PR TITLE
SourceControl intergrated blame

### DIFF
--- a/External/Plugins/SourceControl/Actions/TreeContextMenuUpdate.cs
+++ b/External/Plugins/SourceControl/Actions/TreeContextMenuUpdate.cs
@@ -48,6 +48,8 @@ namespace SourceControl.Actions
                 int minLen = items.Count;
 
                 // specific
+                if (state.Files == 1 && state.Total == 1) items.Add(menuItems.Annotate);
+
                 if (state.Files == 2 && state.Total == 2) items.Add(menuItems.Diff);
                 if (state.Conflict == 1 && state.Total == 1) items.Add(menuItems.EditConflict);
 

--- a/External/Plugins/SourceControl/Helpers/AnnotatedDocument.cs
+++ b/External/Plugins/SourceControl/Helpers/AnnotatedDocument.cs
@@ -1,0 +1,355 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Windows.Forms;
+using PluginCore;
+using PluginCore.Helpers;
+using ScintillaNet;
+using ScintillaNet.Enums;
+
+namespace SourceControl.Helpers
+{
+    internal class AnnotatedDocument : IDisposable
+    {
+        private static List<AnnotatedDocument> documents;
+
+        private IBlameCommand command;
+        private string fileName;
+        private ITabbedDocument document;
+        private ScintillaControl sci;
+        private AnnotationData[] annotations;
+        private Dictionary<string, AnnotationData> commits;
+        private ToolTip tooltip;
+
+        static AnnotatedDocument()
+        {
+            documents = new List<AnnotatedDocument>();
+        }
+
+        private AnnotatedDocument(IBlameCommand cmd, string file, ITabbedDocument doc)
+        {
+            documents.Add(this);
+            command = cmd;
+            fileName = file;
+            document = doc;
+            sci = document.SciControl;
+            annotations = null;
+            commits = new Dictionary<string, AnnotationData>();
+            tooltip = new ToolTip();
+
+            ((Form) document).FormClosed += Document_FormClosed;
+            sci.DwellStart += Sci_DwellStart;
+            sci.DwellEnd += Sci_DwellEnd;
+            sci.MarginClick += Sci_MarginClick;
+        }
+
+        public static AnnotatedDocument CreateAnnotatedDocument(IBlameCommand command, string fileName)
+        {
+            string title = Path.Combine(Path.GetDirectoryName(fileName), "[Annotated] " + Path.GetFileName(fileName));
+            var doc = PluginBase.MainForm.CreateEditableDocument(title, string.Empty, Encoding.UTF8.CodePage) as ITabbedDocument;
+            return doc == null ? null : new AnnotatedDocument(command, fileName, doc);
+        }
+
+        public static bool CheckExisting(string fileName)
+        {
+            foreach (var doc in documents)
+            {
+                if (doc.fileName == fileName)
+                {
+                    doc.command.Update();
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public static void ApplyTheme()
+        {
+            foreach (var doc in documents)
+            {
+                doc.UpdateBackColor(true);
+            }
+        }
+
+        public void Initialize()
+        {
+            sci.IsReadOnly = false;
+            sci.MarginTextClearAll();
+            sci.SetText("Loading..."); // TODO: Localisation
+            sci.IsReadOnly = true;
+
+            annotations = null;
+            commits.Clear();
+        }
+
+        public void Annotate(AnnotationData[] annotationData)
+        {
+            sci.IsReadOnly = false;
+            try
+            {
+                sci.SetText(FileHelper.ReadFile(fileName));
+
+                annotations = annotationData;
+                OrganizeAnnotations();
+                string longestInfo = ParseCommits();
+                ShowAnnotation(longestInfo);
+                UpdateBackColor(false);
+            }
+            finally
+            {
+                sci.SetSavePoint();
+                sci.IsReadOnly = true;
+            }
+        }
+
+        private void OrganizeAnnotations()
+        {
+            Array.Sort(annotations, (x, y) => x.ResultLine.CompareTo(y.ResultLine));
+            int i = 0, offset = 0, length = annotations.Length - 1;
+            while (i < length)
+            {
+                var current = annotations[i++ - offset];
+                var next = annotations[i];
+                if (current.Hash == next.Hash)
+                {
+                    // Assume no lines are missing from 'git blame' output,
+                    // meaning current.ResultLine + current.LineCount == next.ResultLine
+                    current.LineCount += next.LineCount;
+                    offset++;
+                }
+                else
+                {
+                    annotations[i - offset] = next;
+                }
+            }
+            Array.Resize(ref annotations, annotations.Length - offset);
+        }
+
+        private string ParseCommits()
+        {
+            string longestInfo = string.Empty;
+            foreach (var annotation in annotations)
+            {
+                if (commits.ContainsKey(annotation.Hash))
+                {
+                    var def = commits[annotation.Hash];
+                    annotation.Author = def.Author;
+                    annotation.AuthorMail = def.AuthorMail;
+                    annotation.AuthorTime = def.AuthorTime;
+                    annotation.AuthorTimeZone = def.AuthorTimeZone;
+                    annotation.Committer = def.Committer;
+                    annotation.CommitterMail = def.CommitterMail;
+                    annotation.CommitterTime = def.CommitterTime;
+                    annotation.CommitterTimeZone = def.CommitterTimeZone;
+                    annotation.FileName = def.FileName;
+                    annotation.Message = def.Message;
+                    annotation.IsEdit = def.IsEdit;
+                    annotation.MarginStyle = def.MarginStyle;
+                }
+                else
+                {
+                    commits.Add(annotation.Hash, annotation);
+                    int style = 0x80 + commits.Count % 0x80;
+                    sci.StyleSetFont(style, sci.StyleGetFont(0));
+                    sci.StyleSetSize(style, sci.StyleGetSize(0));
+                    sci.StyleSetFore(style, sci.StyleGetFore(0));
+                    sci.StyleSetBack(style, sci.StyleGetBack(0));
+                    sci.StyleSetBold(style, sci.StyleGetBold(0));
+                    sci.StyleSetItalic(style, sci.StyleGetItalic(0));
+                    annotation.MarginStyle = style;
+                }
+
+                string info = annotation.GetInfo();
+                if (info.Length > longestInfo.Length)
+                {
+                    longestInfo = info;
+                }
+            }
+
+            return longestInfo;
+        }
+
+        private void ShowAnnotation(string longestInfo)
+        {
+            int width = longestInfo.Length;
+            sci.SetMarginTypeN(4, (int) MarginType.Text);
+            sci.SetMarginWidthN(4, sci.TextWidth(0, longestInfo));
+            sci.MarginSensitiveN(4, true);
+            sci.SetMarginCursorN(4, (int) CursorShape.Arrow);
+
+            foreach (var annotation in annotations)
+            {
+                int line = annotation.ResultLine;
+                sci.SetMarginText(line, annotation.GetInfo(width));
+                for (int i = 0; i < annotation.LineCount; i++)
+                {
+                    sci.SetMarginStyle(line + i, annotation.MarginStyle);
+                }
+            }
+        }
+
+        private void UpdateBackColor(bool applyingTheme)
+        {
+            if (applyingTheme)
+            {
+                sci.BeginInvoke((MethodInvoker) delegate { UpdateBackColor(false); });
+                return;
+            }
+            var random = new Random();
+            int color = sci.StyleGetBack(0);
+            int r = color >> 16 & 0xFF;
+            int g = color >> 8 & 0xFF;
+            int b = color & 0xFF;
+            foreach (var annotation in commits.Values)
+            {
+                int newR = r + random.Next(0xFF) >> 1;
+                int newG = g + random.Next(0xFF) >> 1;
+                int newB = b + random.Next(0xFF) >> 1;
+                sci.StyleSetBack(annotation.MarginStyle, newR << 16 | newG << 8 | newB);
+            }
+        }
+
+        private void Document_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            Dispose();
+        }
+
+        private void Sci_DwellStart(ScintillaControl sender, int position, int x, int y)
+        {
+            if (!disposed && position == -1)
+            {
+                int line = sci.LineFromPosition(sci.PositionFromPoint(x, y));
+                var annotationData = GetAnnotationData(line);
+                if (annotationData != null)
+                {
+                    tooltip.Show(annotationData.ToString(), sci, x, y + 10);
+                }
+            }
+        }
+
+        private void Sci_DwellEnd(ScintillaControl sender, int position, int x, int y)
+        {
+            if (!disposed)
+            {
+                tooltip.Hide(sci);
+            }
+        }
+
+        private void Sci_MarginClick(ScintillaControl sender, int modifiers, int position, int margin)
+        {
+            if (!disposed)
+            {
+                int line = sci.LineFromPosition(position);
+                var annotationData = GetAnnotationData(line);
+                if (annotationData != null && annotationData.ResultLine == line)
+                {
+                    command.ShowOnFileHistory(annotationData.Hash);
+                }
+            }
+        }
+
+        private AnnotationData GetAnnotationData(int line)
+        {
+            int low = 0;
+            int high = annotations.Length - 1;
+            while (low <= high)
+            {
+                int i = low + (high - low >> 1);
+                var annotationData = annotations[i];
+                if (line < annotationData.ResultLine)
+                {
+                    high = i - 1;
+                }
+                else if (line >= annotationData.ResultLine + annotationData.LineCount)
+                {
+                    low = i + 1;
+                }
+                else return annotationData;
+            }
+            return null;
+        }
+
+        #region IDisposable
+
+        private bool disposed = false;
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (disposing)
+                {
+                    documents.Remove(this);
+                    if (command != null) command.Dispose();
+                    if (tooltip != null) tooltip.Dispose();
+                    if (document != null) ((Form) document).FormClosed -= Document_FormClosed;
+                    if (sci != null)
+                    {
+                        sci.DwellStart -= Sci_DwellStart;
+                        sci.DwellEnd -= Sci_DwellEnd;
+                        sci.MarginClick -= Sci_MarginClick;
+                    }
+                }
+
+                command = null;
+                fileName = null;
+                document = null;
+                sci = null;
+                annotations = null;
+                commits = null;
+                tooltip = null;
+
+                disposed = true;
+            }
+        }
+
+        #endregion
+    }
+
+    internal class AnnotationData : Commit
+    {
+        public bool IsEdit;
+        public int SourceLine;
+        public int ResultLine;
+        public int LineCount;
+        public int MarginStyle;
+
+        public string GetInfo(int width = 0)
+        {
+            string commit = Hash.Substring(0, 8);
+            string authorTime = AuthorTime.ToShortDateString();
+
+            if (commit == "00000000")
+            {
+                return "Local"; // TODO: Localisation
+            }
+            width -= 10 + authorTime.Length;
+            return Hash.Substring(0, 8) + " " + (width > 0 ? Author.PadRight(width) : Author) + " " + authorTime;
+        }
+
+        public override string ToString()
+        {
+            return "Commit" + ": " + Hash + "\n" +
+                "Author" + ": " + Author + " " + AuthorMail + "\n" +
+                "Author Date" + ": " + AuthorTime + " " + AuthorTimeZone + "\n" +
+                "Committer" + ": " + Committer + " " + CommitterMail + "\n" +
+                "Committer Date" + ": " + CommitterTime + " " + CommitterTimeZone + "\n" +
+                "Change" + ": " + (IsEdit ? "edit" : "add") + "\n" +
+                "Lines" + ": " + (ResultLine + 1) + "~" + (ResultLine + LineCount) + "\n" +
+                "Path" + ": " + FileName + "\n" +
+                "\n" + Message;
+        }
+    }
+
+    internal interface IBlameCommand : IDisposable
+    {
+        void Update();
+        void ShowOnFileHistory(string commit);
+    }
+}

--- a/External/Plugins/SourceControl/Helpers/Commit.cs
+++ b/External/Plugins/SourceControl/Helpers/Commit.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace SourceControl.Helpers
+{
+    internal class Commit
+    {
+        public string Hash;
+        public string Author;
+        public string AuthorMail;
+        public DateTime AuthorTime;
+        public string AuthorTimeZone;
+        public string Committer;
+        public string CommitterMail;
+        public DateTime CommitterTime;
+        public string CommitterTimeZone;
+        public string FileName;
+        public string Message;
+    }
+}

--- a/External/Plugins/SourceControl/PluginMain.cs
+++ b/External/Plugins/SourceControl/PluginMain.cs
@@ -82,11 +82,13 @@ namespace SourceControl
         {
             get { return settingObject; }
         }
-        
+
         #endregion
-        
+
         #region Required Methods
-        
+
+        internal static event EventHandler ApplyTheme;
+
         /// <summary>
         /// Initializes the plugin
         /// </summary>
@@ -280,6 +282,9 @@ namespace SourceControl
                         e.Handled = true;
                     }
                     break;
+                case EventType.ApplyTheme:
+                    if (ApplyTheme != null) ApplyTheme(this, EventArgs.Empty);
+                    break;
             }
         }
         
@@ -311,7 +316,7 @@ namespace SourceControl
         /// </summary> 
         public void AddEventHandlers()
         {
-            EventManager.AddEventHandler(this, EventType.UIStarted | EventType.Command | EventType.FileModifyRO | EventType.FileOpen | EventType.FileReload | EventType.FileNew | EventType.FileTemplate);
+            EventManager.AddEventHandler(this, EventType.UIStarted | EventType.Command | EventType.FileModifyRO | EventType.FileOpen | EventType.FileReload | EventType.FileNew | EventType.FileTemplate | EventType.ApplyTheme);
         }
 
         /// <summary>

--- a/External/Plugins/SourceControl/PluginMain.cs
+++ b/External/Plugins/SourceControl/PluginMain.cs
@@ -10,6 +10,7 @@ using ProjectManager;
 using ProjectManager.Actions;
 using ProjectManager.Projects;
 using SourceControl.Actions;
+using SourceControl.Helpers;
 
 namespace SourceControl
 {
@@ -86,9 +87,7 @@ namespace SourceControl
         #endregion
 
         #region Required Methods
-
-        internal static event EventHandler ApplyTheme;
-
+        
         /// <summary>
         /// Initializes the plugin
         /// </summary>
@@ -283,7 +282,7 @@ namespace SourceControl
                     }
                     break;
                 case EventType.ApplyTheme:
-                    if (ApplyTheme != null) ApplyTheme(this, EventArgs.Empty);
+                    AnnotatedDocument.ApplyTheme();
                     break;
             }
         }

--- a/External/Plugins/SourceControl/SourceControl.csproj
+++ b/External/Plugins/SourceControl/SourceControl.csproj
@@ -81,6 +81,8 @@
   <ItemGroup>
     <Compile Include="Actions\ProjectWatcher.cs" />
     <Compile Include="Actions\TreeContextMenuUpdate.cs" />
+    <Compile Include="Helpers\AnnotatedDocument.cs" />
+    <Compile Include="Helpers\Commit.cs" />
     <Compile Include="Managers\FSWatchers.cs" />
     <Compile Include="Managers\OverlayManager.cs" />
     <Compile Include="Managers\VCManager.cs" />

--- a/External/Plugins/SourceControl/SourceControl.csproj
+++ b/External/Plugins/SourceControl/SourceControl.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Managers\OverlayManager.cs" />
     <Compile Include="Managers\VCManager.cs" />
     <Compile Include="Sources\Git\BaseCommand.cs" />
+    <Compile Include="Sources\Git\BlameCommand.cs" />
     <Compile Include="Sources\Git\CommitCommand.cs" />
     <Compile Include="Sources\Git\ResetCommand.cs" />
     <Compile Include="Sources\Git\DeleteCommand.cs" />

--- a/External/Plugins/SourceControl/Sources/Git/BaseCommand.cs
+++ b/External/Plugins/SourceControl/Sources/Git/BaseCommand.cs
@@ -10,10 +10,10 @@ using PluginCore.Utilities;
 
 namespace SourceControl.Sources.Git
 {
-    class BaseCommand
+    internal class BaseCommand
     {
-        static private string resolvedCmd;
-        static private string qualifiedCmd;
+        private static string resolvedCmd;
+        private static string qualifiedCmd;
 
         protected ProcessRunner runner;
         protected List<string> errors = new List<string>();
@@ -48,7 +48,7 @@ namespace SourceControl.Sources.Git
             return resolve ?? ResolveGitPath(cmd);
         }
 
-        static private string ResolveGitPath(string cmd)
+        private static string ResolveGitPath(string cmd)
         {
             if (resolvedCmd == cmd || Path.IsPathRooted(cmd))
                 return qualifiedCmd;

--- a/External/Plugins/SourceControl/Sources/Git/BlameCommand.cs
+++ b/External/Plugins/SourceControl/Sources/Git/BlameCommand.cs
@@ -77,15 +77,19 @@ namespace SourceControl.Sources.Git
                             annotations.Add(ParseAnnotation());
                         }
                         document.Annotate(annotations.ToArray());
+                        return;
                     }
                 }
+                catch { }
                 finally
                 {
                     outputLines = null;
                     running = false;
                 }
             }
-            base.Runner_ProcessEnded(sender, exitCode);
+            runner = null;
+            document.ShowError(string.Join("\n", errors.ToArray()));
+            errors.Clear();
         }
 
         private AnnotationData ParseAnnotation()

--- a/External/Plugins/SourceControl/Sources/Git/BlameCommand.cs
+++ b/External/Plugins/SourceControl/Sources/Git/BlameCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using PluginCore.Managers;
 using SourceControl.Helpers;
 
 namespace SourceControl.Sources.Git
@@ -79,17 +80,28 @@ namespace SourceControl.Sources.Git
                         document.Annotate(annotations.ToArray());
                         return;
                     }
+                    if (errors.Count > 0)
+                    {
+                        document.ShowError(string.Join("\n", errors.ToArray()));
+                    }
                 }
-                catch { }
+                catch (Exception e)
+                {
+                    ErrorManager.ShowError(e);
+                }
                 finally
                 {
-                    outputLines = null;
                     running = false;
+                    outputLines = null;
+                    runner = null;
+                    errors.Clear();
                 }
             }
-            runner = null;
-            document.ShowError(string.Join("\n", errors.ToArray()));
-            errors.Clear();
+            else
+            {
+                runner = null;
+                errors.Clear();
+            }
         }
 
         private AnnotationData ParseAnnotation()

--- a/External/Plugins/SourceControl/Sources/Git/BlameCommand.cs
+++ b/External/Plugins/SourceControl/Sources/Git/BlameCommand.cs
@@ -1,32 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
-using System.Windows.Forms;
-using PluginCore;
-using ScintillaNet;
-using ScintillaNet.Enums;
+using SourceControl.Helpers;
 
 namespace SourceControl.Sources.Git
 {
-    internal class BlameCommand : BaseCommand, IDisposable
+    internal class BlameCommand : BaseCommand, IBlameCommand
     {
-        private static List<BlameCommand> blameCommands;
-
         private string fileName;
-        private ITabbedDocument document;
-        private ScintillaControl sci;
+        private AnnotatedDocument document;
         private LinkedList<string> outputLines;
-        private List<AnnotationData> annotations;
-        private Dictionary<string, AnnotationData> commits;
-        private ToolTip tooltip;
-        private bool loading;
-
-        static BlameCommand()
-        {
-            blameCommands = new List<BlameCommand>();
-            PluginMain.ApplyTheme += ApplyTheme;
-        }
+        private bool running;
 
         public BlameCommand(string file)
         {
@@ -37,65 +21,37 @@ namespace SourceControl.Sources.Git
             else
             {
                 fileName = file;
-                annotations = new List<AnnotationData>();
-                commits = new Dictionary<string, AnnotationData>();
+                running = false;
                 CheckExisting();
                 OpenAnnotatedDocument();
                 Update();
             }
         }
 
-        private static void ApplyTheme(object sender, EventArgs e)
-        {
-            foreach (var cmd in blameCommands)
-            {
-                cmd.UpdateBackColor(true);
-            }
-        }
-        
         private void CheckExisting()
         {
-            for (int i = 0, length = blameCommands.Count; i < length; i++)
+            if (AnnotatedDocument.CheckExisting(fileName))
             {
-                var cmd = blameCommands[i];
-                if (cmd.fileName == fileName)
-                {
-                    cmd.Update();
-                    Dispose();
-                    return;
-                }
+                Dispose();
             }
-            blameCommands.Add(this);
         }
 
         private void OpenAnnotatedDocument()
         {
             if (!disposed)
             {
-                string documentName = Path.Combine(Path.GetDirectoryName(fileName), "[Annotated] " + Path.GetFileName(fileName));
-                document = PluginBase.MainForm.CreateEditableDocument(documentName, "", Encoding.UTF8.CodePage) as ITabbedDocument;
-                if (document == null)
-                {
-                    Dispose();
-                }
-                else
-                {
-                    ((Form) document).FormClosed += Document_FormClosed;
-                    sci = document.SciControl;
-                } 
+                document = AnnotatedDocument.CreateAnnotatedDocument(this, fileName);
             }
         }
 
-        private void Update()
+        public void Update()
         {
-            if (!disposed && !loading)
+            if (!disposed && !running)
             {
-                loading = true;
-                sci.IsReadOnly = false;
-                sci.SetText("Loading..."); // TODO: Localisation
-                sci.IsReadOnly = true;
+                running = true;
+                document.Initialize();
                 outputLines = new LinkedList<string>();
-                Run("blame --porcelain \"" + fileName + "\"", Path.GetDirectoryName(fileName));
+                Run("blame --incremental \"" + fileName + "\"", Path.GetDirectoryName(fileName));
             }
         }
 
@@ -111,179 +67,43 @@ namespace SourceControl.Sources.Git
         {
             if (!disposed)
             {
-                sci.IsReadOnly = false;
                 try
                 {
                     if (outputLines.Count > 0 && exitCode == 0)
                     {
-                        annotations.Clear();
-                        commits.Clear();
-                        int i;
-                        string longestInfo = "";
-                        var sb = new StringBuilder();
-                        AnnotationData lastAnnotation = null;
-                        for (i = 0; 0 < outputLines.Count; i++)
+                        var annotations = new List<AnnotationData>();
+                        while (0 < outputLines.Count)
                         {
-                            var annotation = ParseAnnotation();
-                            if (lastAnnotation != null)
-                            {
-                                lastAnnotation.LineEnd = i - 1;
-                                annotation.Line = sci.NewLineMarker + annotation.Line;
-                            }
-
-                            sb.Append(annotation.Line);
-
-                            if (lastAnnotation == null || annotation.Commit != lastAnnotation.Commit)
-                            {
-                                if (commits.ContainsKey(annotation.Commit))
-                                {
-                                    var def = commits[annotation.Commit];
-                                    annotation.Author = def.Author;
-                                    annotation.AuthorMail = def.AuthorMail;
-                                    annotation.AuthorTime = def.AuthorTime;
-                                    annotation.AuthorTimeZone = def.AuthorTimeZone;
-                                    annotation.Committer = def.Committer;
-                                    annotation.CommitterMail = def.CommitterMail;
-                                    annotation.CommitterTime = def.CommitterTime;
-                                    annotation.CommitterTimeZone = def.CommitterTimeZone;
-                                    annotation.FileName = def.FileName;
-                                    annotation.IsEdit = def.IsEdit;
-                                    annotation.Summary = def.Summary;
-                                    annotation.Color = def.Color;
-                                }
-                                else
-                                {
-                                    commits.Add(annotation.Commit, annotation);
-                                    int style = 128 + commits.Count % 128;
-                                    sci.StyleSetFont(style, sci.StyleGetFont(0));
-                                    sci.StyleSetSize(style, sci.StyleGetSize(0));
-                                    sci.StyleSetFore(style, sci.StyleGetFore(0));
-                                    sci.StyleSetBack(style, sci.StyleGetBack(0));
-                                    sci.StyleSetBold(style, sci.StyleGetBold(0));
-                                    sci.StyleSetItalic(style, sci.StyleGetItalic(0));
-                                    annotation.Color = style;
-                                }
-
-                                string info = annotation.GetInfo();
-                                if (info.Length > longestInfo.Length)
-                                {
-                                    longestInfo = info;
-                                }
-                                annotation.LineStart = i;
-                                lastAnnotation = annotation;
-                                annotations.Add(annotation);
-                            }
+                            annotations.Add(ParseAnnotation());
                         }
-
-                        lastAnnotation.LineEnd = i - 1;
-
-                        sci.SetMarginTypeN(4, (int) MarginType.Text);
-                        sci.SetMarginWidthN(4, sci.TextWidth(0, longestInfo));
-                        sci.MarginSensitiveN(4, true);
-                        sci.SetMarginCursorN(4, 2);
-
-                        sci.SetText(sb.ToString());
-
-                        for (i = 0; i < annotations.Count; i++)
-                        {
-                            var annotation = annotations[i];
-                            sci.SetMarginText(annotation.LineStart, annotation.GetInfo(longestInfo.Length));
-                            for (int j = annotation.LineStart; j <= annotation.LineEnd; j++)
-                            {
-                                sci.SetMarginStyle(j, annotation.Color);
-                            }
-                        }
-
-                        UpdateBackColor(false);
-
-                        outputLines.Clear();
-                        outputLines = null;
-                        annotations.TrimExcess();
-                        tooltip = new ToolTip();
-                        sci.DwellStart += Sci_DwellStart;
-                        sci.DwellEnd += Sci_DwellEnd;
-                        sci.MarginClick += Sci_MarginClick;
+                        document.Annotate(annotations.ToArray());
                     }
                 }
                 finally
                 {
-                    sci.SetSavePoint();
-                    sci.IsReadOnly = true;
-                    loading = false;
+                    outputLines = null;
+                    running = false;
                 }
             }
             base.Runner_ProcessEnded(sender, exitCode);
-        }
-        
-        private void UpdateBackColor(bool applyingTheme)
-        {
-            if (applyingTheme)
-            {
-                sci.BeginInvoke((MethodInvoker) delegate { UpdateBackColor(false); });
-                return;
-            }
-            var random = new Random();
-            int count = 0;
-            int color = sci.StyleGetBack(0);
-            int r = color >> 16 & 0xFF;
-            int g = color >> 8 & 0xFF;
-            int b = color & 0xFF;
-            foreach (var annotation in commits.Values)
-            {
-                int style = 128 + ++count % 128;
-                int newR = r + random.Next(0xFF) >> 1;
-                int newG = g + random.Next(0xFF) >> 1;
-                int newB = b + random.Next(0xFF) >> 1;
-                sci.StyleSetBack(style, newR << 16 | newG << 8 | newB);
-            }
-        }
-
-        private void Document_FormClosed(object sender, FormClosedEventArgs e)
-        {
-            Dispose();
-        }
-
-        private void Sci_DwellStart(ScintillaControl sender, int position, int x, int y)
-        {
-            if (!disposed && position == -1)
-            {
-                int line = sci.LineFromPosition(sci.PositionFromPoint(x, y));
-                var annotationData = GetAnnotationData(line);
-                if (annotationData != null)
-                {
-                    tooltip.Show(annotationData.ToString(), sci, x, y);
-                }
-            }
-        }
-
-        private void Sci_DwellEnd(ScintillaControl sender, int position, int x, int y)
-        {
-            if (!disposed) tooltip.Hide(sci);
-        }
-        
-        private void Sci_MarginClick(ScintillaControl sender, int modifiers, int position, int margin)
-        {
-            if (!disposed)
-            {
-                Console.WriteLine(Control.MouseButtons);
-                int line = sci.LineFromPosition(position);
-                var annotationData = GetAnnotationData(line);
-                if (annotationData != null && annotationData.LineStart == line)
-                {
-                    TortoiseProc.ExecuteCustom("log", string.Format("/path:\"{0}\" /rev:{1}", annotationData.FileName, annotationData.Commit));
-                }
-            }
         }
 
         private AnnotationData ParseAnnotation()
         {
             var data = new AnnotationData();
-            data.Commit = GetNextOutputLine().Substring(0, 40);
+            string[] firstLine = GetNextOutputLine().Split(' ');
+            data.Hash = firstLine[0];
+            data.SourceLine = int.Parse(firstLine[1]) - 1;
+            data.ResultLine = int.Parse(firstLine[2]) - 1;
+            data.LineCount = int.Parse(firstLine[3]);
 
-            string line;
-            while (!(line = GetNextOutputLine()).StartsWith('\t'))
+            while (true)
             {
+                string line = GetNextOutputLine();
+
                 int separator = line.IndexOf(' ');
+                if (separator == -1) continue;
+
                 string key = line.Substring(0, separator);
                 string value = line.Substring(separator + 1);
 
@@ -296,7 +116,7 @@ namespace SourceControl.Sources.Git
                         data.AuthorMail = value;
                         break;
                     case "author-time":
-                        data.AuthorTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(int.Parse(value));
+                        data.AuthorTime = ParseDateTime(value);
                         break;
                     case "author-tz":
                         data.AuthorTimeZone = value;
@@ -308,7 +128,7 @@ namespace SourceControl.Sources.Git
                         data.CommitterMail = value;
                         break;
                     case "committer-time":
-                        data.CommitterTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(int.Parse(value));
+                        data.CommitterTime = ParseDateTime(value);
                         break;
                     case "committer-tz":
                         data.CommitterTimeZone = value;
@@ -317,37 +137,18 @@ namespace SourceControl.Sources.Git
                         data.IsEdit = true;
                         break;
                     case "summary":
-                        data.Summary = value;
+                        data.Message = value;
                         break;
                     case "filename":
                         data.FileName = value;
-                        break;
+                        return data;
                 }
             }
-
-            data.Line = line.Substring(1);
-            return data;
         }
 
-        private AnnotationData GetAnnotationData(int line)
+        private static DateTime ParseDateTime(string value)
         {
-            int low = 0;
-            int high = annotations.Count - 1;
-            while (low <= high)
-            {
-                int i = low + (high - low >> 1);
-                var annotationData = annotations[i];
-                if (line < annotationData.LineStart)
-                {
-                    high = i - 1;
-                }
-                else if (line > annotationData.LineEnd)
-                {
-                    low = i + 1;
-                }
-                else return annotationData;
-            }
-            return null;
+            return new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(int.Parse(value));
         }
 
         private string GetNextOutputLine()
@@ -357,7 +158,7 @@ namespace SourceControl.Sources.Git
             return value;
         }
 
-        #region IDisposable
+        #region IBlameCommand
 
         private bool disposed = false;
 
@@ -370,81 +171,20 @@ namespace SourceControl.Sources.Git
         {
             if (!disposed)
             {
-                if (disposing)
-                {
-                    blameCommands.Remove(this);
-                    if (document != null) ((Form) document).FormClosed -= Document_FormClosed;
-                    if (sci != null)
-                    {
-                        sci.DwellStart -= Sci_DwellStart;
-                        sci.DwellEnd -= Sci_DwellEnd;
-                        sci.MarginClick -= Sci_MarginClick;
-                    }
-                    if (outputLines != null) outputLines.Clear();
-                    if (annotations != null) annotations.Clear();
-                    if (commits != null) commits.Clear();
-                    if (tooltip != null) tooltip.Dispose();
-                }
-                
                 fileName = null;
                 document = null;
-                sci = null;
                 outputLines = null;
-                annotations = null;
-                commits = null;
-                tooltip = null;
-                loading = false;
+                running = false;
 
                 disposed = true;
             }
         }
 
-        #endregion
-
-        class AnnotationData
+        public void ShowOnFileHistory(string commit)
         {
-            public string Commit;
-            public string Author;
-            public string AuthorMail;
-            public DateTime AuthorTime;
-            public string AuthorTimeZone;
-            public string Committer;
-            public string CommitterMail;
-            public DateTime CommitterTime;
-            public string CommitterTimeZone;
-            public string FileName;
-            public string Summary;
-            public string Line;
-            public bool IsEdit;
-            public int LineStart;
-            public int LineEnd;
-            public int Color;
-
-            public string GetInfo(int width = 0)
-            {
-                string commit = Commit.Substring(0, 8);
-                string authorTime = AuthorTime.ToShortDateString();
-
-                if (commit == "00000000")
-                {
-                    return "Local";
-                }
-                width -= 10 + authorTime.Length;
-                return Commit.Substring(0, 8) + " " + (width > 0 ? Author.PadRight(width) : Author) + " " + authorTime;
-            }
-
-            public override string ToString()
-            {
-                return "Commit" + ": " + Commit + "\n" +
-                    "Author" + ": " + Author + " " + AuthorMail + "\n" +
-                    "Author Date" + ": " + AuthorTime + " " + AuthorTimeZone + "\n" +
-                    "Committer" + ": " + Committer + " " + CommitterMail + "\n" +
-                    "Committer Date" + ": " + CommitterTime + " " + CommitterTimeZone + "\n" +
-                    "Change" + ": " + (IsEdit ? "edit" : "add") + "\n" +
-                    "Lines" + ": " + (LineStart + 1) + "~" + (LineEnd + 1) + "\n" +
-                    "Path" + ": " + FileName + "\n" +
-                    "\n" + Summary;
-            }
+            TortoiseProc.ExecuteCustom("log", "/path:\"" + fileName + "\" /rev:" + commit);
         }
+
+        #endregion
     }
 }

--- a/External/Plugins/SourceControl/Sources/Git/BlameCommand.cs
+++ b/External/Plugins/SourceControl/Sources/Git/BlameCommand.cs
@@ -1,0 +1,283 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Windows.Forms;
+using PluginCore;
+using PluginCore.Managers;
+using ScintillaNet;
+using ScintillaNet.Enums;
+
+namespace SourceControl.Sources.Git
+{
+    class BlameCommand : BaseCommand
+    {
+        ScintillaControl sci;
+        ToolTip tooltip;
+        LinkedList<string> outputLines;
+        List<AnnotationData> annotations;
+
+        public BlameCommand(string file)
+        {
+            if (!string.IsNullOrEmpty(file))
+            {
+                string args = "blame --porcelain \"" + file + "\"";
+                OpenAnnotatedDocument(file);
+                outputLines = new LinkedList<string>();
+                Run(args, Path.GetDirectoryName(file));
+            }
+        }
+
+        private void OpenAnnotatedDocument(string file)
+        {
+            string documentName = Path.Combine(Path.GetDirectoryName(file), "[Annotated] " + Path.GetFileName(file));
+            foreach (ITabbedDocument doc in PluginBase.MainForm.Documents)
+            {
+                if (doc.FileName == documentName)
+                {
+                    sci = doc.SciControl;
+                    doc.Activate();
+                    return;
+                }
+            }
+            var document = PluginBase.MainForm.CreateEditableDocument(documentName, "Loading...", Encoding.UTF8.CodePage) as ITabbedDocument;
+            if (document != null)
+            {
+                sci = document.SciControl;
+                sci.IsReadOnly = true;
+            }
+        }
+
+        protected override void Runner_Output(object sender, string line)
+        {
+            outputLines.AddLast(line);
+        }
+
+        protected override void Runner_ProcessEnded(object sender, int exitCode)
+        {
+            if (exitCode == 0)
+            {
+                sci.IsReadOnly = false;
+                try
+                {
+                    if (outputLines.Count > 0)
+                    {
+                        annotations = new List<AnnotationData>();
+                        int i, maxWidth = 0;
+                        AnnotationData lastAnnotation = null;
+                        var sb = new StringBuilder();
+                        var commits = new Dictionary<string, AnnotationData>();
+                        for (i = 0; 0 < outputLines.Count; i++)
+                        {
+                            var annotation = ParseAnnotation();
+                            if (lastAnnotation != null)
+                            {
+                                lastAnnotation.LineEnd = i - 1;
+                                annotation.Line = Environment.NewLine + annotation.Line;
+                            }
+
+                            sb.Append(annotation.Line);
+
+                            if (lastAnnotation == null || annotation.Commit != lastAnnotation.Commit)
+                            {
+                                if (commits.ContainsKey(annotation.Commit))
+                                {
+                                    var def = commits[annotation.Commit];
+                                    annotation.Author = def.Author;
+                                    annotation.AuthorMail = def.AuthorMail;
+                                    annotation.AuthorTime = def.AuthorTime;
+                                    annotation.AuthorTimeZone = def.AuthorTimeZone;
+                                    annotation.Committer = def.Committer;
+                                    annotation.CommitterMail = def.CommitterMail;
+                                    annotation.CommitterTime = def.CommitterTime;
+                                    annotation.CommitterTimeZone = def.CommitterTimeZone;
+                                    annotation.FileName = def.FileName;
+                                    annotation.IsEdit = def.IsEdit;
+                                    annotation.Summary = def.Summary;
+                                }
+                                else commits.Add(annotation.Commit, annotation);
+
+                                maxWidth = Math.Max(annotation.GetInfo().Length, maxWidth);
+                                annotation.LineStart = i;
+                                lastAnnotation = annotation;
+                                annotations.Add(annotation);
+                            }
+                        }
+                        lastAnnotation.LineEnd = i - 1;
+
+                        sci.SetMarginTypeN(4, (int) MarginType.Text);
+                        sci.SetMarginWidthN(4, sci.TextWidth(0, "".PadRight(maxWidth)));
+                        sci.MarginSensitiveN(4, true);
+                        sci.SetMarginCursorN(4, 2);
+
+                        sci.SetText(sb.ToString());
+
+                        for (i = 0; i < annotations.Count; i++)
+                        {
+                            var annotation = annotations[i];
+                            sci.SetMarginText(annotation.LineStart, annotation.GetInfo(maxWidth));
+                        }
+
+                        outputLines.Clear();
+                        outputLines = null;
+                        annotations.TrimExcess();
+                        tooltip = new ToolTip();
+                        sci.Disposed += Sci_Disposed;
+                        sci.MarginClick += Sci_MarginClick;
+                    }
+                }
+                finally
+                {
+                    sci.SetSavePoint();
+                    sci.IsReadOnly = true;
+                }
+            }
+            base.Runner_ProcessEnded(sender, exitCode);
+        }
+
+        private void Sci_Disposed(object sender, EventArgs e)
+        {
+            annotations.Clear();
+            tooltip.Dispose();
+            sci.Disposed -= Sci_Disposed;
+            sci.MarginClick -= Sci_MarginClick;
+        }
+
+        private void Sci_MarginClick(ScintillaControl sender, int modifiers, int position, int margin)
+        {
+            int line = sci.LineFromPosition(position);
+            var annotationData = GetAnnotationData(line);
+            if (annotationData != null)
+            {
+                tooltip.Show(annotationData.ToString(), sci, sci.PointXFromPosition(position), sci.PointYFromPosition(position), 3000);
+            }
+        }
+
+        private AnnotationData GetAnnotationData(int line)
+        {
+            int low = 0;
+            int high = annotations.Count - 1;
+            while (low <= high)
+            {
+                int i = low + (high - low >> 1);
+                var annotationData = annotations[i];
+                if (line < annotationData.LineStart)
+                {
+                    high = i - 1;
+                }
+                else if (line > annotationData.LineEnd)
+                {
+                    low = i + 1;
+                }
+                else return annotationData;
+            }
+            return null;
+        }
+
+        private AnnotationData ParseAnnotation()
+        {
+            var data = new AnnotationData();
+            data.Commit = GetNextOutputLine().Substring(0, 40);
+
+            string line;
+            while (!(line = GetNextOutputLine()).StartsWith('\t'))
+            {
+                int separator = line.IndexOf(' ');
+                string key = line.Substring(0, separator);
+                string value = line.Substring(separator + 1);
+
+                switch (key)
+                {
+                    case "author":
+                        data.Author = value;
+                        break;
+                    case "author-mail":
+                        data.AuthorMail = value;
+                        break;
+                    case "author-time":
+                        data.AuthorTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(int.Parse(value));
+                        break;
+                    case "author-tz":
+                        data.AuthorTimeZone = value;
+                        break;
+                    case "committer":
+                        data.Committer = value;
+                        break;
+                    case "committer-mail":
+                        data.CommitterMail = value;
+                        break;
+                    case "committer-time":
+                        data.CommitterTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(int.Parse(value));
+                        break;
+                    case "committer-tz":
+                        data.CommitterTimeZone = value;
+                        break;
+                    case "previous":
+                        data.IsEdit = true;
+                        break;
+                    case "summary":
+                        data.Summary = value;
+                        break;
+                    case "filename":
+                        data.FileName = value;
+                        break;
+                }
+            }
+
+            data.Line = line.Substring(1);
+            return data;
+        }
+
+        private string GetNextOutputLine()
+        {
+            string value = outputLines.First.Value;
+            outputLines.RemoveFirst();
+            return value;
+        }
+
+        class AnnotationData
+        {
+            public string Commit;
+            public string Author;
+            public string AuthorMail;
+            public DateTime AuthorTime;
+            public string AuthorTimeZone;
+            public string Committer;
+            public string CommitterMail;
+            public DateTime CommitterTime;
+            public string CommitterTimeZone;
+            public string FileName;
+            public string Summary;
+            public string Line;
+            public bool IsEdit;
+            public int LineStart;
+            public int LineEnd;
+
+            public string GetInfo(int width = 0)
+            {
+                string commit = Commit.Substring(0, 8);
+                string authorTime = AuthorTime.ToShortDateString();
+
+                if (commit == "00000000")
+                {
+                    return "Local";
+                }
+                width -= 10 + authorTime.Length;
+                return Commit.Substring(0, 8) + " " + (width > 0 ? Author.PadRight(width) : Author) + " " + authorTime;
+            }
+
+            public override string ToString()
+            {
+                return "Commit" + ": " + Commit + "\n" +
+                    "Author" + ": " + Author + " " + AuthorMail + "\n" +
+                    "Author Date" + ": " + AuthorTime + " " + AuthorTimeZone + "\n" +
+                    "Committer" + ": " + Committer + " " + CommitterMail + "\n" +
+                    "Committer Date" + ": " + CommitterTime + " " + CommitterTimeZone + "\n" +
+                    "Change" + ": " + (IsEdit ? "edit" : "add") + "\n" +
+                    "Lines" + ": " + (LineStart + 1) + "~" + (LineEnd + 1) + "\n" +
+                    "Path" + ": " + FileName + "\n" +
+                    "\n" + Summary;
+            }
+        }
+    }
+}

--- a/External/Plugins/SourceControl/Sources/Git/MenuItems.cs
+++ b/External/Plugins/SourceControl/Sources/Git/MenuItems.cs
@@ -18,6 +18,7 @@ namespace SourceControl.Sources.Git
         ToolStripItem push;
         ToolStripItem showLog;
         ToolStripItem midSeparator;
+        ToolStripItem annotate;
         ToolStripItem diff;
         ToolStripItem diffChange;
         ToolStripItem add;
@@ -34,6 +35,7 @@ namespace SourceControl.Sources.Git
         public ToolStripItem Push { get { return push; } }
         public ToolStripItem ShowLog { get { return showLog; } }
         public ToolStripItem MidSeparator { get { return midSeparator; } }
+        public ToolStripItem Annotate { get { return annotate; } }
         public ToolStripItem Diff { get { return diff; } }
         public ToolStripItem DiffChange { get { return diffChange; } }
         public ToolStripItem Add { get { return add; } }
@@ -52,6 +54,7 @@ namespace SourceControl.Sources.Git
             push = new ToolStripMenuItem(TextHelper.GetString("Label.Push"), PluginBase.MainForm.FindImage("159|9|-3|3"), Push_Click);
             showLog = new ToolStripMenuItem(TextHelper.GetString("Label.ShowLog"), PluginBase.MainForm.FindImage("95"), ShowLog_Click);
             midSeparator = new ToolStripSeparator();
+            annotate = new ToolStripMenuItem("Annotate", PluginBase.MainForm.FindImage("45"), Annotate_Click);
             diff = new ToolStripMenuItem(TextHelper.GetString("Label.Diff"), PluginBase.MainForm.FindImage("251"), Diff_Click);
             diffChange = new ToolStripMenuItem(TextHelper.GetString("Label.DiffWithPrevious"), PluginBase.MainForm.FindImage("251"), DiffChange_Click);
             add = new ToolStripMenuItem(TextHelper.GetString("Label.Add"), PluginBase.MainForm.FindImage("33"), Add_Click);
@@ -99,6 +102,14 @@ namespace SourceControl.Sources.Git
         void Ignore_Click(object sender, EventArgs e)
         {
             TortoiseProc.Execute("ignore", GetPaths());
+        }
+
+        void Annotate_Click(object sender, EventArgs e)
+        {
+            if (currentNodes != null)
+            {
+                new BlameCommand((currentNodes[0] as GenericNode).BackingPath);
+            }
         }
 
         void DiffChange_Click(object sender, EventArgs e)

--- a/External/Plugins/SourceControl/Sources/Git/TortoiseProc.cs
+++ b/External/Plugins/SourceControl/Sources/Git/TortoiseProc.cs
@@ -9,7 +9,7 @@ namespace SourceControl.Sources.Git
         static private string resolvedCmd;
         static private string qualifiedCmd;
 
-        static public void Execute(string command, string path)
+        public static void Execute(string command, string path)
         {
             string args = String.Format("/command:{0} /path:\"{1}\"", command, path);
             ProcessStartInfo info = new ProcessStartInfo(GetTortoiseProc(), args);
@@ -17,12 +17,18 @@ namespace SourceControl.Sources.Git
             Process.Start(info);
         }
 
-        static public void Execute(string command, string path1, string path2)
+        public static void Execute(string command, string path1, string path2)
         {
             string args = String.Format("/command:{0} /path:\"{1}\" /path2:\"{2}\"", command, path1, path2);
             ProcessStartInfo info = new ProcessStartInfo(GetTortoiseProc(), args);
             info.UseShellExecute = true;
             Process.Start(info);
+        }
+
+        public static void ExecuteCustom(string command, string arguments)
+        {
+            string args = "/command:" + command + " " + arguments;
+            Process.Start(new ProcessStartInfo(GetTortoiseProc(), args) { UseShellExecute = true });
         }
 
         static private string GetTortoiseProc()

--- a/External/Plugins/SourceControl/Sources/IVCManager.cs
+++ b/External/Plugins/SourceControl/Sources/IVCManager.cs
@@ -70,6 +70,7 @@ namespace SourceControl.Sources
         ToolStripItem Push { get; }
         ToolStripItem ShowLog { get; }
         ToolStripItem MidSeparator { get; }
+        ToolStripItem Annotate { get; }
         ToolStripItem Diff { get; }
         ToolStripItem DiffChange { get; }
         ToolStripItem Add { get; }

--- a/External/Plugins/SourceControl/Sources/Mercurial/MenuItems.cs
+++ b/External/Plugins/SourceControl/Sources/Mercurial/MenuItems.cs
@@ -17,6 +17,7 @@ namespace SourceControl.Sources.Mercurial
         ToolStripItem push;
         ToolStripItem showLog;
         ToolStripItem midSeparator;
+        ToolStripItem annotate;
         ToolStripItem diffChange;
         ToolStripItem add;
         ToolStripItem ignore;
@@ -32,6 +33,7 @@ namespace SourceControl.Sources.Mercurial
         public ToolStripItem Push { get { return push; } }
         public ToolStripItem ShowLog { get { return showLog; } }
         public ToolStripItem MidSeparator { get { return midSeparator; } }
+        public ToolStripItem Annotate { get { return annotate; } }
         public ToolStripItem Diff { get { return null; } }
         public ToolStripItem DiffChange { get { return diffChange; } }
         public ToolStripItem Add { get { return add; } }
@@ -50,6 +52,7 @@ namespace SourceControl.Sources.Mercurial
             push = new ToolStripMenuItem(TextHelper.GetString("Label.Push"), PluginBase.MainForm.FindImage("159|9|-3|3"), Push_Click);
             showLog = new ToolStripMenuItem(TextHelper.GetString("Label.ShowLog"), PluginBase.MainForm.FindImage("95"), ShowLog_Click);
             midSeparator = new ToolStripSeparator();
+            annotate = new ToolStripMenuItem("Annotate", PluginBase.MainForm.FindImage("45")) { Enabled = false };
             diffChange = new ToolStripMenuItem(TextHelper.GetString("Label.DiffWithPrevious"), PluginBase.MainForm.FindImage("251"), DiffChange_Click);
             add = new ToolStripMenuItem(TextHelper.GetString("Label.Add"), PluginBase.MainForm.FindImage("33"), Add_Click);
             ignore = new ToolStripMenuItem(TextHelper.GetString("Label.AddToIgnoreList"), PluginBase.MainForm.FindImage("166"), Ignore_Click);

--- a/External/Plugins/SourceControl/Sources/Subversion/MenuItems.cs
+++ b/External/Plugins/SourceControl/Sources/Subversion/MenuItems.cs
@@ -17,6 +17,7 @@ namespace SourceControl.Sources.Subversion
         ToolStripItem push;
         ToolStripItem showLog;
         ToolStripItem midSeparator;
+        ToolStripItem annotate;
         ToolStripItem diff;
         ToolStripItem diffChange;
         ToolStripItem add;
@@ -33,6 +34,7 @@ namespace SourceControl.Sources.Subversion
         public ToolStripItem Push { get { return push; } }
         public ToolStripItem ShowLog { get { return showLog; } }
         public ToolStripItem MidSeparator { get { return midSeparator; } }
+        public ToolStripItem Annotate { get { return annotate; } }
         public ToolStripItem Diff { get { return diff; } }
         public ToolStripItem DiffChange { get { return diffChange; } }
         public ToolStripItem Add { get { return add; } }
@@ -51,6 +53,7 @@ namespace SourceControl.Sources.Subversion
             push = null;
             showLog = new ToolStripMenuItem(TextHelper.GetString("Label.ShowLog"), PluginBase.MainForm.FindImage("95"), ShowLog_Click);
             midSeparator = new ToolStripSeparator();
+            annotate = new ToolStripMenuItem("Annotate", PluginBase.MainForm.FindImage("45")) { Enabled = false };
             diff = new ToolStripMenuItem(TextHelper.GetString("Label.Diff"), PluginBase.MainForm.FindImage("251"), Diff_Click);
             diffChange = new ToolStripMenuItem(TextHelper.GetString("Label.DiffWithPrevious"), PluginBase.MainForm.FindImage("251"), DiffChange_Click);
             add = new ToolStripMenuItem(TextHelper.GetString("Label.Add"), PluginBase.MainForm.FindImage("33"), Add_Click);

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -589,7 +589,7 @@ namespace FlashDevelop
         }
 
         /// <summary>
-        /// Opens the specified file and creates a editable document
+        /// Opens the specified file and creates an editable document
         /// </summary>
         public DockContent OpenEditableDocument(String org, Encoding encoding, Boolean restorePosition)
         {

--- a/PluginCore/PluginCore/Controls/UITools.cs
+++ b/PluginCore/PluginCore/Controls/UITools.cs
@@ -175,7 +175,7 @@ namespace PluginCore.Controls
             if (OnMarkerChanged != null) OnMarkerChanged(sender, line);
         }
 
-        private void HandleDwellStart(ScintillaControl sci, int position)
+        private void HandleDwellStart(ScintillaControl sci, int position, int x, int y)
         {
             if (OnMouseHover == null || sci == null || DisableEvents) return;
             try
@@ -226,7 +226,7 @@ namespace PluginCore.Controls
             return new Point(pos.X - ctrlPos.X, pos.Y - ctrlPos.Y);
         }
 
-        private void HandleDwellEnd(ScintillaControl sci, int position)
+        private void HandleDwellEnd(ScintillaControl sci, int position, int x, int y)
         {
             simpleTip.Hide();
             if (OnMouseHoverEnd != null) OnMouseHoverEnd(sci, position);

--- a/PluginCore/ScintillaNet/Configuration/Language.cs
+++ b/PluginCore/ScintillaNet/Configuration/Language.cs
@@ -16,22 +16,22 @@ namespace ScintillaNet.Configuration
         [XmlAttribute()]
         public string name;
         
-        [XmlElement(ElementName="line-comment")]
+        [XmlElement("line-comment")]
         public string linecomment;
         
-        [XmlElement(ElementName="comment-start")]
+        [XmlElement("comment-start")]
         public string commentstart;
         
-        [XmlElement(ElementName="comment-end")]
+        [XmlElement("comment-end")]
         public string commentend;
         
-        [XmlElement(ElementName="file-extensions")]
+        [XmlElement("file-extensions")]
         public string fileextensions;
         
-        [XmlElement(ElementName="character-class")]
+        [XmlElement("character-class")]
         public CharacterClass characterclass;
 
-        [XmlElement(ElementName="editor-style")]
+        [XmlElement("editor-style")]
         public EditorStyle editorstyle;
 
         [XmlArray("use-keywords")]

--- a/PluginCore/ScintillaNet/Configuration/StyleClass.cs
+++ b/PluginCore/ScintillaNet/Configuration/StyleClass.cs
@@ -159,7 +159,7 @@ namespace ScintillaNet.Configuration
                 if (size != null) return ResolveNumber(size);
                 StyleClass p = ParentClass;
                 if (p != null) return p.FontSize;
-                return Int32.Parse("9f", NumberStyles.Float);
+                return 9;
             }
         }
 
@@ -170,7 +170,7 @@ namespace ScintillaNet.Configuration
                 if (back != null) return ResolveColor(back);
                 StyleClass p = ParentClass;
                 if (p != null) return p.BackgroundColor;
-                return 0;
+                return 0x000000;
             }
         }
 
@@ -181,7 +181,7 @@ namespace ScintillaNet.Configuration
                 if (fore != null) return ResolveColor(fore);
                 StyleClass p = ParentClass;
                 if (p  != null) return p.ForegroundColor;
-                return 0;
+                return 0x000000;
             }
         }
 

--- a/PluginCore/ScintillaNet/Enums.cs
+++ b/PluginCore/ScintillaNet/Enums.cs
@@ -261,7 +261,9 @@ namespace ScintillaNet.Enums
     public enum CursorShape
     {    
         Normal = -1,
-        Wait = 4
+        Arrow = 2,
+        Wait = 4,
+        ReverseArror = 7
     }
     
     public enum CaretPolicy

--- a/PluginCore/ScintillaNet/Events.cs
+++ b/PluginCore/ScintillaNet/Events.cs
@@ -19,8 +19,8 @@ namespace ScintillaNet
     public delegate void NeedShownHandler(ScintillaControl sender, int position, int length);
     public delegate void UserListSelectionHandler(ScintillaControl sender, int listType, string text);
     public delegate void URIDroppedHandler(ScintillaControl sender, string text);
-    public delegate void DwellStartHandler(ScintillaControl sender, int position);
-    public delegate void DwellEndHandler(ScintillaControl sender ,int position);
+    public delegate void DwellStartHandler(ScintillaControl sender, int position, int x, int y);
+    public delegate void DwellEndHandler(ScintillaControl sender ,int position, int x, int y);
     public delegate void HotSpotClickHandler(ScintillaControl sender, int modifiers, int position);
     public delegate void HotSpotDoubleClickHandler(ScintillaControl sender, int modifiers, int position);
     public delegate void CallTipClickHandler(ScintillaControl sender, int position);

--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -467,272 +467,272 @@ namespace ScintillaNet
             {
                 WordChars(lang.characterclass.Characters);
             }
+            Type lexerType = null;
+            switch ((Enums.Lexer) lang.lexer.key)
+            {
+                case Enums.Lexer.PYTHON:
+                    lexerType = typeof(Lexers.PYTHON);
+                    break;
+                case Enums.Lexer.CPP:
+                    lexerType = typeof(Lexers.CPP);
+                    break;
+                case Enums.Lexer.HTML:
+                    lexerType = typeof(Lexers.HTML);
+                    break;
+                case Enums.Lexer.XML:
+                    lexerType = typeof(Lexers.XML);
+                    break;
+                case Enums.Lexer.PERL:
+                    lexerType = typeof(Lexers.PERL);
+                    break;
+                case Enums.Lexer.SQL:
+                    lexerType = typeof(Lexers.SQL);
+                    break;
+                case Enums.Lexer.VB:
+                    lexerType = typeof(Lexers.VB);
+                    break;
+                case Enums.Lexer.PROPERTIES:
+                    lexerType = typeof(Lexers.PROPERTIES);
+                    break;
+                case Enums.Lexer.ERRORLIST:
+                    lexerType = typeof(Lexers.ERRORLIST);
+                    break;
+                case Enums.Lexer.MAKEFILE:
+                    lexerType = typeof(Lexers.MAKEFILE);
+                    break;
+                case Enums.Lexer.BATCH:
+                    lexerType = typeof(Lexers.BATCH);
+                    break;
+                case Enums.Lexer.LATEX:
+                    lexerType = typeof(Lexers.LATEX);
+                    break;
+                case Enums.Lexer.LUA:
+                    lexerType = typeof(Lexers.LUA);
+                    break;
+                case Enums.Lexer.DIFF:
+                    lexerType = typeof(Lexers.DIFF);
+                    break;
+                case Enums.Lexer.CONF:
+                    lexerType = typeof(Lexers.CONF);
+                    break;
+                case Enums.Lexer.PASCAL:
+                    lexerType = typeof(Lexers.PASCAL);
+                    break;
+                case Enums.Lexer.AVE:
+                    lexerType = typeof(Lexers.AVE);
+                    break;
+                case Enums.Lexer.ADA:
+                    lexerType = typeof(Lexers.ADA);
+                    break;
+                case Enums.Lexer.LISP:
+                    lexerType = typeof(Lexers.LISP);
+                    break;
+                case Enums.Lexer.RUBY:
+                    lexerType = typeof(Lexers.RUBY);
+                    break;
+                case Enums.Lexer.EIFFEL:
+                    lexerType = typeof(Lexers.EIFFEL);
+                    break;
+                case Enums.Lexer.EIFFELKW:
+                    lexerType = typeof(Lexers.EIFFELKW);
+                    break;
+                case Enums.Lexer.TCL:
+                    lexerType = typeof(Lexers.TCL);
+                    break;
+                case Enums.Lexer.NNCRONTAB:
+                    lexerType = typeof(Lexers.NNCRONTAB);
+                    break;
+                case Enums.Lexer.BULLANT:
+                    lexerType = typeof(Lexers.BULLANT);
+                    break;
+                case Enums.Lexer.VBSCRIPT:
+                    lexerType = typeof(Lexers.VBSCRIPT);
+                    break;
+                case Enums.Lexer.BAAN:
+                    lexerType = typeof(Lexers.BAAN);
+                    break;
+                case Enums.Lexer.MATLAB:
+                    lexerType = typeof(Lexers.MATLAB);
+                    break;
+                case Enums.Lexer.SCRIPTOL:
+                    lexerType = typeof(Lexers.SCRIPTOL);
+                    break;
+                case Enums.Lexer.ASM:
+                    lexerType = typeof(Lexers.ASM);
+                    break;
+                case Enums.Lexer.FORTRAN:
+                    lexerType = typeof(Lexers.FORTRAN);
+                    break;
+                case Enums.Lexer.F77:
+                    lexerType = typeof(Lexers.F77);
+                    break;
+                case Enums.Lexer.CSS:
+                    lexerType = typeof(Lexers.CSS);
+                    break;
+                case Enums.Lexer.POV:
+                    lexerType = typeof(Lexers.POV);
+                    break;
+                case Enums.Lexer.LOUT:
+                    lexerType = typeof(Lexers.LOUT);
+                    break;
+                case Enums.Lexer.ESCRIPT:
+                    lexerType = typeof(Lexers.ESCRIPT);
+                    break;
+                case Enums.Lexer.PS:
+                    lexerType = typeof(Lexers.PS);
+                    break;
+                case Enums.Lexer.NSIS:
+                    lexerType = typeof(Lexers.NSIS);
+                    break;
+                case Enums.Lexer.MMIXAL:
+                    lexerType = typeof(Lexers.MMIXAL);
+                    break;
+                case Enums.Lexer.LOT:
+                    lexerType = typeof(Lexers.LOT);
+                    break;
+                case Enums.Lexer.YAML:
+                    lexerType = typeof(Lexers.YAML);
+                    break;
+                case Enums.Lexer.TEX:
+                    lexerType = typeof(Lexers.TEX);
+                    break;
+                case Enums.Lexer.METAPOST:
+                    lexerType = typeof(Lexers.METAPOST);
+                    break;
+                case Enums.Lexer.POWERBASIC:
+                    lexerType = typeof(Lexers.POWERBASIC);
+                    break;
+                case Enums.Lexer.FORTH:
+                    lexerType = typeof(Lexers.FORTH);
+                    break;
+                case Enums.Lexer.ERLANG:
+                    lexerType = typeof(Lexers.ERLANG);
+                    break;
+                case Enums.Lexer.OCTAVE:
+                    lexerType = typeof(Lexers.OCTAVE);
+                    break;
+                case Enums.Lexer.MSSQL:
+                    lexerType = typeof(Lexers.MSSQL);
+                    break;
+                case Enums.Lexer.VERILOG:
+                    lexerType = typeof(Lexers.VERILOG);
+                    break;
+                case Enums.Lexer.KIX:
+                    lexerType = typeof(Lexers.KIX);
+                    break;
+                case Enums.Lexer.GUI4CLI:
+                    lexerType = typeof(Lexers.GUI4CLI);
+                    break;
+                case Enums.Lexer.SPECMAN:
+                    lexerType = typeof(Lexers.SPECMAN);
+                    break;
+                case Enums.Lexer.AU3:
+                    lexerType = typeof(Lexers.AU3);
+                    break;
+                case Enums.Lexer.APDL:
+                    lexerType = typeof(Lexers.APDL);
+                    break;
+                case Enums.Lexer.BASH:
+                    lexerType = typeof(Lexers.BASH);
+                    break;
+                case Enums.Lexer.ASN1:
+                    lexerType = typeof(Lexers.ASN1);
+                    break;
+                case Enums.Lexer.VHDL:
+                    lexerType = typeof(Lexers.VHDL);
+                    break;
+                case Enums.Lexer.CAML:
+                    lexerType = typeof(Lexers.CAML);
+                    break;
+                case Enums.Lexer.HASKELL:
+                    lexerType = typeof(Lexers.HASKELL);
+                    break;
+                case Enums.Lexer.TADS3:
+                    lexerType = typeof(Lexers.TADS3);
+                    break;
+                case Enums.Lexer.REBOL:
+                    lexerType = typeof(Lexers.REBOL);
+                    break;
+                case Enums.Lexer.SMALLTALK:
+                    lexerType = typeof(Lexers.SMALLTALK);
+                    break;
+                case Enums.Lexer.FLAGSHIP:
+                    lexerType = typeof(Lexers.FLAGSHIP);
+                    break;
+                case Enums.Lexer.CSOUND:
+                    lexerType = typeof(Lexers.CSOUND);
+                    break;
+                case Enums.Lexer.INNOSETUP:
+                    lexerType = typeof(Lexers.INNOSETUP);
+                    break;
+                case Enums.Lexer.OPAL:
+                    lexerType = typeof(Lexers.OPAL);
+                    break;
+                case Enums.Lexer.SPICE:
+                    lexerType = typeof(Lexers.SPICE);
+                    break;
+                case Enums.Lexer.D:
+                    lexerType = typeof(Lexers.D);
+                    break;
+                case Enums.Lexer.CMAKE:
+                    lexerType = typeof(Lexers.CMAKE);
+                    break;
+                case Enums.Lexer.GAP:
+                    lexerType = typeof(Lexers.GAP);
+                    break;
+                case Enums.Lexer.PLM:
+                    lexerType = typeof(Lexers.PLM);
+                    break;
+                case Enums.Lexer.PROGRESS:
+                    lexerType = typeof(Lexers.PROGRESS);
+                    break;
+                case Enums.Lexer.ABAQUS:
+                    lexerType = typeof(Lexers.ABAQUS);
+                    break;
+                case Enums.Lexer.ASYMPTOTE:
+                    lexerType = typeof(Lexers.ASYMPTOTE);
+                    break;
+                case Enums.Lexer.R:
+                    lexerType = typeof(Lexers.R);
+                    break;
+                case Enums.Lexer.MAGIK:
+                    lexerType = typeof(Lexers.MAGIK);
+                    break;
+                case Enums.Lexer.POWERSHELL:
+                    lexerType = typeof(Lexers.POWERSHELL);
+                    break;
+                case Enums.Lexer.MYSQL:
+                    lexerType = typeof(Lexers.MYSQL);
+                    break;
+                case Enums.Lexer.PO:
+                    lexerType = typeof(Lexers.PO);
+                    break;
+                case Enums.Lexer.SORCUS:
+                    lexerType = typeof(Lexers.SORCUS);
+                    break;
+                case Enums.Lexer.POWERPRO:
+                    lexerType = typeof(Lexers.POWERPRO);
+                    break;
+                case Enums.Lexer.NIMROD:
+                    lexerType = typeof(Lexers.NIMROD);
+                    break;
+                case Enums.Lexer.SML:
+                    lexerType = typeof(Lexers.SML);
+                    break;
+            }
             for (int j = 0; j < lang.usestyles.Length; j++)
             {
                 UseStyle usestyle = lang.usestyles[j];
-                if (usestyle.key == 0)
+                if (usestyle.key == 0) //name is defined instead of key
                 {
-                    System.Type theType = null;
-                    switch ((Enums.Lexer)lang.lexer.key)
-                    {
-                        case Enums.Lexer.PYTHON:
-                            theType = typeof(Lexers.PYTHON);
-                            break;
-                        case Enums.Lexer.CPP:
-                            theType = typeof(Lexers.CPP);
-                            break;
-                        case Enums.Lexer.HTML:
-                            theType = typeof(Lexers.HTML);
-                            break;
-                        case Enums.Lexer.XML:
-                            theType = typeof(Lexers.XML);
-                            break;
-                        case Enums.Lexer.PERL:
-                            theType = typeof(Lexers.PERL);
-                            break;
-                        case Enums.Lexer.SQL:
-                            theType = typeof(Lexers.SQL);
-                            break;
-                        case Enums.Lexer.VB:
-                            theType = typeof(Lexers.VB);
-                            break;
-                        case Enums.Lexer.PROPERTIES:
-                            theType = typeof(Lexers.PROPERTIES);
-                            break;
-                        case Enums.Lexer.ERRORLIST:
-                            theType = typeof(Lexers.ERRORLIST);
-                            break;
-                        case Enums.Lexer.MAKEFILE:
-                            theType = typeof(Lexers.MAKEFILE);
-                            break;
-                        case Enums.Lexer.BATCH:
-                            theType = typeof(Lexers.BATCH);
-                            break;
-                        case Enums.Lexer.LATEX:
-                            theType = typeof(Lexers.LATEX);
-                            break;
-                        case Enums.Lexer.LUA:
-                            theType = typeof(Lexers.LUA);
-                            break;
-                        case Enums.Lexer.DIFF:
-                            theType = typeof(Lexers.DIFF);
-                            break;
-                        case Enums.Lexer.CONF:
-                            theType = typeof(Lexers.CONF);
-                            break;
-                        case Enums.Lexer.PASCAL:
-                            theType = typeof(Lexers.PASCAL);
-                            break;
-                        case Enums.Lexer.AVE:
-                            theType = typeof(Lexers.AVE);
-                            break;
-                        case Enums.Lexer.ADA:
-                            theType = typeof(Lexers.ADA);
-                            break;
-                        case Enums.Lexer.LISP:
-                            theType = typeof(Lexers.LISP);
-                            break;
-                        case Enums.Lexer.RUBY:
-                            theType = typeof(Lexers.RUBY);
-                            break;
-                        case Enums.Lexer.EIFFEL:
-                            theType = typeof(Lexers.EIFFEL);
-                            break;
-                        case Enums.Lexer.EIFFELKW:
-                            theType = typeof(Lexers.EIFFELKW);
-                            break;
-                        case Enums.Lexer.TCL:
-                            theType = typeof(Lexers.TCL);
-                            break;
-                        case Enums.Lexer.NNCRONTAB:
-                            theType = typeof(Lexers.NNCRONTAB);
-                            break;
-                        case Enums.Lexer.BULLANT:
-                            theType = typeof(Lexers.BULLANT);
-                            break;
-                        case Enums.Lexer.VBSCRIPT:
-                            theType = typeof(Lexers.VBSCRIPT);
-                            break;
-                        case Enums.Lexer.BAAN:
-                            theType = typeof(Lexers.BAAN);
-                            break;
-                        case Enums.Lexer.MATLAB:
-                            theType = typeof(Lexers.MATLAB);
-                            break;
-                        case Enums.Lexer.SCRIPTOL:
-                            theType = typeof(Lexers.SCRIPTOL);
-                            break;
-                        case Enums.Lexer.ASM:
-                            theType = typeof(Lexers.ASM);
-                            break;
-                        case Enums.Lexer.FORTRAN:
-                            theType = typeof(Lexers.FORTRAN);
-                            break;
-                        case Enums.Lexer.F77:
-                            theType = typeof(Lexers.F77);
-                            break;
-                        case Enums.Lexer.CSS:
-                            theType = typeof(Lexers.CSS);
-                            break;
-                        case Enums.Lexer.POV:
-                            theType = typeof(Lexers.POV);
-                            break;
-                        case Enums.Lexer.LOUT:
-                            theType = typeof(Lexers.LOUT);
-                            break;
-                        case Enums.Lexer.ESCRIPT:
-                            theType = typeof(Lexers.ESCRIPT);
-                            break;
-                        case Enums.Lexer.PS:
-                            theType = typeof(Lexers.PS);
-                            break;
-                        case Enums.Lexer.NSIS:
-                            theType = typeof(Lexers.NSIS);
-                            break;
-                        case Enums.Lexer.MMIXAL:
-                            theType = typeof(Lexers.MMIXAL);
-                            break;
-                        case Enums.Lexer.LOT:
-                            theType = typeof(Lexers.LOT);
-                            break;
-                        case Enums.Lexer.YAML:
-                            theType = typeof(Lexers.YAML);
-                            break;
-                        case Enums.Lexer.TEX:
-                            theType = typeof(Lexers.TEX);
-                            break;
-                        case Enums.Lexer.METAPOST:
-                            theType = typeof(Lexers.METAPOST);
-                            break;
-                        case Enums.Lexer.POWERBASIC:
-                            theType = typeof(Lexers.POWERBASIC);
-                            break;
-                        case Enums.Lexer.FORTH:
-                            theType = typeof(Lexers.FORTH);
-                            break;
-                        case Enums.Lexer.ERLANG:
-                            theType = typeof(Lexers.ERLANG);
-                            break;
-                        case Enums.Lexer.OCTAVE:
-                            theType = typeof(Lexers.OCTAVE);
-                            break;
-                        case Enums.Lexer.MSSQL:
-                            theType = typeof(Lexers.MSSQL);
-                            break;
-                        case Enums.Lexer.VERILOG:
-                            theType = typeof(Lexers.VERILOG);
-                            break;
-                        case Enums.Lexer.KIX:
-                            theType = typeof(Lexers.KIX);
-                            break;
-                        case Enums.Lexer.GUI4CLI:
-                            theType = typeof(Lexers.GUI4CLI);
-                            break;
-                        case Enums.Lexer.SPECMAN:
-                            theType = typeof(Lexers.SPECMAN);
-                            break;
-                        case Enums.Lexer.AU3:
-                            theType = typeof(Lexers.AU3);
-                            break;
-                        case Enums.Lexer.APDL:
-                            theType = typeof(Lexers.APDL);
-                            break;
-                        case Enums.Lexer.BASH:
-                            theType = typeof(Lexers.BASH);
-                            break;
-                        case Enums.Lexer.ASN1:
-                            theType = typeof(Lexers.ASN1);
-                            break;
-                        case Enums.Lexer.VHDL:
-                            theType = typeof(Lexers.VHDL);
-                            break;
-                        case Enums.Lexer.CAML:
-                            theType = typeof(Lexers.CAML);
-                            break;
-                        case Enums.Lexer.HASKELL:
-                            theType = typeof(Lexers.HASKELL);
-                            break;
-                        case Enums.Lexer.TADS3:
-                            theType = typeof(Lexers.TADS3);
-                            break;
-                        case Enums.Lexer.REBOL:
-                            theType = typeof(Lexers.REBOL);
-                            break;
-                        case Enums.Lexer.SMALLTALK:
-                            theType = typeof(Lexers.SMALLTALK);
-                            break;
-                        case Enums.Lexer.FLAGSHIP:
-                            theType = typeof(Lexers.FLAGSHIP);
-                            break;
-                        case Enums.Lexer.CSOUND:
-                            theType = typeof(Lexers.CSOUND);
-                            break;
-                        case Enums.Lexer.INNOSETUP:
-                            theType = typeof(Lexers.INNOSETUP);
-                            break;
-                        case Enums.Lexer.OPAL:
-                            theType = typeof(Lexers.OPAL);
-                            break;
-                        case Enums.Lexer.SPICE:
-                            theType = typeof(Lexers.SPICE);
-                            break;
-                        case Enums.Lexer.D:
-                            theType = typeof(Lexers.D);
-                            break;
-                        case Enums.Lexer.CMAKE:
-                            theType = typeof(Lexers.CMAKE);
-                            break;
-                        case Enums.Lexer.GAP:
-                            theType = typeof(Lexers.GAP);
-                            break;
-                        case Enums.Lexer.PLM:
-                            theType = typeof(Lexers.PLM);
-                            break;
-                        case Enums.Lexer.PROGRESS:
-                            theType = typeof(Lexers.PROGRESS);
-                            break;
-                        case Enums.Lexer.ABAQUS:
-                            theType = typeof(Lexers.ABAQUS);
-                            break;
-                        case Enums.Lexer.ASYMPTOTE:
-                            theType = typeof(Lexers.ASYMPTOTE);
-                            break;
-                        case Enums.Lexer.R:
-                            theType = typeof(Lexers.R);
-                            break;
-                        case Enums.Lexer.MAGIK:
-                            theType = typeof(Lexers.MAGIK);
-                            break;
-                        case Enums.Lexer.POWERSHELL:
-                            theType = typeof(Lexers.POWERSHELL);
-                            break;
-                        case Enums.Lexer.MYSQL:
-                            theType = typeof(Lexers.MYSQL);
-                            break;
-                        case Enums.Lexer.PO:
-                            theType = typeof(Lexers.PO);
-                            break;
-                        case Enums.Lexer.SORCUS:
-                            theType = typeof(Lexers.SORCUS);
-                            break;
-                        case Enums.Lexer.POWERPRO:
-                            theType = typeof(Lexers.POWERPRO);
-                            break;
-                        case Enums.Lexer.NIMROD:
-                            theType = typeof(Lexers.NIMROD);
-                            break;
-                        case Enums.Lexer.SML:
-                            theType = typeof(Lexers.SML);
-                            break;
-                    }
                     try
                     {
-                        usestyle.key = (int)Enum.Parse(theType, usestyle.name, true);
+                        usestyle.key = (int)Enum.Parse(lexerType, usestyle.name, true);
                     }
                     catch (Exception ex)
                     {
                         String info;
-                        if (theType == null)
+                        if (lexerType == null)
                         {
                             info = String.Format("Lexer '{0}' ({1}) unknown.", lang.lexer.name, lang.lexer.key);
                             ErrorManager.ShowWarning(info, ex);
@@ -740,7 +740,7 @@ namespace ScintillaNet
                         }
                         else
                         {
-                            info = String.Format("Style '{0}' in syntax file is not used by lexer '{1}'.", usestyle.name, theType.Name);
+                            info = String.Format("Style '{0}' in syntax file is not used by lexer '{1}'.", usestyle.name, lexerType.Name);
                             ErrorManager.ShowWarning(info, ex);
                         }
                     }
@@ -2583,23 +2583,39 @@ namespace ScintillaNet
         }
 
         /// <summary>
-        /// Set the foreground colour of a style.
+        /// Sets the foreground colour of a style.
         /// </summary>
         public void StyleSetFore(int style, int fore)
         {
             SPerform(2051, style, fore);
         }
+
+        /// <summary>
+        /// Gets the foreground colour of a style.
+        /// </summary>
+        public int StyleGetFore(int style)
+        {
+            return SPerform(2481, style, 0);
+        }
         
         /// <summary>
-        /// Set the background colour of a style.
+        /// Sets the background colour of a style.
         /// </summary>
         public void StyleSetBack(int style, int back)
         {
             SPerform(2052, style, back);
         }
+
+        /// <summary>
+        /// Gets the background colour of a style
+        /// </summary>
+        public int StyleGetBack(int style)
+        {
+            return SPerform(2482, style, 0);
+        }
         
         /// <summary>
-        /// Set a style to be bold or not.
+        /// Sets a style to be bold or not.
         /// </summary>
         public void StyleSetBold(int style, bool bold)
         {
@@ -2607,7 +2623,15 @@ namespace ScintillaNet
         }
 
         /// <summary>
-        /// Set a style to be italic or not.
+        /// Gets whether a style is bold or not.
+        /// </summary>
+        public bool StyleGetBold(int style)
+        {
+            return SPerform(2483, style, 0) != 0;
+        }
+
+        /// <summary>
+        /// Sets a style to be italic or not.
         /// </summary>
         public void StyleSetItalic(int style, bool italic)
         {
@@ -2615,11 +2639,27 @@ namespace ScintillaNet
         }
 
         /// <summary>
-        /// Set the size of characters of a style.
+        /// Gets whether a style is italic or not.
+        /// </summary>
+        public bool StyleGetItalic(int style)
+        {
+            return SPerform(2484, style, 0) != 0;
+        }
+
+        /// <summary>
+        /// Sets the size of characters of a style.
         /// </summary>
         public void StyleSetSize(int style, int sizePoints)
         {
             SPerform(2055, style, sizePoints);
+        }
+
+        /// <summary>
+        /// Gets the size of characters of a style.
+        /// </summary>
+        public int StyleGetSize(int style)
+        {
+            return SPerform(2485, style, 0);
         }
 
         /// <summary>
@@ -2632,6 +2672,17 @@ namespace ScintillaNet
             {
                 SPerform(2056, style, (uint)b);
             }
+        }
+
+        /// <summary>
+        /// Get the font of a style.
+        /// </summary>
+        public unsafe string StyleGetFont(int style)
+        {
+            int size = SPerform(2486, style, 0);
+            byte[] buffer = new byte[size + 1];
+            fixed (byte* b = buffer) SPerform(2486, style, (IntPtr) b);
+            return Encoding.GetEncoding(this.CodePage).GetString(buffer, 0, size);
         }
 
         /// <summary>

--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -2947,6 +2947,22 @@ namespace ScintillaNet
         }
 
         /// <summary>
+        /// Gets the cursor of a margin.
+        /// </summary>
+        public int GetMarginCursorN(int margin)
+        {
+            return SPerform(2249, margin, 0);
+        }
+
+        /// <summary>
+        /// Set the cursor of a margin.
+        /// </summary>
+        public void SetMarginCursorN(int margin, int cursor)
+        {
+            SPerform(2248, margin, cursor);
+        }
+
+        /// <summary>
         /// Retrieve the style of an indicator.
         /// </summary>
         public int GetIndicStyle(int indic)

--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -2589,7 +2589,7 @@ namespace ScintillaNet
         {
             SPerform(2051, style, fore);
         }
-
+        
         /// <summary>
         /// Set the background colour of a style.
         /// </summary>
@@ -2597,7 +2597,7 @@ namespace ScintillaNet
         {
             SPerform(2052, style, back);
         }
-
+        
         /// <summary>
         /// Set a style to be bold or not.
         /// </summary>
@@ -5437,11 +5437,11 @@ namespace ScintillaNet
                             break;
 
                         case (uint)Enums.ScintillaEvents.DwellStart:
-                            if (DwellStart != null) DwellStart(this, scn.position);
+                            if (DwellStart != null) DwellStart(this, scn.position, scn.x, scn.y);
                             break;
 
                         case (uint)Enums.ScintillaEvents.DwellEnd:
-                            if (DwellEnd != null) DwellEnd(this, scn.position);
+                            if (DwellEnd != null) DwellEnd(this, scn.position, scn.x, scn.y);
                             break;
 
                         case (uint)Enums.ScintillaEvents.Zoom:


### PR DESCRIPTION
Added integrated support for "blame" feature. Currently only added support for git.

Support for other vcs plugins can be added by following the pattern used in Sources/Git/BlameCommand.

Example:
![image](https://cloud.githubusercontent.com/assets/13545633/18826784/27325e40-840a-11e6-9775-879884da6857.png)

@Neverbirth 
