### PR TITLE
Fill the find-and-replace text with current selection every time it's activated

### DIFF
--- a/FlashDevelop/Dialogs/FRInDocDialog.cs
+++ b/FlashDevelop/Dialogs/FRInDocDialog.cs
@@ -430,7 +430,20 @@ namespace FlashDevelop.Dialogs
                 this.lookupIsDirty = false;
             }
         }
-        
+
+        /// <summary>
+        /// If there is a word selected, insert it to the find box. This will always update the text regardless of any settings.
+        /// </summary>
+        public void InitializeFindText()
+        {
+            ScintillaControl sci = Globals.SciControl;
+            if (sci != null && sci.SelText.Length > 0)
+            {
+                this.findComboBox.Text = sci.SelText;
+                this.lookupIsDirty = false;
+            }
+        }
+
         /// <summary>
         /// Finds the next result based on direction
         /// </summary>
@@ -767,7 +780,7 @@ namespace FlashDevelop.Dialogs
         {
             base.Show();
             this.lookupIsDirty = false;
-            this.UpdateFindText();
+            this.InitializeFindText();
         }
 
         #endregion

--- a/FlashDevelop/Dialogs/FRInFilesDialog.cs
+++ b/FlashDevelop/Dialogs/FRInFilesDialog.cs
@@ -888,7 +888,6 @@ namespace FlashDevelop.Dialogs
         private void UpdateDialogArguments()
         {
             IProject project = PluginBase.CurrentProject;
-            ITabbedDocument document = Globals.CurrentDocument;
             Boolean doRefresh = lastProject != null && lastProject != project;
             if (project != null)
             {
@@ -919,10 +918,7 @@ namespace FlashDevelop.Dialogs
                     this.extensionComboBox.Text = "*." + def;
                 }
             }
-            if (document.IsEditable && document.SciControl.SelText.Length > 0)
-            {
-                this.findComboBox.Text = document.SciControl.SelText;
-            }
+            UpdateFindTextWithSelection();
             if (project != null) lastProject = project;
         }
 
@@ -1055,6 +1051,18 @@ namespace FlashDevelop.Dialogs
         {
             this.UpdateDialogArguments();
             base.Show();
+        }
+
+        /// <summary>
+        /// Update the find combo box with the currently selected text.
+        /// </summary>
+        public void UpdateFindTextWithSelection()
+        {
+            ITabbedDocument document = Globals.CurrentDocument;
+            if (document.IsEditable && document.SciControl.SelText.Length > 0)
+            {
+                this.findComboBox.Text = document.SciControl.SelText;
+            }
         }
 
         #endregion

--- a/FlashDevelop/Dialogs/FRInFilesDialog.cs
+++ b/FlashDevelop/Dialogs/FRInFilesDialog.cs
@@ -918,7 +918,7 @@ namespace FlashDevelop.Dialogs
                     this.extensionComboBox.Text = "*." + def;
                 }
             }
-            UpdateFindTextWithSelection();
+            UpdateFindText();
             if (project != null) lastProject = project;
         }
 
@@ -1056,7 +1056,7 @@ namespace FlashDevelop.Dialogs
         /// <summary>
         /// Update the find combo box with the currently selected text.
         /// </summary>
-        public void UpdateFindTextWithSelection()
+        public void UpdateFindText()
         {
             ITabbedDocument document = Globals.CurrentDocument;
             if (document.IsEditable && document.SciControl.SelText.Length > 0)

--- a/FlashDevelop/Docking/TabbedDocument.cs
+++ b/FlashDevelop/Docking/TabbedDocument.cs
@@ -364,7 +364,6 @@ namespace FlashDevelop.Docking
             if (!Globals.MainForm.ClosingEntirely && File.Exists(this.FileName))
             {
                 FileInfo fi = new FileInfo(this.FileName);
-                if (this.fileInfo.IsReadOnly != fi.IsReadOnly) return true;
                 if (this.fileInfo.LastWriteTime != fi.LastWriteTime) return true;
             }
             return false;
@@ -469,8 +468,6 @@ namespace FlashDevelop.Docking
                 this.SciControl.SetSel(position, position);
                 this.SciControl.EmptyUndoBuffer();
                 this.InitBookmarks();
-
-                this.fileInfo = new FileInfo(this.FileName);
             }
             Globals.MainForm.OnDocumentReload(this);
         }

