### PR TITLE
Minor UI tweaks

### DIFF
--- a/External/Plugins/TaskListPanel/PluginUI.cs
+++ b/External/Plugins/TaskListPanel/PluginUI.cs
@@ -174,6 +174,7 @@ namespace TaskListPanel
             this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {this.toolStripLabel});
             this.statusStrip.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.statusStrip.Renderer = new DockPanelStripRenderer(false);
+            this.statusStrip.SizingGrip = false;
             this.statusStrip.Name = "statusStrip";
             this.statusStrip.Size = new System.Drawing.Size(278, 22);
             this.statusStrip.TabIndex = 0;

--- a/FlashDevelop/Dialogs/SettingDialog.cs
+++ b/FlashDevelop/Dialogs/SettingDialog.cs
@@ -606,6 +606,7 @@ namespace FlashDevelop.Dialogs
         /// </summary>
         private void DialogClosed(Object sender, FormClosedEventArgs e)
         {
+            Cursor.Current = Cursors.WaitCursor;  // Enough for our sync code
             if (sdkContext != null) sdkContext.Dispose();
             Globals.MainForm.ApplyAllSettings();
             Globals.MainForm.SaveSettings();


### PR DESCRIPTION
- When saving settings show wait cursor to avoid people on slow systems to think they didn't successfully click on Close.
- TaskList Panel status bar was showing the resize indicator when the main form was not maximized.
