### PR TITLE
Improve `Assign statement to local variable`

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -3164,79 +3164,32 @@ namespace ASCompletion.Completion
             }
 
             line = ReplaceAllStringContents(line);
-
-            ASResult resolve = null;
-            int pos = -1; 
-            string word = null;
-            ClassModel type = null;
-
+            int pos = -1;
             if (line.Last() == ')')
             {
-                if (line.Contains('('))
+                var bracesCount = 1;
+                var position = startPos + line.Length - 1;
+                while (position-- > 0)
                 {
-                    int lastIndex = 0;
-                    int bracesBalance = 0;
-                    while (true)
+                    if (sci.PositionIsOnComment(position)) continue;
+                    var c = (char)sci.CharAt(position);
+                    if (c == ')') bracesCount++;
+                    else if (c == '(')
                     {
-                        int pos1 = line.IndexOf('(', lastIndex);
-                        int pos2 = line.IndexOf(')', lastIndex);
-                        if (pos1 != -1 && pos2 != -1)
-                        {
-                            lastIndex = Math.Min(pos1, pos2);
-                        }
-                        else if (pos1 != -1 || pos2 != -1)
-                        {
-                            lastIndex = Math.Max(pos1, pos2);
-                        }
-                        else
-                        {
-                            break;
-                        }
-                        if (lastIndex == pos1)
-                        {
-                            bracesBalance++;
-                            if (bracesBalance == 1)
-                            {
-                                pos = lastIndex;
-                            }
-                        }
-                        else if (lastIndex == pos2)
-                        {
-                            bracesBalance--;
-                        }
-                        lastIndex++;
-                    }
-                    if (pos != -1)
-                    {
-                        line = line.Substring(0, pos);
-                        pos += startPos;
-                        pos -= line.Length - line.TrimEnd().Length + 1;
-                    }
-                }
-                else
-                {
-                    var bracesCount = 1;
-                    var position = startPos + line.Length - 1;
-                    while (position-- > 0)
-                    {
-                        if (sci.PositionIsOnComment(position)) continue;
-                        var c = (char)sci.CharAt(position);
-                        if (c == ')') bracesCount++;
-                        else if (c == '(')
-                        {
-                            bracesCount--;
-                            if (bracesCount > 0) continue;
-                            pos = position;
-                            var lineFromPosition = sci.LineFromPosition(pos);
-                            startPos = sci.PositionFromLine(lineFromPosition);
-                            line = sci.GetLine(lineFromPosition);
-                            line = line.Substring(0, pos - startPos);
-                            break;
-                        }
+                        bracesCount--;
+                        if (bracesCount > 0) continue;
+                        pos = position;
+                        var lineFromPosition = sci.LineFromPosition(pos);
+                        startPos = sci.PositionFromLine(lineFromPosition);
+                        line = sci.GetLine(lineFromPosition);
+                        line = line.Substring(0, pos - startPos);
+                        break;
                     }
                 }
             }
             else pos = startPos + line.Length - 1;
+            ASResult resolve = null;
+            string word = null;
             if (pos != -1)
             {
                 pos = sci.WordEndPosition(pos, true);
@@ -3248,7 +3201,7 @@ namespace ASCompletion.Completion
 
             IASContext ctx = inClass.InFile.Context;
             m = Regex.Match(line, "new\\s+([\\w\\d.<>,_$-]+)+(<[^]]+>)|(<[^]]+>)", RegexOptions.IgnoreCase);
-
+            ClassModel type = null;
             if (m.Success)
             {
                 string m1 = m.Groups[1].Value;

--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -3214,7 +3214,7 @@ namespace ASCompletion.Completion
                     cname = String.Concat(m1, m2);
                 
                 type = ctx.ResolveType(cname, inClass.InFile);
-                if (!type.IsVoid()) resolve.Type = type;// resolve = null;
+                if (!type.IsVoid() && resolve != null) resolve.Type = type;// resolve = null;
             }
             else
             {

--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -1996,7 +1996,7 @@ namespace ASCompletion.Completion
                         break;
                     }
                 }
