### PR TITLE
Do not consider { as the start of a body if we are inside parenthesis

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -1878,7 +1878,7 @@ namespace ASCompletion.Completion
 
             int funcBodyStart = -1;
 
-            int genCount = 0;
+            int genCount = 0, parCount = 0;
             for (int i = posStart; i <= posEnd; i++)
             {
                 char c = (char)sci.CharAt(i);
@@ -1886,7 +1886,7 @@ namespace ASCompletion.Completion
                 if (c == '{')
                 {
                     int style = sci.BaseStyleAt(i);
-                    if (ASComplete.IsCommentStyle(style) || ASComplete.IsLiteralStyle(style) || genCount > 0)
+                    if (ASComplete.IsCommentStyle(style) || ASComplete.IsLiteralStyle(style) || genCount > 0 || parCount > 0)
                         continue;
                     funcBodyStart = i;
                     break;
@@ -1900,8 +1900,20 @@ namespace ASCompletion.Completion
                 else if (c == '>')
                 {
                     int style = sci.BaseStyleAt(i);
-                    if (style == 10)
+                    if (style == 10 && genCount > 0)
                         genCount--;
+                }
+                else if (c == '(')
+                {
+                    int style = sci.BaseStyleAt(i);
+                    if (style == 10)
+                        parCount++;
+                }
+                else if (c == ')')
+                {
+                    int style = sci.BaseStyleAt(i);
+                    if (style == 10)
+                        parCount--;
                 }
             }
 

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
@@ -90,6 +90,7 @@ namespace ASCompletion.Completion
                         .SetName("WithAnotherMemberInTheSameLine")
                         .Ignore("Having only LineFrom and LineTo for members is not enough to handle these cases. FlashDevelop in general is not too kind when it comes to several members in the same line, but we could change the method to use positions and try to get the proper position before.");
                     yield return new TestCaseData("function test<T:{}>(arg:T):void{\r\n\r\n}", 0, 1, "function test<T:{}>(arg:T):void{\r\n\r\n}", 34).SetName("BracketsInGenericConstraint");
+                    yield return new TestCaseData("function test(arg:{x:Int}):void{\r\n\r\n}", 0, 1, "function test(arg:{x:Int}):void{\r\n\r\n}", 34).SetName("AnonymousStructures");
                 }
             }
 


### PR DESCRIPTION
Fixes issue #1397

This function should be changed in the near future to use normal positions instead of lines to support more than a function per line. Although better yet if could also use a model and support single line functions without brackets.