### PR TITLE
ScintillaControl.ReplaceTarget uses replacement length, not source.

### DIFF
--- a/FlashDevelop/Dialogs/FRInDocDialog.cs
+++ b/FlashDevelop/Dialogs/FRInDocDialog.cs
@@ -562,7 +562,7 @@ namespace FlashDevelop.Dialogs
                 sci.BeginUndoAction();
                 try
                 {
-                    for (Int32 i = 0; i < matches.Count; i++)
+                    for (Int32 i = 0, count = matches.Count; i < count; i++)
                     {
                         if (!selectionOnly) FRDialogGenerics.SelectMatch(sci, matches[i]);
                         else FRDialogGenerics.SelectMatchInTarget(sci, matches[i]);
@@ -570,7 +570,7 @@ namespace FlashDevelop.Dialogs
                         FRSearch.PadIndexes(matches, i, matches[i].Value, replaceWith);
                         sci.EnsureVisible(sci.CurrentLine);
                         if (!selectionOnly) sci.ReplaceSel(replaceWith);
-                        else sci.ReplaceTarget(matches[i].Length, replaceWith);
+                        else sci.ReplaceTarget(sci.MBSafeTextLength(replaceWith), replaceWith);
                     }
                 }
                 finally


### PR DESCRIPTION
Fixes #1352.