### PR TITLE
CopyRTF improvements

### DIFF
--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -3687,13 +3687,42 @@ namespace ScintillaNet
         }
 
         /// <summary>
+        /// Cut the selection to the clipboard as RTF.
+        /// </summary>
+        public void CutRTF()
+        {
+            if (SelTextSize > 0)
+            {
+                CopyRTF();
+                Clear();
+            }
+        }
+
+        /// <summary>
         /// Copy the selection to the clipboard as RTF.
         /// </summary>
         public void CopyRTF()
         {
-            Language language = ScintillaControl.Configuration.GetLanguage(this.configLanguage);
-            String conversion = RTF.GetConversion(language, this, this.SelectionStart, this.SelectionEnd);
-            Clipboard.SetText(conversion, TextDataFormat.Rtf);
+            int start = SelectionStart;
+            int end = SelectionEnd;
+
+            if (start < end)
+            {
+                CopyRTF(start, end);
+            }
+        }
+
+        /// <summary>
+        /// Copy the text in range to the clipboard as RTF.
+        /// </summary>
+        public void CopyRTF(int start, int end)
+        {
+            var dataObject = new DataObject();
+            var language = Configuration.GetLanguage(configLanguage);
+            string rtfText = RTF.GetConversion(language, this, start, end);
+            dataObject.SetText(GetTextRange(start, end));
+            dataObject.SetText(rtfText, TextDataFormat.Rtf);
+            Clipboard.SetDataObject(dataObject);
         }
 
         /// <summary>
@@ -7235,7 +7264,7 @@ namespace ScintillaNet
         /// </summary>
         public void CutAllowLineEx()
         {
-            if (this.SelTextSize == 0 && this.GetLine(this.CurrentLine).Trim() != "")
+            if (this.SelTextSize == 0 && this.GetLine(this.CurrentLine).Trim().Length > 0)
             {
                 this.LineCut();
             }
@@ -7243,15 +7272,87 @@ namespace ScintillaNet
         }
 
         /// <summary>
-        /// Cut the selection, if selection empty cut the line with the caret
+        /// Copy the selection, if selection empty copy the line with the caret
         /// </summary>
         public void CopyAllowLineEx()
         {
-            if (this.SelTextSize == 0 && this.GetLine(this.CurrentLine).Trim() != "")
+            if (this.SelTextSize == 0 && this.GetLine(this.CurrentLine).Trim().Length > 0)
             {
                 this.CopyAllowLine();
             }
             else this.Copy();
+        }
+
+        /// <summary>
+        /// Cut the selection in RTF. If selection is empty, cut the line containing the caret.
+        /// </summary>
+        public void CutRTFAllowLine()
+        {
+            if (this.SelTextSize == 0)
+            {
+                int line = this.CurrentLine;
+                this.AnchorPosition = this.PositionFromLine(line);
+                this.CurrentPos = this.PositionFromLine(line + 1);
+            }
+
+            this.CutRTF();
+        }
+
+        /// <summary>
+        /// Copy the selection in RTF. If selection is empty, copy the line containing the caret.
+        /// </summary>
+        public void CopyRTFAllowLine()
+        {
+            int start = this.SelectionStart;
+            int end = this.SelectionEnd;
+
+            if (start == end)
+            {
+                int line = this.CurrentLine;
+                start = this.PositionFromLine(line);
+                end = this.PositionFromLine(line + 1);
+            }
+
+            if (start < end)
+            {
+                this.CopyRTF(start, end);
+            }
+        }
+
+        /// <summary>
+        /// Cut the selection in RTF. If selection is empty and the current line is not empty, cut the line containing the caret.
+        /// </summary>
+        public void CutRTFAllowLineEx()
+        {
+            if (this.SelTextSize == 0 && this.GetLine(this.CurrentLine).Trim().Length > 0)
+            {
+                int line = this.CurrentLine;
+                this.AnchorPosition = this.PositionFromLine(line);
+                this.CurrentPos = this.PositionFromLine(line + 1);
+            }
+
+            this.CutRTF();
+        }
+
+        /// <summary>
+        /// Copy the selection in RTF. If selection is empty and the current line is not empty, copy the line containing the caret.
+        /// </summary>
+        public void CopyRTFAllowLineEx()
+        {
+            int start = this.SelectionStart;
+            int end = this.SelectionEnd;
+
+            if (start == end && this.GetLine(this.CurrentLine).Trim().Length > 0)
+            {
+                int line = this.CurrentLine;
+                start = this.PositionFromLine(line);
+                end = this.PositionFromLine(line + 1);
+            }
+
+            if (start < end)
+            {
+                this.CopyRTF(start, end);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Sets `DataFormats.Text` or `DataFormats.UnicodeText` data as well as `DataFormats.RTF` data on copy.
Added `CutRTF()`.
Added `Cut/CopyAllowLine()` and `Cut/CopyAllowLineEx()` methods.