### PR TITLE
Improve completion after new

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -2201,15 +2201,28 @@ namespace ASCompletion.Completion
                 ICompletionListItem newItem;
                 if (!aClass.IsVoid())
                 {
-                    if (!string.IsNullOrEmpty(aClass.IndexType))
+                    // AS2 special srictly typed Arrays supports
+                    int p = newItemType.IndexOf('@');
+                    if (p > -1)
                     {
-                        newItemType = !string.IsNullOrEmpty(aClass.IndexType) ? aClass.QualifiedName : aClass.Type;
+                        newItemType = newItemType.Substring(0, p);
+                        newItem = null;
+                    }
+                    else if (!string.IsNullOrEmpty(aClass.IndexType))
+                    {
+                        newItemType = aClass.QualifiedName;
                         newItem = new MemberItem(new MemberModel(newItemType, aClass.Type, aClass.Flags, aClass.Access));
                     }
                     else
                     {
                         newItem = null;
                     }
+                }
+                else if (newItemType == "Vector.")
+                {
+                    // HACK: Vector.<*> is wrongly parsed! should be looked into. Remove once it's fixed.
+                    newItemType = "Vector";
+                    newItem = null;
                 }
                 else
                 {
@@ -4604,6 +4617,8 @@ namespace ASCompletion.Completion
     /// </summary>
     public class NonexistentMemberItem : ICompletionListItem
     {
+        private static Bitmap icon; 
+
         private string memberName;
 
         public NonexistentMemberItem(string memberName)
@@ -4626,7 +4641,11 @@ namespace ASCompletion.Completion
 
         public Bitmap Icon
         {
-            get { return (Bitmap)PluginBase.MainForm.FindImage("197"); }
+            get
+            {
+                if (icon == null) icon = (Bitmap)PluginBase.MainForm.FindImage("197");
+                return icon;
+            }
         }
 
         public string Value

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -2132,12 +2132,12 @@ namespace ASCompletion.Completion
 
         #region types_completion
 
-        static private void SelectTypedNewMember(ScintillaControl sci)
+        static private string SelectTypedNewMember(ScintillaControl sci)
         {
             try
             {
                 ASExpr expr = GetExpression(sci, sci.CurrentPos);
-                if (expr.Value == null) return;
+                if (expr.Value == null) return null;
                 IASContext ctx = ASContext.Context;
                 // try local var
                 expr.LocalVars = ParseLocalVars(expr);
@@ -2145,14 +2145,7 @@ namespace ASCompletion.Completion
                 {
                     if (localVar.LineTo == ctx.CurrentLine)
                     {
-                        if (localVar.Type != null) // Might be non typed var
-                        {
-                            string typeName = localVar.Type;
-                            ClassModel aClass = ctx.ResolveType(typeName, ctx.CurrentModel);
-                            if (!aClass.IsVoid()) typeName = aClass.Type;
-                            CompletionList.SelectItem(typeName);
-                        }
-                        return;
+                        return localVar.Type;
                     }
                 }
                 // try member
@@ -2164,36 +2157,80 @@ namespace ASCompletion.Completion
                     ASResult result = EvalExpression(name, expr, ctx.CurrentModel, ctx.CurrentClass, true, false);
                     if (result != null && result.Member != null && result.Member.Type != null) // Might be missing or wrongly typed member
                     {
-                        string typeName = result.Member.Type;
-                        ClassModel aClass = ctx.ResolveType(typeName, ctx.CurrentModel);
-                        if (!aClass.IsVoid()) typeName = aClass.Type;
-                        CompletionList.SelectItem(typeName);
+                        return result.Member.Type;
                     }
                 }
             }
             catch {} // Do not throw exception with incorrect types
+
+            return null;
         }
 
-        static private bool HandleNewCompletion(ScintillaControl Sci, string tail, bool autoHide, string keyword)
+        static private bool HandleNewCompletion(ScintillaControl sci, string tail, bool autoHide, string keyword)
         {
+            List<ICompletionListItem> list;
+
             if (!ASContext.Context.Settings.LazyClasspathExploration
                 && ASContext.Context.Settings.CompletionListAllTypes)
             {
                 // show all project classes
-                HandleAllClassesCompletion(Sci, tail, true, true);
-                SelectTypedNewMember(Sci);
+                list = GetAllClasses(sci, true, true);
+
+                if (list == null) return true;
             }
             else
             {
                 // Consolidate known classes
                 MemberList known = GetVisibleElements();
-                // show
-                List<ICompletionListItem> list = new List<ICompletionListItem>();
+                list = new List<ICompletionListItem>();
                 foreach (MemberModel member in known)
                     list.Add(new MemberItem(new MemberModel(member.Type, member.Type, member.Flags, member.Access)));
-                CompletionList.Show(list, autoHide, tail);
-                SelectTypedNewMember(Sci);
             }
+
+            // If we are instantiating a class:
+            //    1. Type exists:
+            //       a. Generic type -> Show it with our index type.
+            //       b. Not generic type -> Show existing one
+            //    2. Type doesn't exist -> Show it with a warning symbol.
+            string newItemType;
+            if (keyword == "new" && (newItemType = SelectTypedNewMember(sci)) != null)
+            {
+                IASContext ctx = ASContext.Context;
+                ClassModel aClass = ctx.ResolveType(newItemType, ctx.CurrentModel);
+
+                ICompletionListItem newItem;
+                if (!aClass.IsVoid())
+                {
+                    if (!string.IsNullOrEmpty(aClass.IndexType))
+                    {
+                        newItemType = !string.IsNullOrEmpty(aClass.IndexType) ? aClass.QualifiedName : aClass.Type;
+                        newItem = new MemberItem(new MemberModel(newItemType, aClass.Type, aClass.Flags, aClass.Access));
+                    }
+                    else
+                    {
+                        newItem = null;
+                    }
+                }
+                else
+                {
+                    newItem = new NonexistentMemberItem(newItemType);
+                }
+
+                if (newItem != null)
+                {
+                    int itemIndex = list.FindIndex(item => string.Compare(item.Label, newItemType, StringComparison.OrdinalIgnoreCase) >= 0);
+                    itemIndex = itemIndex > 0 ? itemIndex - 1 : 0;
+                    list.Insert(itemIndex, newItem);
+                }
+
+                CompletionList.Show(list, autoHide, tail);
+                CompletionList.SelectItem(newItemType);
+            }
+            else
+            {
+                CompletionList.Show(list, autoHide, tail);
+            }
+
             return true;
         }
 
@@ -2342,74 +2379,7 @@ namespace ASCompletion.Completion
         /// <param name="Sci"></param>
         static public void HandleAllClassesCompletion(ScintillaControl Sci, string tail, bool classesOnly, bool showClassVars)
         {
-            MemberList known = ASContext.Context.GetAllProjectClasses();
-            if (known.Count == 0) return;
-
-            // get local Class vars
-            if (showClassVars)
-            {
-                MemberList found = new MemberList();
-
-                ASExpr expr = GetExpression(Sci, Sci.CurrentPos);
-                if (expr.Value != null)
-                {
-                    MemberList locals = ParseLocalVars(expr);
-                    foreach (MemberModel local in locals)
-                        if (local.Type == "Class")
-                            found.Add(local);
-                }
-
-                if (found.Count > 0)
-                {
-                    found.Sort();
-                    found.Merge(known);
-                    known = found;
-                }
-            }
-
-            if (!ASContext.Context.CurrentClass.IsVoid())
-            {
-                if (ASContext.Context.Features.hasDelegates)
-                {
-                    MemberList delegates = new MemberList();
-
-                    foreach (MemberModel field in ASContext.Context.CurrentClass.Members)
-                        if ((field.Flags & FlagType.Delegate) > 0)
-                            delegates.Add(field);
-
-                    if (delegates.Count > 0)
-                    {
-                        delegates.Sort();
-                        delegates.Merge(known);
-                        known = delegates;
-                    }
-                }
-
-                if (ASContext.Context.Features.hasGenerics)
-                {
-                    var typeParams = GetVisibleTypeParameters();
-
-                    if (typeParams != null && typeParams.Items.Count > 0)
-                    {
-                        typeParams.Sort();
-                        typeParams.Merge(known);
-                        known = typeParams;
-                    }
-                }
-            }
-
-            List<ICompletionListItem> list = new List<ICompletionListItem>();
-            string prev = null;
-            FlagType mask = (classesOnly) ? 
-                FlagType.Class | FlagType.Interface | FlagType.Enum | FlagType.Delegate | FlagType.Struct | FlagType.TypeDef
-                : (FlagType)uint.MaxValue;
-            foreach (MemberModel member in known)
-            {
-                if ((member.Flags & mask) == 0 || prev == member.Name) 
-                    if (!showClassVars || member.Type != "Class") continue;
-                prev = member.Name;
-                list.Add(new MemberItem(member));
-            }
+            List<ICompletionListItem> list = GetAllClasses(Sci, classesOnly, showClassVars);
 
             CompletionList.Show(list, false, tail);
         }
@@ -3930,6 +3900,80 @@ namespace ASCompletion.Completion
             return retVal;
         }
 
