### PR TITLE
[CodeRefactor. OrganizeImports] Fixed `Object reference not set to an instance of an object.`

### DIFF
--- a/External/Plugins/CodeRefactor/Commands/OrganizeImports.cs
+++ b/External/Plugins/CodeRefactor/Commands/OrganizeImports.cs
@@ -151,9 +151,9 @@ namespace CodeRefactor.Commands
         static bool ContainsMember(FileModel file, MemberModel member)
         {
             var currentModelPackage = file.Package;
-            if (!string.IsNullOrEmpty(currentModelPackage) && member.Value.Contains("."))
+            if (!string.IsNullOrEmpty(currentModelPackage) && member.Type.Contains("."))
             {
-                var importPackage = member.Value.Substring(0, member.Value.LastIndexOf('.'));
+                var importPackage = member.Type.Substring(0, member.Type.LastIndexOf('.'));
                 if (importPackage != currentModelPackage) return false;
             }
             return file.Classes.Exists(cls => cls.Name == member.Name);

--- a/External/Plugins/CodeRefactor/Commands/OrganizeImports.cs
+++ b/External/Plugins/CodeRefactor/Commands/OrganizeImports.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using ASCompletion.Context;
 using ASCompletion.Model;
 using PluginCore;
@@ -150,13 +151,9 @@ namespace CodeRefactor.Commands
 
         static bool ContainsMember(FileModel file, MemberModel member)
         {
-            var currentModelPackage = file.Package;
-            if (!string.IsNullOrEmpty(currentModelPackage) && member.Type.Contains("."))
-            {
-                var importPackage = member.Type.Substring(0, member.Type.LastIndexOf('.'));
-                if (importPackage != currentModelPackage) return false;
-            }
-            return file.Classes.Exists(cls => cls.Name == member.Name);
+            var dot = ASContext.Context.Features.dot;
+            var package = string.IsNullOrEmpty(file.Package) ? string.Empty : $"{file.Package}{dot}";
+            return $"{package}{Path.GetFileNameWithoutExtension(file.FileName)}{dot}{member.Name}" == member.Type;
         }
 
         /// <summary>

--- a/Tests/External/Plugins/CodeRefactor.Tests/CodeRefactor.Tests.csproj
+++ b/Tests/External/Plugins/CodeRefactor.Tests/CodeRefactor.Tests.csproj
@@ -149,6 +149,8 @@
     <EmbeddedResource Include="Test Files\coderefactor\organizeimports\haxe\AfterOrganizeImports.hx" />
     <EmbeddedResource Include="Test Files\coderefactor\organizeimports\haxe\BeforeOrganizeImports_withImportsFromSameModule.hx" />
     <EmbeddedResource Include="Test Files\coderefactor\organizeimports\haxe\AfterOrganizeImports_withImportsFromSameModule.hx" />
+    <EmbeddedResource Include="Test Files\coderefactor\organizeimports\haxe\BeforeOrganizeImports_withImportsFromSameModule2.hx" />
+    <EmbeddedResource Include="Test Files\coderefactor\organizeimports\haxe\AfterOrganizeImports_withImportsFromSameModule2.hx" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Tests/External/Plugins/CodeRefactor.Tests/Commands/CodeRefactorTests.cs
+++ b/Tests/External/Plugins/CodeRefactor.Tests/Commands/CodeRefactorTests.cs
@@ -317,12 +317,22 @@ namespace CodeRefactor.Commands
                             new TestCaseData(
                                     TestFile.ReadAllText(
                                         "CodeRefactor.Test_Files.coderefactor.organizeimports.haxe.BeforeOrganizeImports_withImportsFromSameModule.hx"),
-                                    "BeforeOrganizeImports_withImportsFromSameModule.hx"
+                                    "Main.hx"
                                 )
                                 .Returns(
                                     TestFile.ReadAllText(
                                         "CodeRefactor.Test_Files.coderefactor.organizeimports.haxe.AfterOrganizeImports_withImportsFromSameModule.hx"))
-                                .SetName("Issue782");
+                                .SetName("Issue782. Package is empty.");
+                        yield return
+                            new TestCaseData(
+                                    TestFile.ReadAllText(
+                                        "CodeRefactor.Test_Files.coderefactor.organizeimports.haxe.BeforeOrganizeImports_withImportsFromSameModule2.hx"),
+                                    "Main.hx"
+                                )
+                                .Returns(
+                                    TestFile.ReadAllText(
+                                        "CodeRefactor.Test_Files.coderefactor.organizeimports.haxe.AfterOrganizeImports_withImportsFromSameModule2.hx"))
+                                .SetName("Issue782. Package is not empty.");
                     }
                 }
 

--- a/Tests/External/Plugins/CodeRefactor.Tests/Test Files/coderefactor/organizeimports/haxe/AfterOrganizeImports_withImportsFromSameModule2.hx
+++ b/Tests/External/Plugins/CodeRefactor.Tests/Test Files/coderefactor/organizeimports/haxe/AfterOrganizeImports_withImportsFromSameModule2.hx
@@ -1,0 +1,19 @@
+package org.fd;
+import org.fd.Main.Bar.test;
+
+class Main
+{
+    public static function main():Void
+    {   
+
+    }
+}
+
+enum TestEnum
+{
+    Value;
+}
+
+class Bar {
+    public static function test() {}
+}

--- a/Tests/External/Plugins/CodeRefactor.Tests/Test Files/coderefactor/organizeimports/haxe/BeforeOrganizeImports_withImportsFromSameModule2.hx
+++ b/Tests/External/Plugins/CodeRefactor.Tests/Test Files/coderefactor/organizeimports/haxe/BeforeOrganizeImports_withImportsFromSameModule2.hx
@@ -1,0 +1,20 @@
+package org.fd;
+import org.fd.Main.TestEnum;
+import org.fd.Main.Bar.test;
+
+class Main
+{
+    public static function main():Void
+    {   
+
+    }
+}
+
+enum TestEnum
+{
+    Value;
+}
+
+class Bar {
+    public static function test() {}
+}


### PR DESCRIPTION
Fixed `Object reference not set to an instance of an object.`
   at CodeRefactor.Commands.OrganizeImports.ContainsMember(FileModel file, MemberModel member)
   at CodeRefactor.Commands.OrganizeImports.ExecutionImplementation()
   at CodeRefactor.PluginMain.OrganizeImportsClicked(Object sender, EventArgs e)