### PR TITLE
Extra options for AddClosingBraces

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -449,11 +449,20 @@ namespace ASCompletion.Completion
                 if (!(IsStringStyle(styleBefore) && IsStringStyle(styleAfter)) && !(IsCharStyle(styleBefore) && IsCharStyle(styleAfter))
                     || IsInterpolationExpr(sci, sci.CurrentPos - 1))
                 {
+                    char nextChar = sci.CurrentChar;
+                    int nextPos = sci.CurrentPos;
+
+                    while (nextChar == ' ' || nextChar == '\t') // Don't skip new line characters
+                    {
+                        nextPos++;
+                        nextChar = (char) sci.CharAt(nextPos);
+                    }
+
                     foreach (var brace in ASContext.CommonSettings.AddClosingBracesRules)
                     {
                         // Handle opening first for braces that have equal opening & closing chars
-                        if (HandleAddOpeningBrace(sci, c, brace, styleAfter, styleBefore)
-                            || HandleAddClosingBrace(sci, c, brace))
+                        if (HandleBraceOpen(sci, brace, c, styleAfter, styleBefore)
+                            || HandleBraceClose(sci, brace, c, nextChar, nextPos))
                         {
                             undo = false;
                             break;
@@ -462,9 +471,18 @@ namespace ASCompletion.Completion
                 }
                 else if (IsMatchingQuote(c, styleAfter))
                 {
+                    char nextChar = sci.CurrentChar;
+                    int nextPos = sci.CurrentPos;
+
+                    while (nextChar == ' ' || nextChar == '\t') // Don't skip new line characters
+                    {
+                        nextPos++;
+                        nextChar = (char) sci.CharAt(nextPos);
+                    }
+
                     foreach (var brace in ASContext.CommonSettings.AddClosingBracesRules)
                     {
-                        if (HandleAddClosingBrace(sci, c, brace))
+                        if (HandleBraceClose(sci, brace, c, nextChar, nextPos))
                         {
                             undo = false;
                             break;
@@ -502,7 +520,7 @@ namespace ASCompletion.Completion
 
                     foreach (var brace in ASContext.CommonSettings.AddClosingBracesRules)
                     {
-                        if (HandleRemoveBrace(sci, open, c, closePos, brace))
+                        if (HandleBraceRemove(sci, brace, open, c, closePos))
                         {
                             break;
                         }
@@ -511,16 +529,16 @@ namespace ASCompletion.Completion
             }
         }
 
-        private static bool HandleAddOpeningBrace(ScintillaControl sci, char c, Brace braces, byte styleAfter, byte styleBefore)
+        private static bool HandleBraceOpen(ScintillaControl sci, Brace brace, char open, byte styleAfter, byte styleBefore)
         {
-            if (c == braces.Open)
+            if (open == brace.Open)
             {
                 char charAfter = (char) sci.CharAt(sci.CurrentPos);
                 char charBefore = (char) sci.CharAt(sci.CurrentPos - 2);
 
-                if (braces.ShouldAutoClose(charBefore, styleBefore, charAfter, styleAfter))
+                if (brace.ShouldOpen(charBefore, styleBefore, charAfter, styleAfter))
                 {
-                    sci.InsertText(-1, braces.Close.ToString());
+                    sci.InsertText(-1, brace.Close.ToString());
                     return true;
                 }
             }
@@ -528,24 +546,32 @@ namespace ASCompletion.Completion
             return false;
         }
 
-        private static bool HandleAddClosingBrace(ScintillaControl sci, char c, Brace braces)
+        private static bool HandleBraceClose(ScintillaControl sci, Brace brace, char close, char next, int nextPosition)
         {
-            if (c == braces.Close && c == sci.CurrentChar)
+            if (close == brace.Close && next == brace.Close)
             {
-                sci.DeleteForward();
-                return true;
+                if (brace.ShouldClose(sci.CurrentPos, nextPosition))
+                {
+                    sci.DeleteBack();
+                    sci.AnchorPosition = nextPosition;
+                    sci.CurrentPos = nextPosition;
+                    return true;
+                }
             }
 
             return false;
         }
         
-        private static bool HandleRemoveBrace(ScintillaControl sci, char open, char close, int closePosition, Brace braces)
+        private static bool HandleBraceRemove(ScintillaControl sci, Brace brace, char open, char close, int closePosition)
         {
-            if (open == braces.Open && close == braces.Close)
+            if (open == brace.Open && close == brace.Close)
             {
-                sci.SelectionEnd = closePosition + 1;
-                sci.DeleteBack();
-                return true;
+                if (brace.ShouldRemove(sci.CurrentPos, closePosition))
+                {
+                    sci.SelectionEnd = closePosition + 1;
+                    sci.DeleteBack();
+                    return true;
+                }
             }
 
             return false;

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -539,6 +539,10 @@ namespace ASCompletion.Completion
                 if (brace.ShouldOpen(charBefore, styleBefore, charAfter, styleAfter))
                 {
                     sci.InsertText(-1, brace.Close.ToString());
+                    if (brace.AddSpace)
+                    {
+                        sci.AddText(1, " ");
+                    }
                     return true;
                 }
             }

--- a/External/Plugins/ASCompletion/Completion/Brace.cs
+++ b/External/Plugins/ASCompletion/Completion/Brace.cs
@@ -12,6 +12,7 @@ namespace ASCompletion.Completion
         private string name;
         private char open;
         private char close;
+        private bool addSpace;
         private bool ignoreWhitespace;
         private Rule[] rules;
 
@@ -33,6 +34,12 @@ namespace ASCompletion.Completion
             set { close = value; }
         }
 
+        public bool AddSpace
+        {
+            get { return addSpace; }
+            set { addSpace = value; }
+        }
+
         public bool IgnoreWhitespace
         {
             get { return ignoreWhitespace; }
@@ -48,11 +55,12 @@ namespace ASCompletion.Completion
         /// <summary>
         /// Creates an instance of <see cref="Brace"/>.
         /// </summary>
-        public Brace(string name, char open, char close, bool ignoreWhitespace, Rule[] rules)
+        public Brace(string name, char open, char close, bool addSpace, bool ignoreWhitespace, Rule[] rules)
         {
             Name = name;
             Open = open;
             Close = close;
+            AddSpace = addSpace;
             IgnoreWhitespace = ignoreWhitespace;
             Rules = rules;
         }

--- a/External/Plugins/ASCompletion/Completion/Brace.cs
+++ b/External/Plugins/ASCompletion/Completion/Brace.cs
@@ -12,6 +12,7 @@ namespace ASCompletion.Completion
         private string name;
         private char open;
         private char close;
+        private bool ignoreWhitespace;
         private Rule[] rules;
 
         public string Name
@@ -32,6 +33,12 @@ namespace ASCompletion.Completion
             set { close = value; }
         }
 
+        public bool IgnoreWhitespace
+        {
+            get { return ignoreWhitespace; }
+            set { ignoreWhitespace = value; }
+        }
+
         public Rule[] Rules
         {
             get { return rules; }
@@ -41,18 +48,19 @@ namespace ASCompletion.Completion
         /// <summary>
         /// Creates an instance of <see cref="Brace"/>.
         /// </summary>
-        public Brace(string name, char open, char close, Rule[] rules)
+        public Brace(string name, char open, char close, bool ignoreWhitespace, Rule[] rules)
         {
             Name = name;
             Open = open;
             Close = close;
+            IgnoreWhitespace = ignoreWhitespace;
             Rules = rules;
         }
         
         /// <summary>
-        /// Returns whether this brace should close for the specified condition.
+        /// Returns whether this brace should open with the matching close brace automatically inserted.
         /// </summary>
-        public bool ShouldAutoClose(char charBefore, byte styleBefore, char charAfter, byte styleAfter)
+        public bool ShouldOpen(char charBefore, byte styleBefore, char charAfter, byte styleAfter)
         {
             for (int i = 0; i < rules.Length; i++)
             {
@@ -62,6 +70,22 @@ namespace ASCompletion.Completion
                 }
             }
             return false;
+        }
+
+        /// <summary>
+        /// Returns whether this brace should close with the matching close brace overwritten.
+        /// </summary>
+        public bool ShouldClose(int currentPosition, int nextPosition)
+        {
+            return ignoreWhitespace || currentPosition == nextPosition;
+        }
+
+        /// <summary>
+        /// Returns whether this brace should remove the matching close brace.
+        /// </summary>
+        public bool ShouldRemove(int currentPosition, int nextPosition)
+        {
+            return ignoreWhitespace || currentPosition == nextPosition;
         }
 
         /// <summary>

--- a/External/Plugins/ASCompletion/Controls/AddClosingBracesRulesEditorForm.cs
+++ b/External/Plugins/ASCompletion/Controls/AddClosingBracesRulesEditorForm.cs
@@ -18,6 +18,7 @@ namespace ASCompletion.Controls
         private TextBox txtName;
         private TextBox txtOpenChar;
         private TextBox txtCloseChar;
+        private CheckBox cbxIgnoreWhitespace;
         private DataGridView rulesGridView;
         private DataGridViewCheckBoxColumn not1;
         private DataGridViewRegexColumn afterChars;
@@ -65,6 +66,7 @@ namespace ASCompletion.Controls
             txtOpenChar = new TextBox();
             var lblCloseChar = new Label();
             txtCloseChar = new TextBox();
+            cbxIgnoreWhitespace = new CheckBox();
             rulesGridView = new DataGridView();
             not1 = new DataGridViewCheckBoxColumn();
             afterChars = new DataGridViewRegexColumn();
@@ -104,29 +106,29 @@ namespace ASCompletion.Controls
             lblName.AutoSize = true;
             lblName.Location = new Point(207, 15);
             lblName.Name = "lblName";
-            lblName.Size = new Size(53, 17);
-            lblName.Text = "Name: ";
+            lblName.Size = new Size(49, 17);
+            lblName.Text = "Name:";
             // 
             // txtName
             // 
-            txtName.Location = new Point(266, 12);
+            txtName.Location = new Point(262, 12);
             txtName.MaxLength = 32;
             txtName.Name = "txtName";
-            txtName.Size = new Size(200, 22);
+            txtName.Size = new Size(156, 22);
             txtName.TabIndex = 1;
             txtName.TextChanged += TxtName_TextChanged;
             // 
             // lblOpenChar
             // 
             lblOpenChar.AutoSize = true;
-            lblOpenChar.Location = new Point(472, 15);
+            lblOpenChar.Location = new Point(424, 15);
             lblOpenChar.Name = "lblOpenChar";
-            lblOpenChar.Size = new Size(51, 17);
-            lblOpenChar.Text = "Open: ";
+            lblOpenChar.Size = new Size(47, 17);
+            lblOpenChar.Text = "Open:";
             // 
             // txtOpenChar
             // 
-            txtOpenChar.Location = new Point(529, 12);
+            txtOpenChar.Location = new Point(477, 12);
             txtOpenChar.MaxLength = 1;
             txtOpenChar.Name = "txtOpenChar";
             txtOpenChar.Size = new Size(30, 22);
@@ -137,20 +139,32 @@ namespace ASCompletion.Controls
             // lblCloseChar
             // 
             lblCloseChar.AutoSize = true;
-            lblCloseChar.Location = new Point(565, 15);
+            lblCloseChar.Location = new Point(513, 15);
             lblCloseChar.Name = "lblCloseChar";
-            lblCloseChar.Size = new Size(51, 17);
-            lblCloseChar.Text = "Close: ";
+            lblCloseChar.Size = new Size(47, 17);
+            lblCloseChar.Text = "Close:";
             // 
             // txtCloseChar
             // 
-            txtCloseChar.Location = new Point(622, 12);
+            txtCloseChar.Location = new Point(566, 12);
             txtCloseChar.MaxLength = 1;
             txtCloseChar.Name = "txtCloseChar";
             txtCloseChar.Size = new Size(30, 22);
             txtCloseChar.TabIndex = 3;
             txtCloseChar.TextAlign = HorizontalAlignment.Center;
             txtCloseChar.TextChanged += TxtCloseChar_TextChanged;
+            // 
+            // cbxIgnoreWhitespace
+            // 
+            cbxIgnoreWhitespace.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            cbxIgnoreWhitespace.AutoSize = true;
+            cbxIgnoreWhitespace.Location = new Point(822, 12);
+            cbxIgnoreWhitespace.Name = "cbxIgnoreWhitespace";
+            cbxIgnoreWhitespace.Size = new Size(148, 21);
+            cbxIgnoreWhitespace.TabIndex = 12;
+            cbxIgnoreWhitespace.Text = "Ignore Whitespace";
+            cbxIgnoreWhitespace.TextAlign = ContentAlignment.MiddleRight;
+            cbxIgnoreWhitespace.CheckedChanged += CbxIgnoreWhitespace_CheckedChanged;
             // 
             // rulesGridView
             // 
@@ -360,6 +374,7 @@ namespace ASCompletion.Controls
             Controls.Add(btnDown);
             Controls.Add(btnUp);
             Controls.Add(rulesGridView);
+            Controls.Add(cbxIgnoreWhitespace);
             Controls.Add(txtCloseChar);
             Controls.Add(lblCloseChar);
             Controls.Add(txtOpenChar);
@@ -387,10 +402,14 @@ namespace ASCompletion.Controls
             btnUp.Image = PluginBase.MainForm.FindImage16("74", false);
             btnDown.Image = PluginBase.MainForm.FindImage16("60", false);
             btnAddRule.Image = PluginBase.MainForm.FindImage16("550", false);
+
+            btnAddRule.Width = ScaleHelper.Scale(btnAddRule.Width);
         }
 
         private void InitializeFonts()
         {
+            Font = PluginBase.Settings.DefaultFont;
+
             afterChars.DefaultCellStyle.Font = PluginBase.Settings.ConsoleFont;
             beforeChars.DefaultCellStyle.Font = PluginBase.Settings.ConsoleFont;
             txtOpenChar.Font = PluginBase.Settings.ConsoleFont;
@@ -451,17 +470,19 @@ namespace ASCompletion.Controls
             get { return braces; }
         }
 
-        private void ShowRules()
+        private void ShowBraceProperties()
         {
             txtName.TextChanged -= TxtName_TextChanged;
             txtOpenChar.TextChanged -= TxtOpenChar_TextChanged;
             txtCloseChar.TextChanged -= TxtCloseChar_TextChanged;
+            cbxIgnoreWhitespace.CheckedChanged -= CbxIgnoreWhitespace_CheckedChanged;
 
             if (inEdit == null)
             {
                 txtName.Text = "";
                 txtOpenChar.Text = "";
                 txtCloseChar.Text = "";
+                cbxIgnoreWhitespace.Checked = false;
 
                 rulesGridView.Rows.Clear();
             }
@@ -470,6 +491,7 @@ namespace ASCompletion.Controls
                 txtName.Text = inEdit.Name;
                 txtOpenChar.Text = inEdit.Open == '\0' ? "" : inEdit.Open.ToString();
                 txtCloseChar.Text = inEdit.Close == '\0' ? "" : inEdit.Close.ToString();
+                cbxIgnoreWhitespace.Checked = inEdit.IgnoreWhitespace;
 
                 rulesGridView.Rows.Clear();
                 foreach (var rule in inEdit.Rules)
@@ -483,6 +505,7 @@ namespace ASCompletion.Controls
             txtName.TextChanged += TxtName_TextChanged;
             txtOpenChar.TextChanged += TxtOpenChar_TextChanged;
             txtCloseChar.TextChanged += TxtCloseChar_TextChanged;
+            cbxIgnoreWhitespace.CheckedChanged += CbxIgnoreWhitespace_CheckedChanged;
         }
 
         private object[] CreateRow(Brace.Rule rule)
@@ -518,6 +541,7 @@ namespace ASCompletion.Controls
                 txtName.Enabled = false;
                 txtOpenChar.Enabled = false;
                 txtCloseChar.Enabled = false;
+                cbxIgnoreWhitespace.Enabled = false;
                 btnUp.Enabled = false;
                 btnDown.Enabled = false;
                 btnRemove.Enabled = false;
@@ -529,6 +553,7 @@ namespace ASCompletion.Controls
                 txtName.Enabled = true;
                 txtOpenChar.Enabled = true;
                 txtCloseChar.Enabled = true;
+                cbxIgnoreWhitespace.Enabled = true;
                 btnUp.Enabled = listBox.SelectedIndex > 0;
                 btnDown.Enabled = listBox.SelectedIndex < listBox.Items.Count - 1;
                 btnRemove.Enabled = true;
@@ -537,7 +562,7 @@ namespace ASCompletion.Controls
             }
 
             inEdit = (BraceInEdit) listBox.SelectedItem;
-            ShowRules();
+            ShowBraceProperties();
         }
 
         private void TxtName_TextChanged(object sender, EventArgs e)
