### PR TITLE
Fix project open to support read-only files

### DIFF
--- a/External/Plugins/ProjectManager/Projects/ProjectReader.cs
+++ b/External/Plugins/ProjectManager/Projects/ProjectReader.cs
@@ -12,7 +12,7 @@ namespace ProjectManager.Projects
         Project project;
         protected int version;
 
-        public ProjectReader(string filename, Project project) : base(new FileStream(filename,FileMode.Open))
+        public ProjectReader(string filename, Project project) : base(new FileStream(filename,FileMode.Open,FileAccess.Read))
         {
             this.project = project;
             WhitespaceHandling = WhitespaceHandling.None;


### PR DESCRIPTION


Currently, an exception will be thrown if you attempt to open a FD project files that is read-only. This is a problem when using source control programs like Perforce that force everything to read-only if you aren't editing them.

This fix will allow FD to open the project as normal. You won't be able to edit it in any way, but it gives you a clear error when you try so it's not an issue.