### PR TITLE
Reload file on read-only property change

### DIFF
--- a/FlashDevelop/Docking/TabbedDocument.cs
+++ b/FlashDevelop/Docking/TabbedDocument.cs
@@ -364,8 +364,8 @@ namespace FlashDevelop.Docking
             if (!Globals.MainForm.ClosingEntirely && File.Exists(this.FileName))
             {
                 FileInfo fi = new FileInfo(this.FileName);
-				if (this.fileInfo.IsReadOnly != fi.IsReadOnly) return true;
-				if (this.fileInfo.LastWriteTime != fi.LastWriteTime) return true;
+                if (this.fileInfo.IsReadOnly != fi.IsReadOnly) return true;
+                if (this.fileInfo.LastWriteTime != fi.LastWriteTime) return true;
             }
             return false;
         }
@@ -468,17 +468,10 @@ namespace FlashDevelop.Docking
                 this.SciControl.IsReadOnly = FileHelper.FileIsReadOnly(this.FileName);
                 this.SciControl.SetSel(position, position);
                 this.SciControl.EmptyUndoBuffer();
+                this.InitBookmarks();
 
-				List<Int32> bookmarksCopy = this.bookmarks;
-				foreach (var lineNum in bookmarksCopy)
-				{
-					MarkerManager.ToggleMarker(SciControl, 0, lineNum);
-				}
-
-				this.InitBookmarks();
-
-				this.fileInfo = new FileInfo(this.FileName);
-			}
+                this.fileInfo = new FileInfo(this.FileName);
+            }
             Globals.MainForm.OnDocumentReload(this);
         }
 

--- a/FlashDevelop/Docking/TabbedDocument.cs
+++ b/FlashDevelop/Docking/TabbedDocument.cs
@@ -364,7 +364,8 @@ namespace FlashDevelop.Docking
             if (!Globals.MainForm.ClosingEntirely && File.Exists(this.FileName))
             {
                 FileInfo fi = new FileInfo(this.FileName);
-                if (this.fileInfo.LastWriteTime != fi.LastWriteTime) return true;
+				if (this.fileInfo.IsReadOnly != fi.IsReadOnly) return true;
+				if (this.fileInfo.LastWriteTime != fi.LastWriteTime) return true;
             }
             return false;
         }
@@ -468,7 +469,8 @@ namespace FlashDevelop.Docking
                 this.SciControl.SetSel(position, position);
                 this.SciControl.EmptyUndoBuffer();
                 this.InitBookmarks();
-            }
+				this.fileInfo = new FileInfo(this.FileName);
+			}
             Globals.MainForm.OnDocumentReload(this);
         }
 

--- a/FlashDevelop/Docking/TabbedDocument.cs
+++ b/FlashDevelop/Docking/TabbedDocument.cs
@@ -468,7 +468,15 @@ namespace FlashDevelop.Docking
                 this.SciControl.IsReadOnly = FileHelper.FileIsReadOnly(this.FileName);
                 this.SciControl.SetSel(position, position);
                 this.SciControl.EmptyUndoBuffer();
-                this.InitBookmarks();
+
+				List<Int32> bookmarksCopy = this.bookmarks;
+				foreach (var lineNum in bookmarksCopy)
+				{
+					MarkerManager.ToggleMarker(SciControl, 0, lineNum);
+				}
+
+				this.InitBookmarks();
+
 				this.fileInfo = new FileInfo(this.FileName);
 			}
             Globals.MainForm.OnDocumentReload(this);


### PR DESCRIPTION
If the file's read-only property changes, the Scintilla instance is not updated to reflect the change. This means you could continue to edit the file without anything knowing that the file is actually read-only now. This causes issues with some plugins (namely the Perforce plugin) that need to handle edits to a read-only file.

For example, if you use the Perforce plugin to checkout a file through FD, and then revert the file through Perforce outside of FD, FD will never know that the revert happened. This causes it to think that the file is still checked out, which breaks the plugin and gets it in a confused state where it doesn't auto-checkout on edit anymore.

Addtionally, when reloading a file, it doesn't update the fileInfo instance, which means that you can technically reload a file and then be immediately prompted to reload again in some rare circumstances. The fileInfo is now being updated when Reload() is called to prevent this.