@@ -572,6 +597,11 @@ namespace ASCompletion.Controls
             InvalidateListBox();
         }
 
+        private void CbxIgnoreWhitespace_CheckedChanged(object sender, EventArgs e)
+        {
+            inEdit.IgnoreWhitespace = cbxIgnoreWhitespace.Checked;
+        }
+
         private void BtnUp_Click(object sender, EventArgs e)
         {
             int index = listBox.SelectedIndex - 1;
@@ -587,7 +617,7 @@ namespace ASCompletion.Controls
         {
             int index = listBox.SelectedIndex + 1;
             object itemBelow = listBox.Items[index];
-            listBox.Items.RemoveAt(index );
+            listBox.Items.RemoveAt(index);
             listBox.Items.Insert(index - 1, itemBelow);
             btnDown.Enabled = index < listBox.Items.Count - 1;
             btnUp.Enabled = true;
@@ -629,7 +659,7 @@ namespace ASCompletion.Controls
             {
                 if (braceInEdit.Open != '\0' && braceInEdit.Close != '\0' && braceInEdit.Rules.Count > 0)
                 {
-                    braces[count++] = new Brace(braceInEdit.Name, braceInEdit.Open, braceInEdit.Close, braceInEdit.Rules.ToArray());
+                    braces[count++] = braceInEdit.ToBrace();
                 }
             }
 
@@ -782,6 +812,7 @@ namespace ASCompletion.Controls
             public string Name;
             public char Open;
             public char Close;
+            public bool IgnoreWhitespace;
             public List<Brace.Rule> Rules;
 
             public BraceInEdit()
@@ -789,6 +820,7 @@ namespace ASCompletion.Controls
                 Name = "";
                 Open = '\0';
                 Close = '\0';
+                IgnoreWhitespace = false;
                 Rules = new List<Brace.Rule>();
             }
 
@@ -797,11 +829,17 @@ namespace ASCompletion.Controls
                 Name = value.Name;
                 Open = value.Open;
                 Close = value.Close;
+                IgnoreWhitespace = value.IgnoreWhitespace;
                 Rules = new List<Brace.Rule>(value.Rules.Length);
                 foreach (var rule in value.Rules)
                 {
                     Rules.Add(rule.Clone());
                 }
+            }
+
+            public Brace ToBrace()
+            {
+                return new Brace(Name, Open, Close, IgnoreWhitespace, Rules.ToArray());
             }
 
             public override string ToString()

