### PR TITLE
Small fixes

### DIFF
--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -997,7 +997,7 @@ namespace ScintillaNet
         {
             get
             {
-                return SPerform(2027, 0, 0);
+                return SPerform(2027, 0, 0) - 1; //ignore the terminating null character
             }
         }
 
@@ -3190,10 +3190,9 @@ namespace ScintillaNet
         /// </summary>
         unsafe public string GetCurLine(int length)
         {
-            int sz = SPerform(2027, length, 0);
-            byte[] buffer = new byte[sz + 1];
+            byte[] buffer = new byte[length + 1];
             fixed (byte* b = buffer) SPerform(2027, length + 1, (uint)b);
-            return Encoding.GetEncoding(this.CodePage).GetString(buffer, 0, sz - 1);
+            return Encoding.GetEncoding(this.CodePage).GetString(buffer, 0, length);
         }
 
         /// <summary>

--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -3190,6 +3190,7 @@ namespace ScintillaNet
         /// </summary>
         unsafe public string GetCurLine(int length)
         {
+            length = Math.Min(length, SPerform(2027, 0, 0) - 1);
             byte[] buffer = new byte[length + 1];
             fixed (byte* b = buffer) SPerform(2027, length + 1, (uint)b);
             return Encoding.GetEncoding(this.CodePage).GetString(buffer, 0, length);

--- a/Tests/External/Plugins/CodeRefactor.Tests/Commands/CodeRefactorTests.cs
+++ b/Tests/External/Plugins/CodeRefactor.Tests/Commands/CodeRefactorTests.cs
@@ -212,7 +212,7 @@ namespace CodeRefactor.Commands
                     sci.Text = sourceText;
                     SnippetHelper.PostProcessSnippets(sci, 0);
                     ASContext.Context.CurrentMember.Returns(currentMember);
-                    CommandFactoryProvider.GetFactoryFromLanguage(sci.ConfigurationLanguage)
+                    CommandFactoryProvider.GetFactory(sci.ConfigurationLanguage)
                         .CreateExtractLocalVariableCommand(false, newName)
                         .Execute();
                     return sci.Text;
@@ -263,7 +263,7 @@ namespace CodeRefactor.Commands
                     Sci.Text = sourceText;
                     Sci.ConfigurationLanguage = "haxe";
                     SnippetHelper.PostProcessSnippets(Sci, 0);
-                    var command = (ExtractLocalVariableCommand)CommandFactoryProvider.GetFactoryFromLanguage("haxe").CreateExtractLocalVariableCommand(false, newName);
+                    var command = (ExtractLocalVariableCommand)CommandFactoryProvider.GetFactory("haxe").CreateExtractLocalVariableCommand(false, newName);
                     command.Execute();
                     ((CompletionListItem)command.CompletionList[contextualGeneratorItem]).PerformClick();
                     return Sci.Text;


### PR DESCRIPTION
Fix ScintillaControl.CurLineSize and GetCurLine()
Change CommandFactoryProvider.GetFactoryFromLanguage to GetFactory in
CodeRefactorTests.cs

Required for #1519