### PR TITLE
Setting to define when to clear the output panel.

### DIFF
--- a/External/Plugins/OutputPanel/PluginMain.cs
+++ b/External/Plugins/OutputPanel/PluginMain.cs
@@ -116,7 +116,10 @@ namespace OutputPanel
             switch (e.Type)
             {
                 case EventType.ProcessStart:
-                    this.pluginUI.ClearOutput(null, null);
+                    if (this.settingObject.ClearMode == ClearModeAction.OnEveryProcess)
+                    {
+                        this.pluginUI.ClearOutput(null, null);
+                    }
                     break;
 
                 case EventType.ProcessEnd:
@@ -145,6 +148,14 @@ namespace OutputPanel
 
                 case EventType.UIStarted:
                     this.pluginUI.UpdateAfterTheme();
+                    break;
+
+                case EventType.Command:
+                    var dataEvent = e as DataEvent;
+                    if (dataEvent.Action == "ProjectManager.BuildingProject" && this.settingObject.ClearMode == ClearModeAction.OnBuildStart)
+                    {
+                        this.pluginUI.ClearOutput(null, null);
+                    }
                     break;
             }
         }
@@ -192,7 +203,8 @@ namespace OutputPanel
         /// </summary>
         public void AddEventHandlers()
         {
-            EventType eventMask = EventType.ProcessStart | EventType.ProcessEnd | EventType.Trace | EventType.ApplySettings | EventType.Keys | EventType.UIStarted;
+            EventType eventMask = EventType.ProcessStart | EventType.ProcessEnd | EventType.Trace | EventType.ApplySettings | EventType.Keys | EventType.UIStarted
+                | EventType.Command;
             EventManager.AddEventHandler(this, eventMask);
         }
 

--- a/External/Plugins/OutputPanel/Settings.cs
+++ b/External/Plugins/OutputPanel/Settings.cs
@@ -15,6 +15,7 @@ namespace OutputPanel
         private Boolean useLegacyColoring = false;
         private List<HighlightMarker> highlightMarkers;
         private Boolean wrapOutput = false;
+        private ClearModeAction clearMode = ClearModeAction.OnEveryProcess;
 
         /// <summary> 
         /// Get and sets the alwaysShow
@@ -81,6 +82,24 @@ namespace OutputPanel
             set { this.highlightMarkers = value; }
         }
 
+        /// <summary> 
+        /// Get and sets the way in which the output text will be cleared
+        /// </summary>
+        [DisplayName("Clear Mode")]
+        [LocalizedDescription("OutputPanel.Description.ClearMode"), DefaultValue(ClearModeAction.OnEveryProcess)]
+        public ClearModeAction ClearMode
+        {
+            get { return this.clearMode; }
+            set { this.clearMode = value; }
+        }
+
+    }
+
+    public enum ClearModeAction
+    {
+        OnEveryProcess,
+        OnBuildStart,
+        Manual
     }
 
     [Serializable]

--- a/PluginCore/PluginCore/Resources/de_DE.resX
+++ b/PluginCore/PluginCore/Resources/de_DE.resX
@@ -6098,4 +6098,8 @@ OR - One or more conditions are met.
 AND - All conditions are met.</value>
     <comment>Added after 5.1.1</comment>
   </data>
+  <data name="OutputPanel.Description.ClearMode" xml:space="preserve">
+    <value>Defines which method should be used to clean the contents of the output panel.</value>
+    <comment>Added after 5.2.0</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/en_US.resX
+++ b/PluginCore/PluginCore/Resources/en_US.resX
@@ -6113,4 +6113,8 @@ OR - One or more conditions are met.
 AND - All conditions are met.</value>
     <comment>Added after 5.1.1</comment>
   </data>
+  <data name="OutputPanel.Description.ClearMode" xml:space="preserve">
+    <value>Defines which method should be used to clean the contents of the output panel.</value>
+    <comment>Added after 5.2.0</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/eu_ES.resX
+++ b/PluginCore/PluginCore/Resources/eu_ES.resX
@@ -6095,4 +6095,8 @@ OR - One or more conditions are met.
 AND - All conditions are met.</value>
     <comment>Added after 5.1.1</comment>
   </data>
+  <data name="OutputPanel.Description.ClearMode" xml:space="preserve">
+    <value>Defines which method should be used to clean the contents of the output panel.</value>
+    <comment>Added after 5.2.0</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/ja_JP.resX
+++ b/PluginCore/PluginCore/Resources/ja_JP.resX
@@ -6156,4 +6156,8 @@ OR - One or more conditions are met.
 AND - All conditions are met.</value>
     <comment>Added after 5.1.1</comment>
   </data>
+  <data name="OutputPanel.Description.ClearMode" xml:space="preserve">
+    <value>Defines which method should be used to clean the contents of the output panel.</value>
+    <comment>Added after 5.2.0</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/ko_KR.resX
+++ b/PluginCore/PluginCore/Resources/ko_KR.resX
@@ -6117,4 +6117,8 @@ OR - 하나 이상의 조건을 만족할때.
 AND - 모든 조건을 만족할때.</value>
     <comment>Added after 5.1.1</comment>
   </data>
+  <data name="OutputPanel.Description.ClearMode" xml:space="preserve">
+    <value>Defines which method should be used to clean the contents of the output panel.</value>
+    <comment>Added after 5.2.0</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/zh_CN.resx
+++ b/PluginCore/PluginCore/Resources/zh_CN.resx
@@ -6108,4 +6108,8 @@ OR - One or more conditions are met.
 AND - All conditions are met.</value>
     <comment>Added after 5.1.1</comment>
   </data>
+  <data name="OutputPanel.Description.ClearMode" xml:space="preserve">
+    <value>Defines which method should be used to clean the contents of the output panel.</value>
+    <comment>Added after 5.2.0</comment>
+  </data>
 </root>


### PR DESCRIPTION
This is useful for many cases. One case:

- I have a Haxe project. I run it and the build starts. Output panel cleared.
- During the build I have some macros that outputs some stuff.
- The build finishes and I have for running the project another process. The output panel is cleared again and I lose the traces from the macros.

Another one:

- I have important stuff in the output panel.
- I run a FD macro. I lose the stuff in the output panel.