### PR TITLE
Assign statement of callback to var local variable

### DIFF
--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -433,6 +433,8 @@
     <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromNewBitmapDataWithParams_multiline_useSpaces.as" />
     <EmbeddedResource Include="Test Files\generated\as3\BeforeAssignStatementToVarFromFunctionResult_useSpaces.as" />
     <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromFunctionResult_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeAssignStatementToVarFromCallback_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromCallback_useSpaces.as" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
@@ -1006,6 +1006,10 @@ namespace ASCompletion.Completion
                             new TestCaseData(ReadAllTextAS3("BeforeAssignStatementToVarFromFunctionResult_useSpaces"), GeneratorJobType.AssignStatementToVar, false)
                                 .Returns(ReadAllTextAS3("AfterAssignStatementToVarFromFunctionResult_useSpaces"))
                                 .SetName("from foo()");
+                        yield return
+                            new TestCaseData(ReadAllTextAS3("BeforeAssignStatementToVarFromCallback_useSpaces"), GeneratorJobType.AssignStatementToVar, false)
+                                .Returns(ReadAllTextAS3("AfterAssignStatementToVarFromCallback_useSpaces"))
+                                .SetName("from callback");
                     }
                 }
 

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromCallback_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromCallback_useSpaces.as
@@ -1,7 +1,7 @@
 ﻿package {
 	public class Main {
 		public function Main() {
-			var foo1:Function = foo
+			var f:Function = foo
 		}
 
 		private function foo():Number {return 1;}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromCallback_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromCallback_useSpaces.as
@@ -1,0 +1,9 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			var foo1:Function = foo
+		}
+
+		private function foo():Number {return 1;}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromCallback_useSpaces.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromCallback_useSpaces.as
@@ -1,0 +1,9 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			foo$(EntryPoint)
+		}
+
+		private function foo():Number {return 1;}
+	}
+}


### PR DESCRIPTION
Before fix:
```actionscript
function test() {
  foo | <-- cursor here
}
function foo():Number {return 1;}
```
Result
```actionscript
function test() {
  var f:Function = foo
}
function foo():Number {return 1;}
```
Actual for the current release