-                else if (!hasDot && c == '.') hasDot = pc != '<';
+                else if (!hasDot && c == '.') hasDot = pc != '<' && parCount == 0;
                 else if (hasDot && characters.Contains(c))
                 {
                     var exprType = ASComplete.GetExpressionType(sci, i);

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -419,6 +419,12 @@
     <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromMethodChaining_useSpaces.as" />
     <EmbeddedResource Include="Test Files\generated\as3\BeforeAssignStatementToVarFromMethodChaining2_useSpaces.as" />
     <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromMethodChaining2_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeAssignStatementToVarFromNewString_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromNewString_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromNewString2_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeAssignStatementToVarFromNewString2_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromNewBitmapDataWithParams_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeAssignStatementToVarFromNewBitmapDataWithParams_useSpaces.as" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -425,6 +425,14 @@
     <EmbeddedResource Include="Test Files\generated\as3\BeforeAssignStatementToVarFromNewString2_useSpaces.as" />
     <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromNewBitmapDataWithParams_useSpaces.as" />
     <EmbeddedResource Include="Test Files\generated\as3\BeforeAssignStatementToVarFromNewBitmapDataWithParams_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeAssignStatementToVarFromArrayInitializer_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromArrayInitializer_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromArrayInitializer2_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeAssignStatementToVarFromArrayInitializer2_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeAssignStatementToVarFromNewBitmapDataWithParams_multiline_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromNewBitmapDataWithParams_multiline_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeAssignStatementToVarFromFunctionResult_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromFunctionResult_useSpaces.as" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
@@ -978,6 +978,18 @@ namespace ASCompletion.Completion
                             new TestCaseData(ReadAllTextAS3("BeforeAssignStatementToVarFromMethodChaining2_useSpaces"), GeneratorJobType.AssignStatementToVar, false)
                                 .Returns(ReadAllTextAS3("AfterAssignStatementToVarFromMethodChaining2_useSpaces"))
                                 .SetName("From method chaining 2");
+                        yield return
+                            new TestCaseData(ReadAllTextAS3("BeforeAssignStatementToVarFromNewString_useSpaces"), GeneratorJobType.AssignStatementToVar, false)
+                                .Returns(ReadAllTextAS3("AfterAssignStatementToVarFromNewString_useSpaces"))
+                                .SetName("From new String(\"\")");
+                        yield return
+                            new TestCaseData(ReadAllTextAS3("BeforeAssignStatementToVarFromNewString2_useSpaces"), GeneratorJobType.AssignStatementToVar, false)
+                                .Returns(ReadAllTextAS3("AfterAssignStatementToVarFromNewString2_useSpaces"))
+                                .SetName("From new String(\"\".charAt(0))");
+                        yield return
+                            new TestCaseData(ReadAllTextAS3("BeforeAssignStatementToVarFromNewBitmapDataWithParams_useSpaces"), GeneratorJobType.AssignStatementToVar, false)
+                                .Returns(ReadAllTextAS3("AfterAssignStatementToVarFromNewBitmapDataWithParams_useSpaces"))
+                                .SetName("From new BitmapData(rect.width, rect.height)");
                     }
                 }
 
@@ -1050,6 +1062,11 @@ namespace ASCompletion.Completion
                         return string.IsNullOrEmpty(src) ? null : context.GetCodeModel(src);
                     });
                     ASContext.Context.ResolveType(null, null).ReturnsForAnyArgs(it => context.ResolveType(it.ArgAt<string>(0), it.ArgAt<FileModel>(1)));
+                    ASContext.Context.IsImported(null, Arg.Any<int>()).ReturnsForAnyArgs(it =>
+                    {
+                        var member = it.ArgAt<MemberModel>(0);
+                        return member != null && context.IsImported(member, it.ArgAt<int>(1));
+                    });
                     ASGenerator.contextToken = sci.GetWordFromPosition(sci.CurrentPos);
                     ASGenerator.GenerateJob(job, currentMember, ASContext.Context.CurrentClass, null, null);
                     return sci.Text;

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
@@ -990,6 +990,22 @@ namespace ASCompletion.Completion
                             new TestCaseData(ReadAllTextAS3("BeforeAssignStatementToVarFromNewBitmapDataWithParams_useSpaces"), GeneratorJobType.AssignStatementToVar, false)
                                 .Returns(ReadAllTextAS3("AfterAssignStatementToVarFromNewBitmapDataWithParams_useSpaces"))
                                 .SetName("From new BitmapData(rect.width, rect.height)");
