### PR TITLE
Fixed fails after renaming when renaming function parameters in some cases. part2 #467

### DIFF
--- a/External/Plugins/CodeRefactor/Commands/Rename.cs
+++ b/External/Plugins/CodeRefactor/Commands/Rename.cs
@@ -240,10 +240,11 @@ namespace CodeRefactor.Commands
                 var targetMatches = entry.Value;
                 if (isParameterVar)
                 {
-                    var replacement = string.Empty;
                     var lineFrom = Target.Context.ContextFunction.LineFrom;
+                    var lineTo = Target.Context.ContextFunction.LineTo;
                     var search = new FRSearch(NewName) {WholeWord = true, NoCase = false, SingleLine = true};
                     var matches = search.Matches(sci.Text, sci.PositionFromLine(lineFrom), lineFrom);
+                    matches.RemoveAll(it => it.Line < lineFrom || it.Line > lineTo);
                     if (matches.Count != 0)
                     {
                         sci.BeginUndoAction();
@@ -251,6 +252,7 @@ namespace CodeRefactor.Commands
                         {
                             for (var i = 0; i < matches.Count; i++)
                             {
+                                var replacement = string.Empty;
                                 var match = matches[i];
                                 var expr = ASComplete.GetExpressionType(sci, sci.MBSafePosition(match.Index) + sci.MBSafeTextLength(match.Value));
                                 if (expr.IsNull()) continue;

--- a/External/Plugins/CodeRefactor/Commands/Rename.cs
+++ b/External/Plugins/CodeRefactor/Commands/Rename.cs
@@ -252,10 +252,10 @@ namespace CodeRefactor.Commands
                         {
                             for (var i = 0; i < matches.Count; i++)
                             {
-                                var replacement = string.Empty;
                                 var match = matches[i];
                                 var expr = ASComplete.GetExpressionType(sci, sci.MBSafePosition(match.Index) + sci.MBSafeTextLength(match.Value));
                                 if (expr.IsNull()) continue;
+                                var replacement = string.Empty;
                                 var flags = expr.Member.Flags;
                                 if ((flags & FlagType.Static) > 0)
                                 {


### PR DESCRIPTION
code for example:
```actionscript
package {
	import flash.display.Sprite;
	
	public class Main extends Sprite {
		
		public function Main(value:String) {
			v = value;
			trace(v);
		}
		
		private var v:String;
	}
}
```
Expected result after rename `value` to `v`:
```actionscript
package {
	import flash.display.Sprite;
	
	public class Main extends Sprite {
		
		public function Main(v:String) {
			this.v = value;
			trace(this.v);
		}
		
		private var v:String;
	}
}
```
Actual result after rename `value` to `v`:
```actionscript
package {
	import flash.display.Sprite;
	
	public class Main extends Sprite {
		
		public function Main(v:String) {
			this.v = value;
			trace(this.v);
		}
		
		private var this.v:String;// <-- BUG: this.v should be v
	}
}
```