### PR TITLE
ResultsPanel Improvements v2

### DIFF
--- a/External/Plugins/ResultsPanel/Helpers/ResultsPanelHelper.cs
+++ b/External/Plugins/ResultsPanel/Helpers/ResultsPanelHelper.cs
@@ -160,7 +160,7 @@ namespace ResultsPanel.Helpers
                 }
             }
         }
-        
+
         /// <summary>
         /// Creates a new results panel.
         /// </summary>
@@ -205,7 +205,7 @@ namespace ResultsPanel.Helpers
                 var traceGroup = TraceManager.GetTraceGroup(groupId);
                 ui.GroupData = groupData;
                 ui.Text = string.Format(traceGroup.Title ?? TextHelper.GetString("Title.PluginPanel"), args);
-                ui.ParentPanel.Text = ui.Text; 
+                ui.ParentPanel.Text = ui.Text;
             }
         }
 

--- a/External/Plugins/ResultsPanel/Helpers/ResultsPanelHelper.cs
+++ b/External/Plugins/ResultsPanel/Helpers/ResultsPanelHelper.cs
@@ -102,8 +102,10 @@ namespace ResultsPanel.Helpers
             foreach (var pluginUI in pluginUIs)
             {
                 pluginUI.ApplySettings();
+                pluginUI.ClearSquiggles();
             }
-            
+
+            mainUI.ClearSquiggles();
             mainUI.AddSquiggles();
             if (mainUI.Settings.HighlightOnlyActivePanelEntries)
             {

--- a/External/Plugins/ResultsPanel/ListViewEx.cs
+++ b/External/Plugins/ResultsPanel/ListViewEx.cs
@@ -1,6 +1,5 @@
 ﻿using PluginCore;
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
 using System.Windows.Forms.VisualStyles;
@@ -35,7 +34,7 @@ namespace ResultsPanel
             upArrowIndex = SmallImageList.Images.Count - 2;
             downArrowIndex = upArrowIndex + 1;
         }
-        
+
         internal void SortGroups(ColumnHeader columnHeader, SortOrder sortOrder, Comparison<ListViewGroup> comparison)
         {
             SetArrow(columnHeader, sortOrder);
@@ -43,24 +42,53 @@ namespace ResultsPanel
             SortedColumn = columnHeader;
             SortOrder = sortOrder;
 
-            var groups = new ListViewGroup[Groups.Count];
-            Groups.CopyTo(groups, 0);
-
-            switch (sortOrder)
+            if (sortOrder != SortOrder.None)
             {
-                case SortOrder.None:
-                    break;
-                case SortOrder.Ascending:
-                    Array.Sort(groups, comparison);
-                    break;
-                case SortOrder.Descending:
-                    Array.Sort(groups, comparison);
-                    Array.Reverse(groups);
-                    break;
-            }
+                var groups = new ListViewGroup[Groups.Count];
+                Groups.CopyTo(groups, 0);
 
-            Groups.Clear();
-            Groups.AddRange(groups);
+                switch (sortOrder)
+                {
+                    case SortOrder.Ascending:
+                        Array.Sort(groups, comparison);
+                        break;
+                    case SortOrder.Descending:
+                        Array.Sort(groups, comparison);
+                        Array.Reverse(groups);
+                        break;
+                }
+
+                Groups.Clear();
+                Groups.AddRange(groups);
+            }
+        }
+
+        internal void SortItems(ColumnHeader columnHeader, SortOrder sortOrder, Comparison<ListViewItem> comparison)
+        {
+            SetArrow(columnHeader, sortOrder);
+
+            SortedColumn = columnHeader;
+            SortOrder = sortOrder;
+
+            if (sortOrder != SortOrder.None)
+            {
+                var items = new ListViewItem[Items.Count];
+                Items.CopyTo(items, 0);
+
+                switch (sortOrder)
+                {
+                    case SortOrder.Ascending:
+                        Array.Sort(items, comparison);
+                        break;
+                    case SortOrder.Descending:
+                        Array.Sort(items, comparison);
+                        Array.Reverse(items);
+                        break;
+                }
+
+                Items.Clear();
+                Items.AddRange(items);
+            }
         }
 
         protected override void OnDrawColumnHeader(object sender, DrawListViewColumnHeaderEventArgs e)
@@ -70,7 +98,7 @@ namespace ResultsPanel
             Color back = PluginBase.MainForm.GetThemeColor("ColumnHeader.BackColor");
             Color text = PluginBase.MainForm.GetThemeColor("ColumnHeader.TextColor");
             Color border = PluginBase.MainForm.GetThemeColor("ColumnHeader.BorderColor");