+                        yield return
+                            new TestCaseData(ReadAllTextAS3("BeforeAssignStatementToVarFromNewBitmapDataWithParams_multiline_useSpaces"), GeneratorJobType.AssignStatementToVar, false)
+                                .Returns(ReadAllTextAS3("AfterAssignStatementToVarFromNewBitmapDataWithParams_multiline_useSpaces"))
+                                .SetName("From new BitmapData(rect.width, rect.height). Multiline constructor");
+                        yield return
+                            new TestCaseData(ReadAllTextAS3("BeforeAssignStatementToVarFromArrayInitializer_useSpaces"), GeneratorJobType.AssignStatementToVar, false)
+                                .Returns(ReadAllTextAS3("AfterAssignStatementToVarFromArrayInitializer_useSpaces"))
+                                .SetName("from []");
+                        yield return
+                            new TestCaseData(ReadAllTextAS3("BeforeAssignStatementToVarFromArrayInitializer2_useSpaces"), GeneratorJobType.AssignStatementToVar, false)
+                                .Returns(ReadAllTextAS3("AfterAssignStatementToVarFromArrayInitializer2_useSpaces"))
+                                .SetName("from [rect.width, rect.height]");
+                        yield return
+                            new TestCaseData(ReadAllTextAS3("BeforeAssignStatementToVarFromFunctionResult_useSpaces"), GeneratorJobType.AssignStatementToVar, false)
+                                .Returns(ReadAllTextAS3("AfterAssignStatementToVarFromFunctionResult_useSpaces"))
+                                .SetName("from foo()");
                     }
                 }
 

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
@@ -2167,6 +2167,57 @@ namespace ASCompletion.Completion
                 }
             }
 
