### PR TITLE
Fixed "Sequence contains no elements"

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -3239,11 +3239,17 @@ namespace ASCompletion.Completion
                             pos = startPos + line.Length;
                             break;
                         }
-                        pos = position;
-                        var lineFromPosition = sci.LineFromPosition(pos);
+                        var lineFromPosition = sci.LineFromPosition(position);
                         startPos = sci.PositionFromLine(lineFromPosition);
-                        line = sci.GetLine(lineFromPosition);
-                        line = line.Substring(0, pos - startPos);
+                        var tmpLine = sci.GetLine(lineFromPosition);
+                        tmpLine = tmpLine.Substring(0, position - startPos);
+                        if (string.IsNullOrEmpty(tmpLine.TrimStart()))
+                        {
+                            pos = startPos + line.Length;
+                            break;
+                        }
+                        line = tmpLine;
+                        pos = position;
                         bracesRemoved = true;
                         break;
                     }

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -571,6 +571,8 @@
     <EmbeddedResource Include="Test Files\generated\haxe\AfterGenerateFunction_issue103_21.hx" />
     <EmbeddedResource Include="Test Files\generated\haxe\BeforeAssignStatementToVarFromCastExp.hx" />
     <EmbeddedResource Include="Test Files\generated\haxe\AfterAssignStatementToVarFromCastExp.hx" />
+    <EmbeddedResource Include="Test Files\generated\as3\BeforeAssignStatementToVarFromUnsafeCastExpr.as" />
+    <EmbeddedResource Include="Test Files\generated\as3\AfterAssignStatementToVarFromUnsafeCastExpr.as" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
@@ -1143,6 +1143,10 @@ namespace ASCompletion.Completion
                             new TestCaseData(ReadAllTextAS3("BeforeAssignStatementToVarFromNewVar"), GeneratorJobType.AssignStatementToVar, true)
                                 .Returns(ReadAllTextAS3("AfterAssignStatementToVarFromNewVar"))
                                 .SetName("from new Var()");
+                        yield return
+                            new TestCaseData(ReadAllTextAS3("BeforeAssignStatementToVarFromUnsafeCastExpr"), GeneratorJobType.AssignStatementToVar, true)
+                                .Returns(ReadAllTextAS3("AfterAssignStatementToVarFromUnsafeCastExpr"))
+                                .SetName("from (new type() as String)");
                     }
                 }
 

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromUnsafeCastExpr.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/AfterAssignStatementToVarFromUnsafeCastExpr.as
@@ -1,0 +1,8 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			var cls:Class = String;
+			var string:String = (new cls() as String)
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromUnsafeCastExpr.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/generated/as3/BeforeAssignStatementToVarFromUnsafeCastExpr.as
@@ -1,0 +1,8 @@
+﻿package {
+	public class Main {
+		public function Main() {
+			var cls:Class = String;
+			(new cls() as String)$(EntryPoint)
+		}
+	}
+}


### PR DESCRIPTION
```
   at System.Linq.Enumerable.Last[TSource](IEnumerable`1 source)
   at ASCompletion.Completion.ASGenerator.GetStatementReturnType(ScintillaControl sci, ClassModel inClass, String line, Int32 startPos)
   at ASCompletion.Completion.ASGenerator.AssignStatementToVar(ClassModel inClass, ScintillaControl sci, MemberModel member)
   at ASCompletion.Completion.ASGenerator.GenerateJob(GeneratorJobType job, MemberModel member, ClassModel inClass, String itemLabel, Object data)
   at ASCompletion.Completion.GeneratorItem.get_Value()
   at PluginCore.Controls.CompletionList.ReplaceText(ScintillaControl sci, String tail, Char trigger)
   at PluginCore.Controls.CompletionList.HandleKeys(ScintillaControl sci, Keys key)
   at PluginCore.Controls.UITools.HandleKeys(Keys key)
   at PluginCore.Controls.UITools.HandleEvent(Object sender, NotifyEvent e, HandlingPriority priority)
   at PluginCore.Managers.EventManager.DispatchEvent(Object sender, NotifyEvent e)
```