--- a/External/Plugins/ASCompletion/Controls/AddClosingBracesRulesEditorForm.cs
+++ b/External/Plugins/ASCompletion/Controls/AddClosingBracesRulesEditorForm.cs
@@ -18,6 +18,7 @@ namespace ASCompletion.Controls
         private TextBox txtName;
         private TextBox txtOpenChar;
         private TextBox txtCloseChar;
+        private CheckBox cbxAddSpace;
         private CheckBox cbxIgnoreWhitespace;
         private DataGridView rulesGridView;
         private DataGridViewCheckBoxColumn not1;
@@ -66,6 +67,7 @@ namespace ASCompletion.Controls
             txtOpenChar = new TextBox();
             var lblCloseChar = new Label();
             txtCloseChar = new TextBox();
+            cbxAddSpace = new CheckBox();
             cbxIgnoreWhitespace = new CheckBox();
             rulesGridView = new DataGridView();
             not1 = new DataGridViewCheckBoxColumn();
@@ -154,6 +156,18 @@ namespace ASCompletion.Controls
             txtCloseChar.TextAlign = HorizontalAlignment.Center;
             txtCloseChar.TextChanged += TxtCloseChar_TextChanged;
             // 
+            // cbxAddSpace
+            // 
+            cbxAddSpace.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            cbxAddSpace.AutoSize = true;
+            cbxAddSpace.Location = new Point(717, 12);
+            cbxAddSpace.Name = "cbxAddSpace";
+            cbxAddSpace.Size = new Size(99, 21);
+            cbxAddSpace.TabIndex = 4;
+            cbxAddSpace.Text = "Add Space";
+            cbxAddSpace.TextAlign = ContentAlignment.MiddleRight;
+            cbxAddSpace.CheckedChanged += CbxAddSpace_CheckedChanged;
+            // 
             // cbxIgnoreWhitespace
             // 
             cbxIgnoreWhitespace.Anchor = AnchorStyles.Top | AnchorStyles.Right;
@@ -161,7 +175,7 @@ namespace ASCompletion.Controls
             cbxIgnoreWhitespace.Location = new Point(822, 12);
             cbxIgnoreWhitespace.Name = "cbxIgnoreWhitespace";
             cbxIgnoreWhitespace.Size = new Size(148, 21);
-            cbxIgnoreWhitespace.TabIndex = 12;
+            cbxIgnoreWhitespace.TabIndex = 5;
             cbxIgnoreWhitespace.Text = "Ignore Whitespace";
             cbxIgnoreWhitespace.TextAlign = ContentAlignment.MiddleRight;
             cbxIgnoreWhitespace.CheckedChanged += CbxIgnoreWhitespace_CheckedChanged;
@@ -195,7 +209,7 @@ namespace ASCompletion.Controls
             rulesGridView.RowTemplate.Height = 24;
             rulesGridView.ScrollBars = ScrollBars.Vertical;
             rulesGridView.Size = new Size(760, 265);
-            rulesGridView.TabIndex = 4;
+            rulesGridView.TabIndex = 6;
             rulesGridView.CellContentClick += RulesGridView_CellContentClick;
             rulesGridView.CellEndEdit += RulesGridView_CellEndEdit;
             rulesGridView.CellValueChanged += RulesGridView_CellValueChanged;
@@ -289,7 +303,7 @@ namespace ASCompletion.Controls
             btnUp.Location = new Point(174, 42);
             btnUp.Name = "btnUp";
             btnUp.Size = new Size(30, 30);
-            btnUp.TabIndex = 5;
+            btnUp.TabIndex = 7;
             btnUp.UseVisualStyleBackColor = true;
             btnUp.Click += BtnUp_Click;
             // 
@@ -298,7 +312,7 @@ namespace ASCompletion.Controls
             btnDown.Location = new Point(174, 78);
             btnDown.Name = "btnDown";
             btnDown.Size = new Size(30, 30);
-            btnDown.TabIndex = 6;
+            btnDown.TabIndex = 8;
             btnDown.UseVisualStyleBackColor = true;
             btnDown.Click += BtnDown_Click;
             // 
@@ -308,7 +322,7 @@ namespace ASCompletion.Controls
             btnAdd.Location = new Point(12, 261);
             btnAdd.Name = "btnAdd";
             btnAdd.Size = new Size(75, 30);
-            btnAdd.TabIndex = 7;
+            btnAdd.TabIndex = 9;
             btnAdd.Text = "Add";
             btnAdd.UseVisualStyleBackColor = true;
             btnAdd.Click += BtnAdd_Click;
@@ -319,7 +333,7 @@ namespace ASCompletion.Controls
             btnRemove.Location = new Point(93, 261);
             btnRemove.Name = "btnRemove";
             btnRemove.Size = new Size(75, 30);
-            btnRemove.TabIndex = 8;
+            btnRemove.TabIndex = 10;
             btnRemove.Text = "Remove";
             btnRemove.UseVisualStyleBackColor = true;
             btnRemove.Click += BtnRemove_Click;
@@ -330,7 +344,7 @@ namespace ASCompletion.Controls
             btnAddRule.Location = new Point(210, 311);
             btnAddRule.Name = "btnAddRule";
             btnAddRule.Size = new Size(30, 30);
-            btnAddRule.TabIndex = 9;
+            btnAddRule.TabIndex = 11;
             btnAddRule.Text = "";
             btnAddRule.UseVisualStyleBackColor = true;
             btnAddRule.Click += BtnAddRule_Click;
@@ -342,7 +356,7 @@ namespace ASCompletion.Controls
             btnOk.Location = new Point(724, 311);
             btnOk.Name = "btnOk";
             btnOk.Size = new Size(120, 30);