-            
+
             if (UseTheme && back != Color.Empty && border != Color.Empty && text != Color.Empty)
             {
                 base.OnDrawColumnHeader(sender, e);
@@ -145,7 +173,7 @@ namespace ResultsPanel
             {
                 order = SortOrder;
             }
-            
+
             VisualStyleElement arrow = null;
             switch (order)
             {

--- a/External/Plugins/ResultsPanel/PluginUI.cs
+++ b/External/Plugins/ResultsPanel/PluginUI.cs
@@ -69,19 +69,12 @@ namespace ResultsPanel
             this.warningCount = 0;
             this.messageCount = 0;
             this.sortOrder = SortOrder.Ascending;
-            this.lastColumn = -1;
             this.InitializeComponent();
             this.InitializeContextMenu();
             this.InitializeGraphics();
             this.InitializeTexts();
             this.InitializeLayout();
             ScrollBarEx.Attach(entriesView);
-
-            this.entryFile.Tag = GroupingMethod.File;
-            this.entryDesc.Tag = GroupingMethod.Description;
-            this.entryType.Tag = GroupingMethod.Type;
-            this.entryPath.Tag = GroupingMethod.Path;
-            this.entryLine.Tag = GroupingMethod.Line;
 
             GroupData = groupData;
             GroupId = groupId;
@@ -105,6 +98,20 @@ namespace ResultsPanel
                 this.toolStripFilters.Items.Insert(0, this.toolStripButtonInfo);
             }
 
+            this.entryFile.Tag = GroupingMethod.File;
+            this.entryType.Tag = GroupingMethod.Type;
+            this.entryDesc.Tag = GroupingMethod.Description;
+            this.entryPath.Tag = GroupingMethod.Path;
+            this.entryLine.Tag = GroupingMethod.Line;
+            this.groupingMethod = Settings.DefaultGrouping;
+            this.lastColumn = new Dictionary<GroupingMethod, ColumnHeader>()
+            {
+                [(GroupingMethod) this.entryFile.Tag] = this.entryFile,
+                [(GroupingMethod) this.entryType.Tag] = this.entryType,
+                [(GroupingMethod) this.entryDesc.Tag] = this.entryDesc,
+                [(GroupingMethod) this.entryPath.Tag] = this.entryPath,
+                [(GroupingMethod) this.entryLine.Tag] = this.entryLine
+            }[this.groupingMethod].Index;
             ApplySettings(false);
         }
 
@@ -208,9 +215,10 @@ namespace ResultsPanel
             this.entryPath});
             this.entriesView.Dock = System.Windows.Forms.DockStyle.Fill;
             this.entriesView.FullRowSelect = true;
-            this.entriesView.GridLines = true;
+            this.entriesView.GridLines = false;
             this.entriesView.Location = new System.Drawing.Point(0, 28);
             this.entriesView.Name = "entriesView";
+            this.entriesView.ShowGroups = true;
             this.entriesView.ShowItemToolTips = true;
             this.entriesView.Size = new System.Drawing.Size(710, 218);
             this.entriesView.TabIndex = 1;
@@ -436,7 +444,7 @@ namespace ResultsPanel
             {
                 invalidate = false;
             }
-            
+
             if (invalidate)
             {
                 FilterResults();

--- a/External/Plugins/ResultsPanel/Settings.cs
+++ b/External/Plugins/ResultsPanel/Settings.cs
@@ -29,7 +29,7 @@ namespace ResultsPanel
         }
 
         [DisplayName("Highlight Only Active Panel Entries")]
-        [LocalizedDescription("ResultsPanel.Description.HighlightOnlyActivePanelEntries"), DefaultValue(true)]
+        [LocalizedDescription("ResultsPanel.Description.HighlightOnlyActivePanelEntries"), DefaultValue(false)]
         public bool HighlightOnlyActivePanelEntries
         {
             get { return highlightOnlyActivePanelEntries; }

--- a/External/Plugins/ResultsPanel/Settings.cs
+++ b/External/Plugins/ResultsPanel/Settings.cs
@@ -10,6 +10,7 @@ namespace ResultsPanel
         private Boolean scrollToBottom = false;
         private GroupingMethod defaultGroup = GroupingMethod.File;
         private Boolean highlightOnlyActivePanelEntries = false;
+        private Boolean keepResultsByDefault = false;
 
         [DisplayName("Scroll To Bottom")]
         [LocalizedDescription("ResultsPanel.Description.ScrollToBottom"), DefaultValue(false)]
@@ -33,6 +34,14 @@ namespace ResultsPanel
         {
             get { return highlightOnlyActivePanelEntries; }
             set { highlightOnlyActivePanelEntries = value; }
+        }
+
+        [DisplayName("Keep Results By Default")]
+        [LocalizedDescription("ResultsPanel.Description.KeepResultsByDefault"), DefaultValue(false)]
+        public bool KeepResultsByDefault
+        {
+            get { return keepResultsByDefault; }
+            set { keepResultsByDefault = value; }
         }
     }
 

