### PR TITLE
Fixed generation and override of functions with type parameters.

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -4096,6 +4096,7 @@ namespace ASCompletion.Completion
                         if (!rType.IsVoid()) type = rType.Name;
                     }
                 }
+                newMember.Template = member.Template;
                 newMember.Type = type;
                 // fix parameters if needed
                 if (member.Parameters != null)

--- a/External/Plugins/ASCompletion/Completion/TemplateUtils.cs
+++ b/External/Plugins/ASCompletion/Completion/TemplateUtils.cs
@@ -75,7 +75,7 @@ namespace ASCompletion.Completion
         {
             // Insert Name
             if (m.Name != null)
-                template = ReplaceTemplateVariable(template, "Name", m.Name);
+                template = ReplaceTemplateVariable(template, "Name", m.FullName);
             else
                 template = ReplaceTemplateVariable(template, "Name", null);
 

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -435,6 +435,8 @@
     <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromFunctionResult_useSpaces.as" />
     <EmbeddedResource Include="Test Files\generated\as3\BeforeAssignStatementToVarFromCallback_useSpaces.as" />
     <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromCallback_useSpaces.as" />
+    <EmbeddedResource Include="Test Files\generated\haxe\AfterOverrideFunctionWithTypeParams.hx" />
+    <EmbeddedResource Include="Test Files\generated\haxe\BeforeOverrideFunctionWithTypeParams.hx" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
@@ -426,6 +426,14 @@ namespace ASCompletion.Completion
                                     Value = "1"
                                 }
                             }
+                        },
+                        new MemberModel("testMethodWithTypeParams", "Float", FlagType.Function, Visibility.Public)
+                        {
+                            Template = "<K:IOtherInterface>",
+                            Parameters = new List<MemberModel>
+                            {
+                                new MemberModel("arg", "K", FlagType.Variable, Visibility.Default)
+                            }
                         }
                     });
 
@@ -1696,6 +1704,10 @@ namespace ASCompletion.Completion
                             new TestCaseData(ReadAllTextHaxe("BeforeOverridePrivateFunction"), "Foo", "foo", FlagType.Function)
                                 .Returns(ReadAllTextHaxe("AfterOverridePrivateFunction"))
                                 .SetName("Override private function");
+                        yield return
+                            new TestCaseData(ReadAllTextHaxe("BeforeOverrideFunctionWithTypeParams"), "Foo", "foo", FlagType.Function)
+                                .Returns(ReadAllTextHaxe("AfterOverrideFunctionWithTypeParams"))
+                                .SetName("Override function with type parameters");
                     }
                 }
 

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterOverrideFunctionWithTypeParams.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterOverrideFunctionWithTypeParams.hx
@@ -1,0 +1,11 @@
+﻿﻿package;
+class Foo {
+	public function new() {}
+	public function foo<K:ISomething, V:(Iterable<String>, Measurable)>(arg1:K, arg2:V):K {}
+}
+
+class Bar extends Foo {
+	public override function foo<K:ISomething,V:(Iterable<String>,Measurable)>(arg1:K, arg2:V):K {
+		return super.foo(arg1, arg2);
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterOverrideFunctionWithTypeParams.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/AfterOverrideFunctionWithTypeParams.hx
@@ -1,4 +1,4 @@
-﻿﻿package;
+﻿package;
 class Foo {
 	public function new() {}
 	public function foo<K:ISomething, V:(Iterable<String>, Measurable)>(arg1:K, arg2:V):K {}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeOverrideFunctionWithTypeParams.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/BeforeOverrideFunctionWithTypeParams.hx
@@ -1,0 +1,9 @@
+﻿package;
+class Foo {
+	public function new() {}
+	public function foo<K:ISomething, V:(Iterable<String>, Measurable)>(arg1:K, arg2:V):K {}
+}
+
+class Bar extends Foo {
+	override $(EntryPoint)foo
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/ImplementInterfaceNoMembers.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/haxe/ImplementInterfaceNoMembers.hx
@@ -37,4 +37,8 @@ class ImplementTest{
 	function testPrivateMethod(?arg:String, ?arg2:Int = 1):Float {
 		
 	}
+	
+	public function testMethodWithTypeParams<K:IOtherInterface>(arg:K):Float {
+		
+	}
 }


### PR DESCRIPTION
Import of types used in constraints and spaces between params may be removed, but it's not considered as important right now.

@SlavaRa  Any concern with this?