-            btnOk.TabIndex = 10;
+            btnOk.TabIndex = 12;
             btnOk.Text = "OK";
             btnOk.UseVisualStyleBackColor = true;
             btnOk.Click += BtnOk_Click;
@@ -354,7 +368,7 @@ namespace ASCompletion.Controls
             btnCancel.Location = new Point(850, 311);
             btnCancel.Name = "btnCancel";
             btnCancel.Size = new Size(120, 30);
-            btnCancel.TabIndex = 11;
+            btnCancel.TabIndex = 13;
             btnCancel.Text = "Cancel";
             btnCancel.UseVisualStyleBackColor = true;
             btnCancel.Click += BtnCancel_Click;
@@ -375,6 +389,7 @@ namespace ASCompletion.Controls
             Controls.Add(btnUp);
             Controls.Add(rulesGridView);
             Controls.Add(cbxIgnoreWhitespace);
+            Controls.Add(cbxAddSpace);
             Controls.Add(txtCloseChar);
             Controls.Add(lblCloseChar);
             Controls.Add(txtOpenChar);
@@ -475,6 +490,7 @@ namespace ASCompletion.Controls
             txtName.TextChanged -= TxtName_TextChanged;
             txtOpenChar.TextChanged -= TxtOpenChar_TextChanged;
             txtCloseChar.TextChanged -= TxtCloseChar_TextChanged;
+            cbxAddSpace.CheckedChanged -= CbxAddSpace_CheckedChanged;
             cbxIgnoreWhitespace.CheckedChanged -= CbxIgnoreWhitespace_CheckedChanged;
 
             if (inEdit == null)
@@ -482,6 +498,7 @@ namespace ASCompletion.Controls
                 txtName.Text = "";
                 txtOpenChar.Text = "";
                 txtCloseChar.Text = "";
+                cbxAddSpace.Checked = false;
                 cbxIgnoreWhitespace.Checked = false;
 
                 rulesGridView.Rows.Clear();
@@ -491,6 +508,7 @@ namespace ASCompletion.Controls
                 txtName.Text = inEdit.Name;
                 txtOpenChar.Text = inEdit.Open == '\0' ? "" : inEdit.Open.ToString();
                 txtCloseChar.Text = inEdit.Close == '\0' ? "" : inEdit.Close.ToString();
+                cbxAddSpace.Checked = inEdit.AddSpace;
                 cbxIgnoreWhitespace.Checked = inEdit.IgnoreWhitespace;
 
                 rulesGridView.Rows.Clear();
@@ -505,6 +523,7 @@ namespace ASCompletion.Controls
             txtName.TextChanged += TxtName_TextChanged;
             txtOpenChar.TextChanged += TxtOpenChar_TextChanged;
             txtCloseChar.TextChanged += TxtCloseChar_TextChanged;
+            cbxAddSpace.CheckedChanged += CbxAddSpace_CheckedChanged;
             cbxIgnoreWhitespace.CheckedChanged += CbxIgnoreWhitespace_CheckedChanged;
         }
 
@@ -541,6 +560,7 @@ namespace ASCompletion.Controls
                 txtName.Enabled = false;
                 txtOpenChar.Enabled = false;
                 txtCloseChar.Enabled = false;
+                cbxAddSpace.Enabled = false;
                 cbxIgnoreWhitespace.Enabled = false;
                 btnUp.Enabled = false;
                 btnDown.Enabled = false;
@@ -553,6 +573,7 @@ namespace ASCompletion.Controls
                 txtName.Enabled = true;
                 txtOpenChar.Enabled = true;
                 txtCloseChar.Enabled = true;
+                cbxAddSpace.Enabled = true;
                 cbxIgnoreWhitespace.Enabled = true;
                 btnUp.Enabled = listBox.SelectedIndex > 0;
                 btnDown.Enabled = listBox.SelectedIndex < listBox.Items.Count - 1;
@@ -597,6 +618,11 @@ namespace ASCompletion.Controls
             InvalidateListBox();
         }
 
+        private void CbxAddSpace_CheckedChanged(object sender, EventArgs e)
+        {
+            inEdit.AddSpace = cbxAddSpace.Checked;
+        }
+
         private void CbxIgnoreWhitespace_CheckedChanged(object sender, EventArgs e)
         {
             inEdit.IgnoreWhitespace = cbxIgnoreWhitespace.Checked;
@@ -635,7 +661,7 @@ namespace ASCompletion.Controls
         private void BtnRemove_Click(object sender, EventArgs e)
         {
             int selectedIndex = listBox.SelectedIndex;
-            listBox.SelectedIndex = selectedIndex - 1;
+            listBox.SelectedIndex = selectedIndex == 0 && listBox.Items.Count > 1 ? 1 : selectedIndex - 1;
             listBox.Items.RemoveAt(selectedIndex);
             listBox.Select();
         }
@@ -812,6 +838,7 @@ namespace ASCompletion.Controls
             public string Name;
             public char Open;
             public char Close;
+            public bool AddSpace;
             public bool IgnoreWhitespace;
             public List<Brace.Rule> Rules;
 
@@ -820,6 +847,7 @@ namespace ASCompletion.Controls
                 Name = "";
                 Open = '\0';
                 Close = '\0';
+                AddSpace = false;
                 IgnoreWhitespace = false;
                 Rules = new List<Brace.Rule>();
             }
@@ -829,6 +857,7 @@ namespace ASCompletion.Controls
                 Name = value.Name;
                 Open = value.Open;
                 Close = value.Close;
+                AddSpace = value.AddSpace;
                 IgnoreWhitespace = value.IgnoreWhitespace;
                 Rules = new List<Brace.Rule>(value.Rules.Length);
                 foreach (var rule in value.Rules)
@@ -839,7 +868,7 @@ namespace ASCompletion.Controls
 
             public Brace ToBrace()
             {
-                return new Brace(Name, Open, Close, IgnoreWhitespace, Rules.ToArray());
+                return new Brace(Name, Open, Close, AddSpace, IgnoreWhitespace, Rules.ToArray());
             }
 
             public override string ToString()

--- a/External/Plugins/ASCompletion/Controls/AddClosingBracesRulesEditorForm.cs
+++ b/External/Plugins/ASCompletion/Controls/AddClosingBracesRulesEditorForm.cs
@@ -96,44 +96,44 @@ namespace ASCompletion.Controls
             // 
             listBox.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left;
             listBox.IntegralHeight = false;
-            listBox.ItemHeight = 16;
+            listBox.ItemHeight = 20;
             listBox.Location = new Point(12, 12);
             listBox.Name = "listBox";
-            listBox.Size = new Size(156, 243);
+            listBox.Size = new Size(156, 250);
             listBox.TabIndex = 0;
             listBox.SelectedValueChanged += ListBox_SelectedValueChanged;
             // 
             // lblName
             // 
             lblName.AutoSize = true;
-            lblName.Location = new Point(207, 15);
+            lblName.Location = new Point(206, 15);
             lblName.Name = "lblName";
-            lblName.Size = new Size(49, 17);
+            lblName.Size = new Size(52, 20);
             lblName.Text = "Name:";
             // 
             // txtName
             // 
-            txtName.Location = new Point(262, 12);
+            txtName.Location = new Point(264, 12);
             txtName.MaxLength = 32;
             txtName.Name = "txtName";
-            txtName.Size = new Size(156, 22);
+            txtName.Size = new Size(156, 27);
             txtName.TabIndex = 1;
             txtName.TextChanged += TxtName_TextChanged;
             // 
             // lblOpenChar
             // 
             lblOpenChar.AutoSize = true;
-            lblOpenChar.Location = new Point(424, 15);
+            lblOpenChar.Location = new Point(426, 15);
             lblOpenChar.Name = "lblOpenChar";
-            lblOpenChar.Size = new Size(47, 17);
+            lblOpenChar.Size = new Size(48, 20);
             lblOpenChar.Text = "Open:";
             // 
             // txtOpenChar
             // 
-            txtOpenChar.Location = new Point(477, 12);
+            txtOpenChar.Location = new Point(480, 12);
             txtOpenChar.MaxLength = 1;
             txtOpenChar.Name = "txtOpenChar";
