### PR TITLE
Fix ScintillaCommand exception with overloaded methods

### DIFF
--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -4103,7 +4103,7 @@ namespace FlashDevelop
                 ToolStripItem button = (ToolStripItem)sender;
                 String command = ((ItemData)button.Tag).Tag;
                 Type mfType = Globals.SciControl.GetType();
-                MethodInfo method = mfType.GetMethod(command);
+                MethodInfo method = mfType.GetMethod(command, new Type[0]);
                 method.Invoke(Globals.SciControl, null);
             }
             catch (Exception ex)


### PR DESCRIPTION
When the method is overloaded, ScintillaCommand throws an exception without parameter types explicitly specified.