### PR TITLE
Check for missing AddClipboardFormatListener entry point

### DIFF
--- a/FlashDevelop/Managers/ClipboardManager.cs
+++ b/FlashDevelop/Managers/ClipboardManager.cs
@@ -44,12 +44,19 @@ namespace FlashDevelop.Managers
 
             if (Win32.ShouldUseWin32())
             {
-                hwnd = window.Handle;
-                if (!UnsafeNativeMethods.AddClipboardFormatListener(hwnd))
+                try
+                {
+                    hwnd = window.Handle;
+                    if (!UnsafeNativeMethods.AddClipboardFormatListener(hwnd))
+                    {
+                        hwnd = IntPtr.Zero;
+                        var ex = new Win32Exception(Marshal.GetLastWin32Error());
+                        throw new NotSupportedException(ex.Message, ex);
+                    }
+                }
+                catch (EntryPointNotFoundException)
                 {
                     hwnd = IntPtr.Zero;
-                    var ex = new Win32Exception(Marshal.GetLastWin32Error());
-                    throw new NotSupportedException(ex.Message, ex);
                 }
             }
 
@@ -78,7 +85,7 @@ namespace FlashDevelop.Managers
             {
                 throw new InvalidOperationException(nameof(ClipboardManager) + " is either not initialized or already disposed.");
             }
-            else if (Win32.ShouldUseWin32())
+            else if (hwnd != IntPtr.Zero)
             {
                 if (!UnsafeNativeMethods.RemoveClipboardFormatListener(hwnd))
                 {


### PR DESCRIPTION
Another solution (checks if Vista or higher): instead of `Win32.ShouldUseWin32()`
```c#
Environment.OSVersion.Platform == PlatformID.Win32NT && Environment.OSVersion.Version > 5
```

But since this is more about whether a certain function is available, I think checking for `EntryPointNotFoundException` makes more sense.

Closes #1621 