### PR TITLE
Added GetTextRange function to ScintillaControl

### DIFF
--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -3481,6 +3481,28 @@ namespace ScintillaNet
         }
 
         /// <summary>
+        /// Gets a range of text from the document.
+        /// </summary>
+        /// <param name="position">The zero-based starting byte position of the range to get.</param>
+        /// <param name="end">The end byte position of the range to get.</param>
+        /// <returns>A string representing the text range.</returns>
+        unsafe public string GetTextRange(int position, int end)
+        {
+            int length = end - position;
+            var bytes = new byte[length + 1];
+            fixed (byte* bp = bytes)
+            {
+                TextRange* range = stackalloc TextRange[1];
+                range->chrg.cpMin = position;
+                range->chrg.cpMax = end;
+                range->lpstrText = new IntPtr(bp);
+
+                SPerform(2162 /*SCI_GETTEXTRANGE*/, 0, new IntPtr(range));
+                return new string((sbyte*)bp, 0, length, Encoding);
+            }
+        }
+
+        /// <summary>
         /// Draw the selection in normal style or with selection highlighted.
         /// </summary>
         public void HideSelection(bool normal)

--- a/PluginCore/ScintillaNet/Structs.cs
+++ b/PluginCore/ScintillaNet/Structs.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 
 namespace ScintillaNet
 {
@@ -30,13 +31,15 @@ namespace ScintillaNet
         public int x;
         public int y;
     };
-    
+
+    [StructLayout(LayoutKind.Sequential)]
     public struct CharacterRange
     {
         public int cpMin;
         public int cpMax;
     };
-    
+
+    [StructLayout(LayoutKind.Sequential)]
     public struct TextRange
     {
         public CharacterRange chrg;


### PR DESCRIPTION
Right now there are a lot of code that needs to get arbitrary ranges of text from Scintilla, and people are using sci.GetSel() + sci.SelText, this is not very nice... plus also forces the people to store the previous selection indexes...

I saw there is also a SCI_GETRANGEPOINTER function in Scintilla that may be marginally faster, but I don't know if our version already supports it.