### PR TITLE
SetVersion: Path.DirectorySeparatorChar instead of hardcoded backslash

### DIFF
--- a/External/Tools/SetVersion/Program.cs
+++ b/External/Tools/SetVersion/Program.cs
@@ -26,7 +26,6 @@ namespace SetVersion
                 return;
             }
             var head = File.ReadAllText(Path.Combine(git, "HEAD")).Trim();
-            Console.WriteLine(head);
             var headRef = Regex.Match(head, "ref: refs/heads/(.*)");
             if (!headRef.Success)
             {

--- a/External/Tools/SetVersion/Program.cs
+++ b/External/Tools/SetVersion/Program.cs
@@ -26,6 +26,7 @@ namespace SetVersion
                 return;
             }
             var head = File.ReadAllText(Path.Combine(git, "HEAD")).Trim();
+            Console.WriteLine(head);
             var headRef = Regex.Match(head, "ref: refs/heads/(.*)");
             if (!headRef.Success)
             {
@@ -38,7 +39,7 @@ namespace SetVersion
                 return;
             }
             branch = headRef.Groups[1].Value;
-            var refPath = Path.Combine(Path.Combine(git, "refs\\heads"), branch);
+            var refPath = Path.Combine(Path.Combine(git, "refs" + Path.DirectorySeparatorChar + "heads"), branch);
             if (!File.Exists(refPath))
             {
                 Console.WriteLine("SetVersion: Can not read ref commit hash.");

--- a/External/Tools/SetVersion/Program.cs
+++ b/External/Tools/SetVersion/Program.cs
@@ -38,7 +38,7 @@ namespace SetVersion
                 return;
             }
             branch = headRef.Groups[1].Value;
-            var refPath = Path.Combine(Path.Combine(git, "refs" + Path.DirectorySeparatorChar + "heads"), branch);
+            var refPath = Path.Combine(Path.Combine(git, Path.Combine("refs", "heads")), branch);
             if (!File.Exists(refPath))
             {
                 Console.WriteLine("SetVersion: Can not read ref commit hash.");


### PR DESCRIPTION
Should i also commit compiled SetVersion.exe?