### PR TITLE
Fixes "Object reference not set to an instance of an object."

### DIFF
--- a/External/Plugins/CodeRefactor/Provider/RefactoringHelper.cs
+++ b/External/Plugins/CodeRefactor/Provider/RefactoringHelper.cs
@@ -374,7 +374,7 @@ namespace CodeRefactor.Provider
                 return null;
             }
             // if the target we are trying to rename exists as a local variable or a function parameter we only need to search the current file
-            var currentFileOnly = member != null && (member.Access == Visibility.Private && !member.InFile.haXe || (member.Flags & (FlagType.LocalVar | FlagType.ParameterVar)) > 0)
+            var currentFileOnly = member != null && (member.Access == Visibility.Private && !target.InFile.haXe || (member.Flags & (FlagType.LocalVar | FlagType.ParameterVar)) > 0)
                                || member == null && (type.Access == Visibility.Private && !type.InFile.haXe || new SemVer(PluginBase.CurrentSDK.Version).IsOlderThan(new SemVer("4.0.0")));
             FRConfiguration config;
             IProject project = PluginBase.CurrentProject;


### PR DESCRIPTION
```
at CodeRefactor.Provider.RefactoringHelper.FindTargetInFiles(ASResult target, FRProgressReportHandler progressReportHandler, FRFinishedHandler findFinishedHandler, Boolean asynchronous, Boolean onlySourceFiles, Boolean ignoreSdkFiles, Boolean includeComments, Boolean includeStrings)
   at CodeRefactor.Commands.FindAllReferences.ExecutionImplementation()
   at CodeRefactor.Commands.Rename.ExecutionImplementation()
   at CodeRefactor.Provider.RenamingHelper.ExecuteFirst()
```

I will do tests for this helper next week. Today I checked all renames manually