+        static private List<ICompletionListItem> GetAllClasses(ScintillaControl sci, bool classesOnly, bool showClassVars)
+        {
+            MemberList known = ASContext.Context.GetAllProjectClasses();
+            if (known.Count == 0) return null;
+
+            // get local Class vars
+            if (showClassVars)
+            {
+                MemberList found = new MemberList();
+
+                ASExpr expr = GetExpression(sci, sci.CurrentPos);
+                if (expr.Value != null)
+                {
+                    MemberList locals = ParseLocalVars(expr);
+                    foreach (MemberModel local in locals)
+                        if (local.Type == "Class")
+                            found.Add(local);
+                }
+
+                if (found.Count > 0)
+                {
+                    found.Sort();
+                    found.Merge(known);
+                    known = found;
+                }
+            }
+
+            if (!ASContext.Context.CurrentClass.IsVoid())
+            {
+                if (ASContext.Context.Features.hasDelegates)
+                {
+                    MemberList delegates = new MemberList();
+
+                    foreach (MemberModel field in ASContext.Context.CurrentClass.Members)
+                        if ((field.Flags & FlagType.Delegate) > 0)
+                            delegates.Add(field);
+
+                    if (delegates.Count > 0)
+                    {
+                        delegates.Sort();
+                        delegates.Merge(known);
+                        known = delegates;
+                    }
+                }
+
+                if (ASContext.Context.Features.hasGenerics)
+                {
+                    var typeParams = GetVisibleTypeParameters();
+
+                    if (typeParams != null && typeParams.Items.Count > 0)
+                    {
+                        typeParams.Sort();
+                        typeParams.Merge(known);
+                        known = typeParams;
+                    }
+                }
+            }
+
+            List<ICompletionListItem> list = new List<ICompletionListItem>();
+            string prev = null;
+            FlagType mask = (classesOnly) ?
+                FlagType.Class | FlagType.Interface | FlagType.Enum | FlagType.Delegate | FlagType.Struct | FlagType.TypeDef
+                : (FlagType)uint.MaxValue;
+            foreach (MemberModel member in known)
+            {
+                if ((member.Flags & mask) == 0 || prev == member.Name)
+                    if (!showClassVars || member.Type != "Class") continue;
+                prev = member.Name;
+                list.Add(new MemberItem(member));
+            }
+
+            return list;
+        }
+
         private static MemberList GetVisibleElements()
         {
             MemberList known = ASContext.Context.GetVisibleExternalElements();
@@ -4538,13 +4582,64 @@ namespace ASCompletion.Completion
         {
             get 
             {
-                if (member.Name.IndexOf('<') > 0)
+                if (member.Name.IndexOf('<') > 0 && member.Template != null)
                 {
-                    if (member.Name.IndexOfOrdinal(".<") > 0) 
+                    if (member.Name.IndexOfOrdinal(".<") > 0)
                         return member.Name.Substring(0, member.Name.IndexOfOrdinal(".<"));
-                    else return member.Name.Substring(0, member.Name.IndexOf('<'));
+
+                    return member.Name.Substring(0, member.Name.IndexOf('<'));
                 }
-                return member.Name; 
+                return member.Name;
+            }
+        }
+
+        public override string ToString()
+        {
+            return Label;
+        }
+    }
+
+    /// <summary>
+    /// Nonexistent member completion list item
+    /// </summary>
+    public class NonexistentMemberItem : ICompletionListItem
+    {
+        private string memberName;
+
+        public NonexistentMemberItem(string memberName)
+        {
+            this.memberName = memberName;
+        }
+
+        public string Label
+        {
+            get { return memberName; }
+        }
+
+        public virtual string Description
+        {
+            get
+            {
+                return memberName;
+            }
+        }
+
+        public Bitmap Icon
+        {
+            get { return (Bitmap)PluginBase.MainForm.FindImage("197"); }
+        }
+
+        public string Value
+        {
+            get
+            {
+                if (memberName.IndexOf('<') > 0)
+                {
+                    if (memberName.IndexOfOrdinal(".<") > 0)
+                        return memberName.Substring(0, memberName.IndexOfOrdinal(".<"));
+                    else return memberName.Substring(0, memberName.IndexOf('<'));
+                }
+                return memberName;
             }
         }
 

--- a/PluginCore/PluginCore/Controls/CompletionList.cs
+++ b/PluginCore/PluginCore/Controls/CompletionList.cs
@@ -214,9 +214,7 @@ namespace PluginCore.Controls
         /// </summary>
         static public void SelectItem(String name)
         {
-            int p = name.IndexOf('<');
-            if (p > 1) name = name.Substring(0, p) + "<T>";
-            string pname = (name.IndexOf('.') < 0) ? "." + name : null;
+            string pname = name.IndexOf('.') < 0 ? "." + name : null;
             ICompletionListItem found = null;
             foreach (ICompletionListItem item in completionList.Items)
             {


### PR DESCRIPTION
  - If we are instantiating an nonexistent item add it to the list and notify about its missing state.
  - If we are instantiating a generic type, add it with the index type to the list.
This closes #71.

Sample:

![selectnew](https://cloud.githubusercontent.com/assets/2273861/19389306/d1f152a6-9223-11e6-8da3-d61666b832f0.gif)

EDIT: There are some artifacts in the GIF for some reason.