-            txtOpenChar.Size = new Size(30, 22);
+            txtOpenChar.Size = new Size(30, 27);
             txtOpenChar.TabIndex = 2;
             txtOpenChar.TextAlign = HorizontalAlignment.Center;
             txtOpenChar.TextChanged += TxtOpenChar_TextChanged;
@@ -141,17 +141,17 @@ namespace ASCompletion.Controls
             // lblCloseChar
             // 
             lblCloseChar.AutoSize = true;
-            lblCloseChar.Location = new Point(513, 15);
+            lblCloseChar.Location = new Point(516, 15);
             lblCloseChar.Name = "lblCloseChar";
-            lblCloseChar.Size = new Size(47, 17);
+            lblCloseChar.Size = new Size(48, 20);
             lblCloseChar.Text = "Close:";
             // 
             // txtCloseChar
             // 
-            txtCloseChar.Location = new Point(566, 12);
+            txtCloseChar.Location = new Point(570, 12);
             txtCloseChar.MaxLength = 1;
             txtCloseChar.Name = "txtCloseChar";
-            txtCloseChar.Size = new Size(30, 22);
+            txtCloseChar.Size = new Size(30, 27);
             txtCloseChar.TabIndex = 3;
             txtCloseChar.TextAlign = HorizontalAlignment.Center;
             txtCloseChar.TextChanged += TxtCloseChar_TextChanged;
@@ -160,9 +160,9 @@ namespace ASCompletion.Controls
             // 
             cbxAddSpace.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             cbxAddSpace.AutoSize = true;
-            cbxAddSpace.Location = new Point(717, 12);
+            cbxAddSpace.Location = new Point(706, 12);
             cbxAddSpace.Name = "cbxAddSpace";
-            cbxAddSpace.Size = new Size(99, 21);
+            cbxAddSpace.Size = new Size(103, 24);
             cbxAddSpace.TabIndex = 4;
             cbxAddSpace.Text = "Add Space";
             cbxAddSpace.TextAlign = ContentAlignment.MiddleRight;
@@ -172,9 +172,9 @@ namespace ASCompletion.Controls
             // 
             cbxIgnoreWhitespace.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             cbxIgnoreWhitespace.AutoSize = true;
-            cbxIgnoreWhitespace.Location = new Point(822, 12);
+            cbxIgnoreWhitespace.Location = new Point(815, 12);
             cbxIgnoreWhitespace.Name = "cbxIgnoreWhitespace";
-            cbxIgnoreWhitespace.Size = new Size(148, 21);
+            cbxIgnoreWhitespace.Size = new Size(155, 24);
             cbxIgnoreWhitespace.TabIndex = 5;
             cbxIgnoreWhitespace.Text = "Ignore Whitespace";
             cbxIgnoreWhitespace.TextAlign = ContentAlignment.MiddleRight;
@@ -204,11 +204,11 @@ namespace ASCompletion.Controls
                 beforeStyles,
                 colDelete
             });
-            rulesGridView.Location = new Point(210, 40);
+            rulesGridView.Location = new Point(210, 45);
             rulesGridView.Name = "rulesGridView";
             rulesGridView.RowTemplate.Height = 24;
             rulesGridView.ScrollBars = ScrollBars.Vertical;
-            rulesGridView.Size = new Size(760, 265);
+            rulesGridView.Size = new Size(760, 260);
             rulesGridView.TabIndex = 6;
             rulesGridView.CellContentClick += RulesGridView_CellContentClick;
             rulesGridView.CellEndEdit += RulesGridView_CellEndEdit;
@@ -232,6 +232,7 @@ namespace ASCompletion.Controls
             // 
             logic1.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCellsExceptHeader;
             logic1.HeaderText = "";
+            logic1.MinimumWidth = 40;
             logic1.Name = "logic1";
             logic1.SortMode = DataGridViewColumnSortMode.NotSortable;
             // 
@@ -253,6 +254,7 @@ namespace ASCompletion.Controls
             // 
             logic2.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCellsExceptHeader;
             logic2.HeaderText = "";
+            logic2.MinimumWidth = 40;
             logic2.Name = "logic2";
             logic2.SortMode = DataGridViewColumnSortMode.NotSortable;
             // 
@@ -274,6 +276,7 @@ namespace ASCompletion.Controls
             // 
             logic3.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCellsExceptHeader;
             logic3.HeaderText = "";
+            logic3.MinimumWidth = 40;
             logic3.Name = "logic3";
             logic3.SortMode = DataGridViewColumnSortMode.NotSortable;
             // 
@@ -295,12 +298,13 @@ namespace ASCompletion.Controls
             // 
             colDelete.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCellsExceptHeader;
             colDelete.HeaderText = "";
+            colDelete.MinimumWidth = 21;
             colDelete.Name = "colDelete";
             colDelete.SortMode = DataGridViewColumnSortMode.NotSortable;
             // 
             // btnUp
             // 
-            btnUp.Location = new Point(174, 42);
+            btnUp.Location = new Point(174, 50);
             btnUp.Name = "btnUp";
             btnUp.Size = new Size(30, 30);
             btnUp.TabIndex = 7;
@@ -309,7 +313,7 @@ namespace ASCompletion.Controls
             // 
             // btnDown
             // 
-            btnDown.Location = new Point(174, 78);
+            btnDown.Location = new Point(174, 84);
             btnDown.Name = "btnDown";
             btnDown.Size = new Size(30, 30);
             btnDown.TabIndex = 8;
@@ -319,7 +323,7 @@ namespace ASCompletion.Controls
             // btnAdd
             // 
             btnAdd.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
-            btnAdd.Location = new Point(12, 261);
+            btnAdd.Location = new Point(12, 268);
             btnAdd.Name = "btnAdd";
             btnAdd.Size = new Size(75, 30);
             btnAdd.TabIndex = 9;
@@ -330,7 +334,7 @@ namespace ASCompletion.Controls
             // btnRemove
             // 
             btnRemove.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
-            btnRemove.Location = new Point(93, 261);
+            btnRemove.Location = new Point(93, 268);
             btnRemove.Name = "btnRemove";
             btnRemove.Size = new Size(75, 30);
             btnRemove.TabIndex = 10;
@@ -373,10 +377,10 @@ namespace ASCompletion.Controls
             btnCancel.UseVisualStyleBackColor = true;
             btnCancel.Click += BtnCancel_Click;
             // 
-            // AddClosingBracesRulesEditor
+            // AddClosingBracesRulesEditorForm
             // 
             AcceptButton = btnOk;
-            AutoScaleDimensions = new SizeF(8F, 16F);
+            AutoScaleDimensions = new SizeF(8F, 20F);
             AutoScaleMode = AutoScaleMode.Font;
             CancelButton = btnCancel;
             ClientSize = new Size(982, 353);
@@ -399,12 +403,13 @@ namespace ASCompletion.Controls
             Controls.Add(listBox);
             FormBorderStyle = FormBorderStyle.SizableToolWindow;
             MinimumSize = new Size(900, 300);
-            Name = "AddClosingBracesRulesEditor";
+            Name = "AddClosingBracesRulesEditorForm";
             ShowInTaskbar = false;
             StartPosition = FormStartPosition.CenterParent;
             Text = "AddClosingBracesRulesEditor";
             ((ISupportInitialize) (rulesGridView)).EndInit();
             ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -417,8 +422,6 @@ namespace ASCompletion.Controls
             btnUp.Image = PluginBase.MainForm.FindImage16("74", false);
             btnDown.Image = PluginBase.MainForm.FindImage16("60", false);
             btnAddRule.Image = PluginBase.MainForm.FindImage16("550", false);
-
-            btnAddRule.Width = ScaleHelper.Scale(btnAddRule.Width);
         }
 
         private void InitializeFonts()

