### PR TITLE
Fixed exception: "Length cannot be less than zero. Parameter name: length"

### DIFF
--- a/PluginCore/PluginCore/Controls/CompletionList.cs
+++ b/PluginCore/PluginCore/Controls/CompletionList.cs
@@ -885,9 +885,10 @@ namespace PluginCore.Controls
             switch (key)
             {
                 case Keys.Back:
-                    if (word.Length >= MinWordLength)
+                    var wordLength = word.Length;
+                    if (wordLength > 0 && wordLength >= MinWordLength)
                     {
-                        word = word.Substring(0, word.Length - 1);
+                        word = word.Substring(0, wordLength - 1);
                         currentPos = sci.CurrentPos - 1;
                         lastIndex = 0;
                         FindWordStartingWith(word);


### PR DESCRIPTION
```
   at System.String.InternalSubStringWithChecks(Int32 startIndex, Int32 length, Boolean fAlwaysCopy)
   at System.String.Substring(Int32 startIndex, Int32 length)
   at PluginCore.Controls.CompletionList.HandleKeys(ScintillaControl sci, Keys key) in C:\projects\flashdevelop\PluginCore\PluginCore\Controls\CompletionList.cs:line 890
   at PluginCore.Controls.UITools.HandleKeys(Keys key) in C:\projects\flashdevelop\PluginCore\PluginCore\Controls\UITools.cs:line 441
   at PluginCore.Controls.UITools.HandleEvent(Object sender, NotifyEvent e, HandlingPriority priority) in C:\projects\flashdevelop\PluginCore\PluginCore\Controls\UITools.cs:line 138
   at PluginCore.Managers.EventManager.DispatchEvent(Object sender, NotifyEvent e) in C:\projects\flashdevelop\PluginCore\PluginCore\Managers\EventManager.cs:line 141
```
![completionlist_fix_crash_after_press_backspace](https://cloud.githubusercontent.com/assets/1700940/24587014/84d53b5e-17b6-11e7-8610-fa14290ae704.gif)