--- a/FlashDevelop/Docking/TabbedDocument.cs
+++ b/FlashDevelop/Docking/TabbedDocument.cs
@@ -364,8 +364,8 @@ namespace FlashDevelop.Docking
             if (!Globals.MainForm.ClosingEntirely && File.Exists(this.FileName))
             {
                 FileInfo fi = new FileInfo(this.FileName);
-				if (this.fileInfo.IsReadOnly != fi.IsReadOnly) return true;
-				if (this.fileInfo.LastWriteTime != fi.LastWriteTime) return true;
+                if (this.fileInfo.IsReadOnly != fi.IsReadOnly) return true;
+                if (this.fileInfo.LastWriteTime != fi.LastWriteTime) return true;
             }
             return false;
         }
@@ -468,17 +468,10 @@ namespace FlashDevelop.Docking
                 this.SciControl.IsReadOnly = FileHelper.FileIsReadOnly(this.FileName);
                 this.SciControl.SetSel(position, position);
                 this.SciControl.EmptyUndoBuffer();
+                this.InitBookmarks();
 
-				List<Int32> bookmarksCopy = this.bookmarks;
-				foreach (var lineNum in bookmarksCopy)
-				{
-					MarkerManager.ToggleMarker(SciControl, 0, lineNum);
-				}
-
-				this.InitBookmarks();
-
-				this.fileInfo = new FileInfo(this.FileName);
-			}
+                this.fileInfo = new FileInfo(this.FileName);
+            }
             Globals.MainForm.OnDocumentReload(this);
         }
 

--- a/FlashDevelop/Docking/TabbedDocument.cs
+++ b/FlashDevelop/Docking/TabbedDocument.cs
@@ -364,7 +364,8 @@ namespace FlashDevelop.Docking
             if (!Globals.MainForm.ClosingEntirely && File.Exists(this.FileName))
             {
                 FileInfo fi = new FileInfo(this.FileName);
-                if (this.fileInfo.LastWriteTime != fi.LastWriteTime) return true;
+				if (this.fileInfo.IsReadOnly != fi.IsReadOnly) return true;
+				if (this.fileInfo.LastWriteTime != fi.LastWriteTime) return true;
             }
             return false;
         }
@@ -468,7 +469,8 @@ namespace FlashDevelop.Docking
                 this.SciControl.SetSel(position, position);
                 this.SciControl.EmptyUndoBuffer();
                 this.InitBookmarks();
-            }
+				this.fileInfo = new FileInfo(this.FileName);
+			}
             Globals.MainForm.OnDocumentReload(this);
         }
 

--- a/FlashDevelop/Docking/TabbedDocument.cs
+++ b/FlashDevelop/Docking/TabbedDocument.cs
@@ -468,7 +468,15 @@ namespace FlashDevelop.Docking
                 this.SciControl.IsReadOnly = FileHelper.FileIsReadOnly(this.FileName);
                 this.SciControl.SetSel(position, position);
                 this.SciControl.EmptyUndoBuffer();
-                this.InitBookmarks();
+
+				List<Int32> bookmarksCopy = this.bookmarks;
+				foreach (var lineNum in bookmarksCopy)
+				{
+					MarkerManager.ToggleMarker(SciControl, 0, lineNum);
+				}
+
+				this.InitBookmarks();
+
 				this.fileInfo = new FileInfo(this.FileName);
 			}
             Globals.MainForm.OnDocumentReload(this);

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -2938,7 +2938,11 @@ namespace FlashDevelop
         public void FindAndReplaceInFiles(Object sender, System.EventArgs e)
         {
             if (!this.frInFilesDialog.Visible) this.frInFilesDialog.Show();
-            else this.frInFilesDialog.Activate();
+            else
+            {
+                this.frInFilesDialog.UpdateFindTextWithSelection();
+                this.frInFilesDialog.Activate();
+            }
         }
 
         /// <summary>

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -2914,7 +2914,11 @@ namespace FlashDevelop
         public void FindAndReplace(Object sender, System.EventArgs e)
         {
             if (!this.frInDocDialog.Visible) this.frInDocDialog.Show();
-            else this.frInDocDialog.Activate();
+            else
+            {
+                this.frInDocDialog.InitializeFindText();
+                this.frInDocDialog.Activate();
+            }
         }
 
         /// <summary>
@@ -2940,7 +2944,7 @@ namespace FlashDevelop
             if (!this.frInFilesDialog.Visible) this.frInFilesDialog.Show();
             else
             {
-                this.frInFilesDialog.UpdateFindTextWithSelection();
+                this.frInFilesDialog.UpdateFindText();
                 this.frInFilesDialog.Activate();
             }
         }


### PR DESCRIPTION


When opening the find-and-replace dialog the first time it automatically populates the find text with whatever you have selected. Every additional attempt will no longer update the text.

This change makes it so every time you activate the dialog, usually through Ctrl+Shift+F, it will update the find text to use whatever you had selected at the time, making it much easier to use.