--- a/External/Plugins/ASCompletion/Settings/GeneralSettings.cs
+++ b/External/Plugins/ASCompletion/Settings/GeneralSettings.cs
@@ -309,36 +309,36 @@ namespace ASCompletion.Settings
 
         static Brace[] DEFAULT_ADD_CLOSING_BRACES_RULES =
         {
-            new Brace("Parentheses", '(', ')', new[]
+            new Brace("Parentheses", '(', ')', true, new[]
             {
                 new Brace.Rule(null, null, null, null, false, ")}]>", false, new[] { Style.Default, Style.Comment, Style.CommentLine, Style.CommentDoc, Style.CommentLineDoc, Style.Preprocessor, Style.Keyword, Style.Attribute }, Brace.Logic.Or),
                 new Brace.Rule(null, null, false, new[] { Style.Character }, true, "'", false, new[] { Style.Character }, Brace.Logic.And)
             }),
-            new Brace("Braces", '{', '}', new[]
+            new Brace("Braces", '{', '}', true, new[]
             {
                 new Brace.Rule(null, null, null, null, false, ")}]>", false, new[] { Style.Default }, Brace.Logic.Or),
                 new Brace.Rule(false, "$", false, new[] { Style.Character }, null, null, false, new[] { Style.Character }, Brace.Logic.And),
                 new Brace.Rule(null, null, false, new[] { Style.Character }, true, "'", false, new[] { Style.Character }, Brace.Logic.And)
             }),
-            new Brace("Brackets", '[', ']', new[]
+            new Brace("Brackets", '[', ']', true, new[]
             {
                 new Brace.Rule(null, null, null, null, false, ")}]>", false, new[] { Style.Default, Style.Comment, Style.CommentLine, Style.CommentDoc, Style.CommentLineDoc, Style.Preprocessor, Style.Keyword, Style.Attribute }, Brace.Logic.Or),
                 new Brace.Rule(null, null, false, new[] { Style.Character }, true, "'", false, new[] { Style.Character }, Brace.Logic.And)
             }),
-            new Brace("Generic", '<', '>', new[]
+            new Brace("Generic", '<', '>', false, new[]
             {
                 new Brace.Rule(null, null, false, new[] { Style.Type }, true, "<", true, new[] { Style.Identifier, Style.Type }, Brace.Logic.And)
             }),
-            new Brace("AS3 Vector", '<', '>', new[]
+            new Brace("AS3 Vector", '<', '>', false, new[]
             {
                 new Brace.Rule(false, ".", false, new[] { Style.Operator }, true, "<", true, new[] { Style.Identifier, Style.Type }, Brace.Logic.And)
             }),
-            new Brace("String", '"', '"', new[]
+            new Brace("String", '"', '"', false, new[]
             {
                 new Brace.Rule(null, null, null, null, null, null, false, new[] { Style.Default, Style.Comment, Style.CommentLine, Style.CommentDoc, Style.CommentLineDoc, Style.String, Style.Character, Style.Preprocessor, Style.Operator, Style.Attribute }, null),
                 new Brace.Rule(null, null, false, new[] { Style.Character }, true, "'", false, new[] { Style.Character }, Brace.Logic.And)
             }),
-            new Brace("Character", '\'', '\'', new[]
+            new Brace("Character", '\'', '\'', false, new[]
             {
                 new Brace.Rule(null, null, null, null, null, null, false, new[] { Style.Default, Style.Comment, Style.CommentLine, Style.CommentDoc, Style.CommentLineDoc, Style.String, Style.Character, Style.Preprocessor, Style.Operator, Style.Attribute }, null),
                 new Brace.Rule(null, null, false, new[] { Style.Character }, true, "'", false, new[] { Style.Character }, Brace.Logic.And)

--- a/External/Plugins/ASCompletion/Settings/GeneralSettings.cs
+++ b/External/Plugins/ASCompletion/Settings/GeneralSettings.cs
@@ -309,36 +309,39 @@ namespace ASCompletion.Settings
 
         static Brace[] DEFAULT_ADD_CLOSING_BRACES_RULES =
         {
-            new Brace("Parentheses", '(', ')', true, new[]
+            new Brace("Parentheses", '(', ')', false, true, new[]
             {
                 new Brace.Rule(null, null, null, null, false, ")}]>", false, new[] { Style.Default, Style.Comment, Style.CommentLine, Style.CommentDoc, Style.CommentLineDoc, Style.Preprocessor, Style.Keyword, Style.Attribute }, Brace.Logic.Or),
                 new Brace.Rule(null, null, false, new[] { Style.Character }, true, "'", false, new[] { Style.Character }, Brace.Logic.And)
             }),
-            new Brace("Braces", '{', '}', true, new[]
+            new Brace("Haxe Interpolation", '{', '}', false, true, new[]
+            {
+                new Brace.Rule(false, "$", false, new[] { Style.Character }, null, null, false, new[] { Style.Character }, Brace.Logic.And)
+            }),
+            new Brace("Braces", '{', '}', true, true, new[]
             {
                 new Brace.Rule(null, null, null, null, false, ")}]>", false, new[] { Style.Default }, Brace.Logic.Or),
-                new Brace.Rule(false, "$", false, new[] { Style.Character }, null, null, false, new[] { Style.Character }, Brace.Logic.And),
                 new Brace.Rule(null, null, false, new[] { Style.Character }, true, "'", false, new[] { Style.Character }, Brace.Logic.And)
             }),
-            new Brace("Brackets", '[', ']', true, new[]
+            new Brace("Brackets", '[', ']', false, true, new[]
             {
                 new Brace.Rule(null, null, null, null, false, ")}]>", false, new[] { Style.Default, Style.Comment, Style.CommentLine, Style.CommentDoc, Style.CommentLineDoc, Style.Preprocessor, Style.Keyword, Style.Attribute }, Brace.Logic.Or),
                 new Brace.Rule(null, null, false, new[] { Style.Character }, true, "'", false, new[] { Style.Character }, Brace.Logic.And)
             }),
-            new Brace("Generic", '<', '>', false, new[]
+            new Brace("Generic", '<', '>', false, false, new[]
             {
                 new Brace.Rule(null, null, false, new[] { Style.Type }, true, "<", true, new[] { Style.Identifier, Style.Type }, Brace.Logic.And)
             }),
-            new Brace("AS3 Vector", '<', '>', false, new[]
+            new Brace("AS3 Vector", '<', '>', false, false, new[]
             {
                 new Brace.Rule(false, ".", false, new[] { Style.Operator }, true, "<", true, new[] { Style.Identifier, Style.Type }, Brace.Logic.And)
             }),
-            new Brace("String", '"', '"', false, new[]
+            new Brace("String", '"', '"', false, false, new[]
             {
                 new Brace.Rule(null, null, null, null, null, null, false, new[] { Style.Default, Style.Comment, Style.CommentLine, Style.CommentDoc, Style.CommentLineDoc, Style.String, Style.Character, Style.Preprocessor, Style.Operator, Style.Attribute }, null),
                 new Brace.Rule(null, null, false, new[] { Style.Character }, true, "'", false, new[] { Style.Character }, Brace.Logic.And)
             }),
-            new Brace("Character", '\'', '\'', false, new[]
+            new Brace("Character", '\'', '\'', false, false, new[]
             {
                 new Brace.Rule(null, null, null, null, null, null, false, new[] { Style.Default, Style.Comment, Style.CommentLine, Style.CommentDoc, Style.CommentLineDoc, Style.String, Style.Character, Style.Preprocessor, Style.Operator, Style.Attribute }, null),
                 new Brace.Rule(null, null, false, new[] { Style.Character }, true, "'", false, new[] { Style.Character }, Brace.Logic.And)

--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -5831,28 +5831,45 @@ namespace ScintillaNet
                             int curLine = CurrentLine;
                             int tempLine = curLine;
                             int previousIndent;
-                            string tempText;
+                            string tempText3; //line text without newline
+                            string tempText2; //line text trim end
+                            string tempText; //line text without comment and trim end
                             do
                             {
                                 --tempLine;
-                                previousIndent = GetLineIndentation(tempLine);
-                                tempText = GetLine(tempLine).TrimEnd();
+                                tempText3 = GetLine(tempLine);
+                                tempText3 = tempText3.Substring(0, tempText3.Length - 1); //remove newline
+                                tempText2 = tempText3.TrimEnd();
+                                tempText = tempText2;
                                 if (tempText.Length == 0) previousIndent = -1;
+                                else previousIndent = GetLineIndentation(tempLine);
                             }
                             while ((tempLine > 0) && (previousIndent < 0));
-                            if (tempText.IndexOfOrdinal("//") > 0) // remove comment at end of line
+                            int commentIndex = tempText.IndexOfOrdinal("//");
+                            if (commentIndex > 0) // remove comment at end of line
                             {
-                                int slashes = this.MBSafeTextLength(tempText.Substring(0, tempText.IndexOfOrdinal("//") + 1));
+                                int slashes = this.MBSafeTextLength(tempText.Substring(0, commentIndex + 1));
                                 if (this.PositionIsOnComment(PositionFromLine(tempLine) + slashes))
-                                    tempText = tempText.Substring(0, tempText.IndexOfOrdinal("//")).Trim();
+                                    tempText = tempText.Substring(0, commentIndex).TrimEnd();
                             }
                             if (tempText.EndsWith('{'))
                             {
-                                int bracePos = CurrentPos - 1;
-                                while (bracePos > 0 && CharAt(bracePos) != '{') bracePos--;
+                                int bracePos = CurrentPos - 2 - (tempText3.Length - tempText.Length); //CurrentPos - 1 is always ch (newline)
                                 int style = BaseStyleAt(bracePos);
                                 if (bracePos >= 0 && CharAt(bracePos) == '{' && (style == 10/*CPP*/ || style == 5/*CSS*/))
+                                {
                                     previousIndent += TabWidth;
+                                    if (tempText.Length == tempText2.Length) //Doesn't end with comment
+                                    {
+                                        if (tempText3.Length > tempText.Length) //Ends with whitespace after {
+                                        {
+                                            AnchorPosition = bracePos + 1;
+                                            CurrentPos--; //before ch (newline)
+                                            DeleteBack();
+                                            CurrentPos = bracePos + 2; //same as CurrentPos++ (after ch)
+                                        }
+                                    }
+                                }
                             }
                             // TODO: Should this test a config variable for indenting after case : statements?
                             if (Lexer == 3 && tempText.EndsWith(':') && !tempText.EndsWithOrdinal("::") && !this.PositionIsOnComment(PositionFromLine(tempLine)))

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASCompleteTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASCompleteTests.cs
@@ -735,7 +735,7 @@ namespace ASCompletion.Completion
                 get
                 {
                     yield return new TestCaseData(")+ )").  Returns(" )"). SetName(prefix + "Close ) to overwrite ) after whitespace");
-                    yield return new TestCaseData("}+\n}"). Returns("\n}").SetName(prefix + "Close } to overwrite } after whitespace");
+                    yield return new TestCaseData("}+\t}"). Returns("\t}").SetName(prefix + "Close } to overwrite } after whitespace");
                     yield return new TestCaseData("]+\t]"). Returns("\t]").SetName(prefix + "Close ] to overwrite ] after whitespace");
 
                     yield return new TestCaseData("(- )").  Returns("").   SetName(prefix + "Delete ( to delete ) and the whitespace in between");

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASCompleteTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASCompleteTests.cs
@@ -632,6 +632,13 @@ namespace ASCompletion.Completion
                     yield return new TestCaseData("(+>").      Returns("()>").       SetName(prefix + "Open ( after 'Default' before >");
                     yield return new TestCaseData("(+a").      Returns("(a").        SetName(prefix + "Open ( after 'Default' before 'Identifier'");
 
+                    yield return new TestCaseData("{+").       Returns("{}").        SetName(prefix + "Open { after 'Default' before 'Default'");
+                    yield return new TestCaseData("{+)").      Returns("{})").       SetName(prefix + "Open { after 'Default' before )");
+                    yield return new TestCaseData("{+}").      Returns("{}}").       SetName(prefix + "Open { after 'Default' before }");
+                    yield return new TestCaseData("{+]").      Returns("{}]").       SetName(prefix + "Open { after 'Default' before ]");
+                    yield return new TestCaseData("{+>").      Returns("{}>").       SetName(prefix + "Open { after 'Default' before >");
+                    yield return new TestCaseData("{+a").      Returns("{a").        SetName(prefix + "Open { after 'Default' before 'Identifier'");
+
                     yield return new TestCaseData("[+").       Returns("[]").        SetName(prefix + "Open [ after 'Default' before 'Default'");
                     yield return new TestCaseData("[+/* */").  Returns("[]/* */").   SetName(prefix + "Open [ after 'Default' before 'Comment'");
                     yield return new TestCaseData("[+//").     Returns("[]//").      SetName(prefix + "Open [ after 'Default' before 'CommentLine'");
@@ -642,13 +649,6 @@ namespace ASCompletion.Completion
                     yield return new TestCaseData("[+]").      Returns("[]]").       SetName(prefix + "Open [ after 'Default' before ]");
                     yield return new TestCaseData("[+>").      Returns("[]>").       SetName(prefix + "Open [ after 'Default' before >");
                     yield return new TestCaseData("[+a").      Returns("[a").        SetName(prefix + "Open [ after 'Default' before 'Identifier'");
-
-                    yield return new TestCaseData("{+").       Returns("{}").        SetName(prefix + "Open { after 'Default' before 'Default'");
-                    yield return new TestCaseData("{+)").      Returns("{})").       SetName(prefix + "Open { after 'Default' before )");
-                    yield return new TestCaseData("{+}").      Returns("{}}").       SetName(prefix + "Open { after 'Default' before }");
-                    yield return new TestCaseData("{+]").      Returns("{}]").       SetName(prefix + "Open { after 'Default' before ]");
-                    yield return new TestCaseData("{+>").      Returns("{}>").       SetName(prefix + "Open { after 'Default' before >");
-                    yield return new TestCaseData("{+a").      Returns("{a").        SetName(prefix + "Open { after 'Default' before 'Identifier'");
 
                     yield return new TestCaseData("\"+").      Returns("\"\"").      SetName(prefix + "Open \" after 'Default' before 'Default'");
                     yield return new TestCaseData("\"+/* */"). Returns("\"\"/* */"). SetName(prefix + "Open \" after 'Default' before 'Comment'");
@@ -686,8 +686,8 @@ namespace ASCompletion.Completion
                 get
                 {
                     yield return new TestCaseData("()+)").     Returns("()").      SetName(prefix + "Close ) to overwrite )");
-                    yield return new TestCaseData("[]+]").     Returns("[]").      SetName(prefix + "Close ] to overwrite ]");
                     yield return new TestCaseData("{}+}").     Returns("{}").      SetName(prefix + "Close } to overwrite }");
+                    yield return new TestCaseData("[]+]").     Returns("[]").      SetName(prefix + "Close ] to overwrite ]");
                     yield return new TestCaseData("\"\"+\"").  Returns("\"\"").    SetName(prefix + "Close \" to overwrite \"");
                     yield return new TestCaseData("\"\\\"+\"").Returns("\"\\\"\"").SetName(prefix + "Close \" escaped should not overwrite \"");
                     yield return new TestCaseData("''+'").     Returns("''").      SetName(prefix + "Close ' to overwrite '");
@@ -701,8 +701,8 @@ namespace ASCompletion.Completion
                 get
                 {
                     yield return new TestCaseData("(-)").  Returns("").SetName(prefix + "Delete ( to delete )");
-                    yield return new TestCaseData("[-]").  Returns("").SetName(prefix + "Delete [ to delete ]");
                     yield return new TestCaseData("{-}").  Returns("").SetName(prefix + "Delete { to delete }");
+                    yield return new TestCaseData("[-]").  Returns("").SetName(prefix + "Delete [ to delete ]");
                     yield return new TestCaseData("\"-\"").Returns("").SetName(prefix + "Delete \" to delete \"");
                     yield return new TestCaseData("'-'").  Returns("").SetName(prefix + "Delete ' to delete '");
                     yield return new TestCaseData("<->").  Returns("").SetName(prefix + "Delete < to delete >");
@@ -734,12 +734,16 @@ namespace ASCompletion.Completion
             {
                 get
                 {
-                    yield return new TestCaseData("(-  )").  Returns("").SetName(prefix + "Delete ( to delete ) and the whitespace in between");
-                    yield return new TestCaseData("[-\t]").  Returns("").SetName(prefix + "Delete [ to delete ] and the whitespace in between");
-                    yield return new TestCaseData("{-\n}").  Returns("").SetName(prefix + "Delete { to delete } and the whitespace in between");
-                    yield return new TestCaseData("\"-  \"").Returns("").SetName(prefix + "Delete \" to delete \" and the whitespace in between");
-                    yield return new TestCaseData("'-  '").  Returns("").SetName(prefix + "Delete ' to delete ' and the whitespace in between");
-                    yield return new TestCaseData("<-  >").  Returns("").SetName(prefix + "Delete < to delete > and the whitespace in between");
+                    yield return new TestCaseData(")+ )").  Returns(" )"). SetName(prefix + "Close ) to overwrite ) after whitespace");
+                    yield return new TestCaseData("}+\n}"). Returns("\n}").SetName(prefix + "Close } to overwrite } after whitespace");
+                    yield return new TestCaseData("]+\t]"). Returns("\t]").SetName(prefix + "Close ] to overwrite ] after whitespace");
+
+                    yield return new TestCaseData("(- )").  Returns("").   SetName(prefix + "Delete ( to delete ) and the whitespace in between");
+                    yield return new TestCaseData("{-\n}"). Returns("").   SetName(prefix + "Delete { to delete } and the whitespace in between");
+                    yield return new TestCaseData("[-\t]"). Returns("").   SetName(prefix + "Delete [ to delete ] and the whitespace in between");
+                    yield return new TestCaseData("\"- \"").Returns(" \"").SetName(prefix + "Delete \" without deleting \" and the whitespace in between");
+                    yield return new TestCaseData("'- '").  Returns(" '"). SetName(prefix + "Delete ' without deleting ' and the whitespace in between");
+                    yield return new TestCaseData("<- >").  Returns(" >"). SetName(prefix + "Delete < without deleting > and the whitespace in between");
                 }
             }
 
@@ -814,7 +818,7 @@ namespace ASCompletion.Completion
                 {
                     sci.DeleteBack(); // Backspace is handled after HandleAddClosingBraces(), so mimic that behaviour
                 }
-                return sci.GetCurLine(sci.CurLineSize - 1); // Ignore the last new line character
+                return sci.GetTextRange(1, sci.TextLength - 1); // Ignore the surrounding new line characters
             }
         }
 

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASCompleteTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASCompleteTests.cs
@@ -632,11 +632,11 @@ namespace ASCompletion.Completion
                     yield return new TestCaseData("(+>").      Returns("()>").       SetName(prefix + "Open ( after 'Default' before >");
                     yield return new TestCaseData("(+a").      Returns("(a").        SetName(prefix + "Open ( after 'Default' before 'Identifier'");
 
-                    yield return new TestCaseData("{+").       Returns("{}").        SetName(prefix + "Open { after 'Default' before 'Default'");
-                    yield return new TestCaseData("{+)").      Returns("{})").       SetName(prefix + "Open { after 'Default' before )");
-                    yield return new TestCaseData("{+}").      Returns("{}}").       SetName(prefix + "Open { after 'Default' before }");
-                    yield return new TestCaseData("{+]").      Returns("{}]").       SetName(prefix + "Open { after 'Default' before ]");
-                    yield return new TestCaseData("{+>").      Returns("{}>").       SetName(prefix + "Open { after 'Default' before >");
+                    yield return new TestCaseData("{+").       Returns("{ }").       SetName(prefix + "Open { after 'Default' before 'Default'");
+                    yield return new TestCaseData("{+)").      Returns("{ })").      SetName(prefix + "Open { after 'Default' before )");
+                    yield return new TestCaseData("{+}").      Returns("{ }}").      SetName(prefix + "Open { after 'Default' before }");
+                    yield return new TestCaseData("{+]").      Returns("{ }]").      SetName(prefix + "Open { after 'Default' before ]");
+                    yield return new TestCaseData("{+>").      Returns("{ }>").      SetName(prefix + "Open { after 'Default' before >");
                     yield return new TestCaseData("{+a").      Returns("{a").        SetName(prefix + "Open { after 'Default' before 'Identifier'");
 
                     yield return new TestCaseData("[+").       Returns("[]").        SetName(prefix + "Open [ after 'Default' before 'Default'");
@@ -755,7 +755,7 @@ namespace ASCompletion.Completion
                     yield return new TestCaseData("'${-}'").    Returns("'$'").      SetName(prefix + "Delete interpolation { to delete }");
 
                     yield return new TestCaseData("'${(+}'").   Returns("'${()}'").  SetName(prefix + "Open ( inside string interpolation");
-                    yield return new TestCaseData("'${{+}'").   Returns("'${{}}'").  SetName(prefix + "Open { inside string interpolation");
+                    yield return new TestCaseData("'${{+}'").   Returns("'${{ }}'"). SetName(prefix + "Open { inside string interpolation");
                     yield return new TestCaseData("'${[+}'").   Returns("'${[]}'").  SetName(prefix + "Open [ inside string interpolation");
                     yield return new TestCaseData("'${\"+}'").  Returns("'${\"\"}'").SetName(prefix + "Open \" inside string interpolation");
                     yield return new TestCaseData("'${'+}'").   Returns("'${''}'").  SetName(prefix + "Open ' inside string interpolation");


### PR DESCRIPTION
## Part 1 - 3c3bf6f
Ignore Whitespace setting
![1-1](https://cloud.githubusercontent.com/assets/13545633/25288994/cf63c234-2702-11e7-87f1-77261eeb5167.PNG)
Rather than ignoring whitespace globally, allow individual settings.
Features:
- Overwrite closing with whitespace in the middle (`' '` or `'\t'`)
**Add `}`:**
![1-2](https://cloud.githubusercontent.com/assets/13545633/25289046/08d927ca-2703-11e7-9f37-84c8f90eb631.PNG)
Result: ![1-3](https://cloud.githubusercontent.com/assets/13545633/25289066/1fcb5098-2703-11e7-8d42-242566cd6e21.PNG) Before: ![1-4](https://cloud.githubusercontent.com/assets/13545633/25289071/26861dd2-2703-11e7-885e-b420eea29685.PNG)
- Delete matching closing brace with whitespace in the middle (`char.IsWhiteSpace()`)
**Backspace:**
![1-5](https://cloud.githubusercontent.com/assets/13545633/25289138/6cb99996-2703-11e7-982d-88b07990a14c.PNG)
Result: ![1-6](https://cloud.githubusercontent.com/assets/13545633/25289147/72eb3644-2703-11e7-9317-4c6d400ee2ac.PNG) Before: ![1-7](https://cloud.githubusercontent.com/assets/13545633/25289156/7b9907da-2703-11e7-8669-86ffacba484b.PNG)
**Also deletes new line characters:**
![1-8](https://cloud.githubusercontent.com/assets/13545633/25289171/8b265cac-2703-11e7-976f-a2a67fa09b8e.PNG)
Result: ![1-9](https://cloud.githubusercontent.com/assets/13545633/25289179/913bc690-2703-11e7-8ecd-34d515e56030.PNG) Before: ![1-10](https://cloud.githubusercontent.com/assets/13545633/25289187/95eabad4-2703-11e7-81eb-a74a1bed27f6.PNG)

## Part 2 - 42a05a4
Add space setting
![2-1](https://cloud.githubusercontent.com/assets/13545633/25289318/0d5f730c-2704-11e7-98ed-7c7cd50c13ea.PNG)
Insert a space after typing the opening brace. Only `{ Braces }` brace has this option checked by default.
Features:
- Inserting `{`:
![2-2](https://cloud.githubusercontent.com/assets/13545633/25289393/5e14b6b8-2704-11e7-9d28-27be639c9825.PNG)
- Separated haxe interpolation expression brace rule:
![2-3](https://cloud.githubusercontent.com/assets/13545633/25289448/a0379560-2704-11e7-933a-5a1c53912a19.PNG)
Which doesn't have the Add Space option checked:
![2-4](https://cloud.githubusercontent.com/assets/13545633/25289436/88a16caa-2704-11e7-98d2-a01206184353.PNG)

## Part 3 - d96595d
Remove whitespaces on newline after opening brace.
Features:
- Pressing enter:
![3-1](https://cloud.githubusercontent.com/assets/13545633/25289521/eaed82fe-2704-11e7-814a-e034fedbf346.PNG)
Result: ![3-2](https://cloud.githubusercontent.com/assets/13545633/25289525/ee98cb5c-2704-11e7-822d-6c7979204da2.PNG) Before: ![3-3](https://cloud.githubusercontent.com/assets/13545633/25289529/f4329b9c-2704-11e7-9979-56173e7d8995.PNG)

---
**Miscellaneous**
Part 1 also contains:
- AddClosingBracesRulesEditorForm now uses settings default font, enabling font scaling.
- btnAddRule's width will also scale accordingly.

Part 2 also contains:
- In AddClosingBracesRulesEditorForm, removing items from ListBox at index 0 set selected index to -1. Now correctly sets selected index to 0.