+            [TestFixture]
+            public class GetStartOfStatement : GenerateJob
+            {
+                public IEnumerable<TestCaseData> AS3TestCases
+                {
+                    get
+                    {
+                        yield return
+                            new TestCaseData(" new Vector.<int>()$(EntryPoint)")
+                                .Returns(1);
+                        yield return
+                            new TestCaseData(" new <int>[]$(EntryPoint)")
+                                .Returns(1);
+                        yield return
+                            new TestCaseData(" new <Object>[{}]$(EntryPoint)")
+                                .Returns(1);
+                        yield return
+                            new TestCaseData(" new <Vector.<Object>>[new <Object>[{}]]$(EntryPoint)")
+                                .Returns(1);
+                        yield return
+                            new TestCaseData(" new <Object>[{a:[new Number('10.0')]}]$(EntryPoint)")
+                                .Returns(1);
+                        yield return
+                            new TestCaseData(" new Object()$(EntryPoint)")
+                                .Returns(1);
+                    }
+                }
+
+                [Test, TestCaseSource(nameof(AS3TestCases))]
+                public int AS3(string sourceText) => GetStartOfStatementAS3(sourceText, sci);
+
+                internal static int GetStartOfStatementAS3(string sourceText, ScintillaControl sci)
+                {
+                    sci.ConfigurationLanguage = "as3";
+                    ASContext.Context.SetAs3Features();
+                    return Common(sourceText, sci);
+                }
+
+                internal static int Common(string sourceText, ScintillaControl sci)
+                {
+                    var expr = new ASResult
+                    {
+                        Type = new ClassModel {Flags = FlagType.Class},
+                        Context = new ASExpr {WordBefore = "new"}
+                    };
+                    sci.Text = sourceText;
+                    SnippetHelper.PostProcessSnippets(sci, 0);
+                    return ASGenerator.GetStartOfStatement(sci, sci.CurrentPos, expr);
+                }
+            }
+
             protected static void BuildClassPath(AS3Context.Context context)
             {
                 context.BuildClassPath();

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromArrayInitializer2_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromArrayInitializer2_useSpaces.as
@@ -1,0 +1,9 @@
+﻿package {
+	import flash.geom.Rectangle;
+	public class Main {
+		public function Main() {
+			var rect:Rectangle = new Rectangle(1, 1, 0, 0);
+			var h:Array = [rect.width, rect.height];
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromArrayInitializer_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromArrayInitializer_useSpaces.as
@@ -1,0 +1,7 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			var array:Array = []
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromFunctionResult_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromFunctionResult_useSpaces.as
@@ -1,0 +1,9 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			var f:Number = foo()
+		}
+
+		private function foo():Number {return 1;}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromNewBitmapDataWithParams_multiline_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromNewBitmapDataWithParams_multiline_useSpaces.as
@@ -1,0 +1,13 @@
+﻿package {
+	import flash.display.BitmapData;
+	import flash.geom.Rectangle
+	public class Main {
+		public function Main() {
+			var rectangle:Rectangle = new Rectangle(100, 100, 0, 0)
+			var bitmapData:BitmapData = new BitmapData(
+				rectangle.width,
+				rectangle.height
+			);
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromNewBitmapDataWithParams_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromNewBitmapDataWithParams_useSpaces.as
@@ -1,0 +1,10 @@
+﻿package {
+	import flash.display.BitmapData;
+	import flash.geom.Rectangle
+	public class Main {
+		public function Main() {
+			var rectangle:Rectangle = new Rectangle(100, 100, 0, 0)
+			var bitmapData:BitmapData = new BitmapData(rectangle.width, rectangle.height);
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromNewString2_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromNewString2_useSpaces.as
@@ -1,0 +1,7 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			var string:String = new String("".charAt(0))
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromNewString_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromNewString_useSpaces.as
@@ -1,0 +1,7 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			var string:String = new String("")
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromArrayInitializer2_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromArrayInitializer2_useSpaces.as
@@ -1,0 +1,9 @@
+﻿package {
+	import flash.geom.Rectangle;
+	public class Main {
+		public function Main() {
+			var rect:Rectangle = new Rectangle(1, 1, 0, 0);
+			[rect.width, rect.height];$(EntryPoint)
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromArrayInitializer_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromArrayInitializer_useSpaces.as
@@ -1,0 +1,7 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			[]$(EntryPoint)
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromFunctionResult_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromFunctionResult_useSpaces.as
@@ -1,0 +1,9 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			foo()$(EntryPoint)
+		}
+
+		private function foo():Number {return 1;}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromNewBitmapDataWithParams_multiline_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromNewBitmapDataWithParams_multiline_useSpaces.as
@@ -1,0 +1,13 @@
+﻿package {
+	import flash.display.BitmapData;
+	import flash.geom.Rectangle
+	public class Main {
+		public function Main() {
+			var rectangle:Rectangle = new Rectangle(100, 100, 0, 0)
+			new BitmapData(
+				rectangle.width,
+				rectangle.height
+			);$(EntryPoint)
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromNewBitmapDataWithParams_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromNewBitmapDataWithParams_useSpaces.as
@@ -1,0 +1,10 @@
+﻿package {
+	import flash.display.BitmapData;
+	import flash.geom.Rectangle
+	public class Main {
+		public function Main() {
+			var rectangle:Rectangle = new Rectangle(100, 100, 0, 0)
+			new BitmapData(rectangle.width, rectangle.height);$(EntryPoint)
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromNewString2_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromNewString2_useSpaces.as
@@ -1,0 +1,7 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			new String("".charAt(0))$(EntryPoint)
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromNewString_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromNewString_useSpaces.as
@@ -1,0 +1,7 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			new String("")$(EntryPoint)
+		}
+	}
+}


### PR DESCRIPTION
Fixes `new BitmapData(rect.width, rect.height) -> new var bitmapData:BitmapData(rect.width, rect.height)`
Fixes assign statement to local variable from multilime constructor, for example:
```actionscript
new BitmapData(
    rect.width,
    rect.height
) | <<- cursor here
```