--- a/PluginCore/PluginCore/Resources/de_DE.resx
+++ b/PluginCore/PluginCore/Resources/de_DE.resx
@@ -6170,4 +6170,8 @@ AND - All conditions are met.</value>
     <value>Highlight only the entries in the active panel and the main panel.</value>
     <comment>Added after 5.2.0</comment>
   </data>
+  <data name="ResultsPanel.Description.KeepResultsByDefault" xml:space="preserve">
+    <value>Keep result panels locked by default.</value>
+    <comment>Added after 5.2.0</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/en_US.resx
+++ b/PluginCore/PluginCore/Resources/en_US.resx
@@ -6185,4 +6185,8 @@ AND - All conditions are met.</value>
     <value>Highlight only the entries in the active panel and the main panel.</value>
     <comment>Added after 5.2.0</comment>
   </data>
+  <data name="ResultsPanel.Description.KeepResultsByDefault" xml:space="preserve">
+    <value>Keep result panels locked by default.</value>
+    <comment>Added after 5.2.0</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/eu_ES.resx
+++ b/PluginCore/PluginCore/Resources/eu_ES.resx
@@ -6167,4 +6167,8 @@ AND - All conditions are met.</value>
     <value>Highlight only the entries in the active panel and the main panel.</value>
     <comment>Added after 5.2.0</comment>
   </data>
+  <data name="ResultsPanel.Description.KeepResultsByDefault" xml:space="preserve">
+    <value>Keep result panels locked by default.</value>
+    <comment>Added after 5.2.0</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/ja_JP.resx
+++ b/PluginCore/PluginCore/Resources/ja_JP.resx
@@ -6228,4 +6228,8 @@ AND - All conditions are met.</value>
     <value>Highlight only the entries in the active panel and the main panel.</value>
     <comment>Added after 5.2.0</comment>
   </data>
+  <data name="ResultsPanel.Description.KeepResultsByDefault" xml:space="preserve">
+    <value>Keep result panels locked by default.</value>
+    <comment>Added after 5.2.0</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/ko_KR.resx
+++ b/PluginCore/PluginCore/Resources/ko_KR.resx
@@ -6189,4 +6189,8 @@ AND - 모든 조건을 만족할때.</value>
     <value>Highlight only the entries in the active panel and the main panel.</value>
     <comment>Added after 5.2.0</comment>
   </data>
+  <data name="ResultsPanel.Description.KeepResultsByDefault" xml:space="preserve">
+    <value>Keep result panels locked by default.</value>
+    <comment>Added after 5.2.0</comment>
+  </data>
 </root>

--- a/PluginCore/PluginCore/Resources/zh_CN.resx
+++ b/PluginCore/PluginCore/Resources/zh_CN.resx
@@ -6180,4 +6180,8 @@ AND - All conditions are met.</value>
     <value>Highlight only the entries in the active panel and the main panel.</value>
     <comment>Added after 5.2.0</comment>
   </data>
+  <data name="ResultsPanel.Description.KeepResultsByDefault" xml:space="preserve">
+    <value>Keep result panels locked by default.</value>
+    <comment>Added after 5.2.0</comment>
+  </data>
 </root>


### PR DESCRIPTION
- Added `KeepResultsByDefault` setting.
- View Menu for multiple panels as a drop down.
  - Note that hidden panels are present in the drop down list. However closed panels are not.
- Sorting improved:
  - You can now sort by line numbers.
  - Sorting by line numbers or descriptions does not group the entries.
    - This is because their values are likely to be all unique, thus it will only create groups with only one or two entries otherwise.
- `DefaultGrouping` setting does not affect panels that already exist anymore.
- `HighlightOnlyActivePanelEntries` setting defaults to `false`.
- Bug fixes:
  - `RefreshSquiggles()` should respect the settings.
  - Only refresh when related settings have changed.

Closes #1596 
Related to issue 1 in #1601 