### PR TITLE
Refactoring for highlights management

### DIFF
--- a/External/Plugins/HaXeContext/Completion/HaxeComplete.cs
+++ b/External/Plugins/HaXeContext/Completion/HaxeComplete.cs
@@ -258,7 +258,6 @@ namespace HaXeContext
                         Errors = lines;
                         return HaxeCompleteStatus.ERROR;
                     }
-                    break;
                 default:
                     try
                     {

--- a/External/Plugins/HaXeContext/Linters/DiagnosticsLinter.cs
+++ b/External/Plugins/HaXeContext/Linters/DiagnosticsLinter.cs
@@ -68,7 +68,7 @@ namespace HaXeContext.Linters
                                     result.Severity = LintingSeverity.Error;
                                     break;
                                 case HaxeDiagnosticsSeverity.WARNING:
-                                    result.Severity = LintingSeverity.Info;
+                                    result.Severity = LintingSeverity.Warning;
                                     break;
                                 default:
                                     continue;

--- a/External/Plugins/HaXeContext/Linters/DiagnosticsLinter.cs
+++ b/External/Plugins/HaXeContext/Linters/DiagnosticsLinter.cs
@@ -15,14 +15,6 @@ namespace HaXeContext.Linters
 {
     class DiagnosticsLinter : ILintProvider
     {
-        static readonly Dictionary<HaxeDiagnosticsSeverity, LintingSeverity> DiagnosticsSeverityToLintingSeverity =
-            new Dictionary<HaxeDiagnosticsSeverity, LintingSeverity>
-            {
-                {HaxeDiagnosticsSeverity.ERROR, LintingSeverity.Error},
-                {HaxeDiagnosticsSeverity.INFO, LintingSeverity.Info},
-                {HaxeDiagnosticsSeverity.WARNING, LintingSeverity.Warning}
-            };
-
         public void LintAsync(string[] files, LintCallback callback)
         {
             var context = ASContext.GetLanguageContext("haxe") as Context;
@@ -65,8 +57,22 @@ namespace HaXeContext.Linters
                                 FirstChar = res.Range.CharacterStart,
                                 Length = lastChar - firstChar,
                                 Line = line,
-                                Severity = DiagnosticsSeverityToLintingSeverity[res.Severity]
                             };
+
+                            switch (res.Severity)
+                            {
+                                case HaxeDiagnosticsSeverity.INFO:
+                                    result.Severity = LintingSeverity.Info;
+                                    break;
+                                case HaxeDiagnosticsSeverity.ERROR:
+                                    result.Severity = LintingSeverity.Error;
+                                    break;
+                                case HaxeDiagnosticsSeverity.WARNING:
+                                    result.Severity = LintingSeverity.Info;
+                                    break;
+                                default:
+                                    continue;
+                            }
 
                             switch (res.Kind)
                             {

--- a/External/Plugins/LintingHelper/Managers/LintingManager.cs
+++ b/External/Plugins/LintingHelper/Managers/LintingManager.cs
@@ -161,7 +161,7 @@ namespace LintingHelper.Managers
             var cachedResults = Cache.GetAllResults();
             foreach (var result in cachedResults)
             {
-                string chars = null;
+                string chars;
                 if (result.Length > 0)
                 {
                     chars = $"chars {result.FirstChar}-{result.FirstChar + result.Length}";
@@ -196,11 +196,6 @@ namespace LintingHelper.Managers
                 }
                 TraceManager.Add(message, state, TraceGroup);
             }
-
-            PluginBase.RunAsync(() =>
-            {
-                PluginBase.MainForm.CallCommand("PluginCommand", "ResultsPanel.ShowResults;" + TraceGroup);
-            });
         }
     }
 }

--- a/External/Plugins/ResultsPanel/PluginUI.cs
+++ b/External/Plugins/ResultsPanel/PluginUI.cs
@@ -1116,50 +1116,77 @@ namespace ResultsPanel
         /// </summary>
         private void AddSquiggle(ListViewItem item)
         {
-            bool fixIndexes = true;
-            Match match = errorCharacters.Match(item.SubItems[2].Text);
-            if (match.Success)
+            ITabbedDocument document = null;
+            string fileName = GetFileName(item);
+            foreach (var doc in PluginBase.MainForm.Documents)
             {
-                // An error with this pattern is most likely a MTASC error (not multibyte)
-                if (item.ImageIndex != 0) fixIndexes = false;
-            }
-            else match = errorCharacter.Match(item.SubItems[2].Text);
-            if (!match.Success) match = errorCharacters2.Match(item.SubItems[2].Text);
-            if (match.Success)
-            {
-                string fileName = GetFileName(item);
-                int line = Convert.ToInt32(item.SubItems[1].Text) - 1;
-                int style = (int) ((item.ImageIndex == 0) ? IndicatorStyle.RoundBox : IndicatorStyle.Squiggle);
-                int indicator = (item.ImageIndex == 0) ? 0 : 2;
-                foreach (var document in PluginBase.MainForm.Documents)
+                if (fileName == doc.FileName)
                 {
-                    if (document.IsEditable && fileName == document.FileName)
-                    {
-                        ScintillaControl sci = document.SciControl;
-                        int fore = (item.ImageIndex == 0) ? PluginBase.MainForm.SciConfig.GetLanguage(sci.ConfigurationLanguage).editorstyle.HighlightBackColor : 0x000000ff;
-                        int end;
-                        int start = Convert.ToInt32(match.Groups["start"].Value);
-                        // start column is (probably) a multibyte length
-                        if (fixIndexes) start = this.MBSafeColumn(sci, line, start);
-                        if (match.Groups["end"] != null && match.Groups["end"].Success)
-                        {
-                            end = Convert.ToInt32(match.Groups["end"].Value);
-                            // end column is (probably) a multibyte length
-                            if (fixIndexes) end = this.MBSafeColumn(sci, line, end);
-                        }
-                        else
-                        {
-                            start = Math.Max(1, Math.Min(sci.LineLength(line) - 1, start));
-                            end = start--;
-                        }
-                        if ((start >= 0) && (end > start) && (end < sci.TextLength))
-                        {
-                            int position = sci.PositionFromLine(line) + start;
-                            sci.AddHighlight(indicator, style, fore, position, end - start);
-                        }
-                        break;
-                    }
+                    document = doc;
+                    break;
                 }
+            }
+            if (document == null || !document.IsEditable)
+            {
+                return;
+            }
+            var sci = document.SciControl;
+
+            int line = Convert.ToInt32(item.SubItems[1].Text) - 1;
+            string description = item.SubItems[2].Text;
+            int start, end;
+            Match match;
+            if ((match = errorCharacters.Match(description)).Success) // "chars {start}-{end}"
+            {
+                start = Convert.ToInt32(match.Groups["start"].Value);
+                end = Convert.ToInt32(match.Groups["end"].Value);
+                // An error (!=0) with this pattern is most likely a MTASC error (not multibyte)
+                if (item.ImageIndex == 0)
+                {
+                    // start & end columns are multibyte lengths
+                    start = this.MBSafeColumn(sci, line, start);
+                    end = this.MBSafeColumn(sci, line, end);
+                }
+            }
+            else if ((match = errorCharacter.Match(description)).Success // "char {start}"
+                || (match = errorCharacters2.Match(description)).Success) // "col: {start}"
+            {
+                start = Convert.ToInt32(match.Groups["start"].Value);
+                // column is a multibyte length
+                start = this.MBSafeColumn(sci, line, start);
+                end = start + 1;
+            }
+            else
+            {
+                return;
+            }
+            if (0 <= start && start < end && end <= sci.TextLength)
+            {
+                int indicator;
+                int style;
+                int color;
+                switch (item.ImageIndex)
+                {
+                    case 0:
+                        indicator = (int) TraceType.Info;
+                        style = (int) IndicatorStyle.RoundBox;
+                        color = PluginBase.MainForm.SciConfig.GetLanguage(sci.ConfigurationLanguage).editorstyle.HighlightBackColor;
+                        break;
+                    case 1:
+                        indicator = (int) TraceType.Error;
+                        style = (int) IndicatorStyle.Squiggle;
+                        color = PluginBase.MainForm.SciConfig.GetLanguage(sci.ConfigurationLanguage).editorstyle.ErrorLineBack;
+                        break;
+                    case 2:
+                        indicator = (int) TraceType.Warning;
+                        style = (int) IndicatorStyle.Squiggle;
+                        color = PluginBase.MainForm.SciConfig.GetLanguage(sci.ConfigurationLanguage).editorstyle.DebugLineBack;
+                        break;
+                    default:
+                        return;
+                }
+                int position = sci.PositionFromLine(line) + start;
+                sci.AddHighlight(indicator, style, color, position, end - start);
             }
         }
 
@@ -1174,11 +1201,16 @@ namespace ResultsPanel
                 string fileName = GetFileName(item);
                 foreach (var document in PluginBase.MainForm.Documents)
                 {
-                    var sci = document.SciControl;
-                    if (fileName == document.FileName && !cleared.Contains(fileName))
+                    if (fileName == document.FileName)
                     {
-                        sci.RemoveHighlights((item.ImageIndex == 0) ? 0 : 2);
-                        cleared.Add(fileName);
+                        if (!cleared.Contains(fileName))
+                        {
+                            var sci = document.SciControl;
+                            sci.RemoveHighlights((int) TraceType.Info);
+                            sci.RemoveHighlights((int) TraceType.Error);
+                            sci.RemoveHighlights((int) TraceType.Warning);
+                            cleared.Add(fileName);
+                        }
                         break;
                     }
                 }
@@ -1260,7 +1292,7 @@ namespace ResultsPanel
         */
         private static Regex errorCharacter = new Regex("(character|char)[\\s]+[^0-9]*(?<start>[0-9]+)", RegexOptions.Compiled);
         private static Regex errorCharacters = new Regex("(characters|chars)[\\s]+[^0-9]*(?<start>[0-9]+)-(?<end>[0-9]+)", RegexOptions.Compiled);
-        private static Regex errorCharacters2 = new Regex(@"col: (?<start>[0-9]+)\s*", RegexOptions.Compiled);
+        private static Regex errorCharacters2 = new Regex("col: (?<start>[0-9]+)\\s*", RegexOptions.Compiled);
 
         #endregion
 

--- a/PluginCore/ScintillaNet/Configuration/EditorStyle.cs
+++ b/PluginCore/ScintillaNet/Configuration/EditorStyle.cs
@@ -60,39 +60,35 @@ namespace ScintillaNet.Configuration
         [XmlAttribute("colorize-marker-back")]
         public string colorizemarkerback;
 
-        public int ResolveColor(string aColor)
+        public int ResolveColor(string colorString)
         {
-            if (aColor != null)
+            if (string.IsNullOrEmpty(colorString))
             {
-                Value v = _parent.MasterScintilla.GetValue(aColor);
-                while (v != null)
-                {
-                    aColor = v.val;
-                    v = _parent.MasterScintilla.GetValue(aColor);
-                }
-                Color c = Color.FromName(aColor);
-                if (c.ToArgb() == 0)
-                {
-                    if (aColor.IndexOfOrdinal("0x") == 0)
-                    {
-                        return TO_COLORREF(Int32.Parse(aColor.Substring(2), NumberStyles.HexNumber));
-                    } 
-                    else 
-                    {
-                        try
-                        {
-                            return TO_COLORREF(Int32.Parse(aColor));
-                        }
-                        catch (Exception){}
-                    }
-                }
-                return TO_COLORREF(c.ToArgb() & 0x00ffffff);
+                return 0x000000;
             }
-            return 0;
+            var value = _parent.MasterScintilla.GetValue(colorString);
+            while (value != null)
+            {
+                colorString = value.val;
+                value = _parent.MasterScintilla.GetValue(colorString);
+            }
+            int color = Color.FromName(colorString).ToArgb();
+            if (color == 0x00000000)
+            {
+                if (!colorString.StartsWithOrdinal("0x") || !int.TryParse(colorString.Substring(2), NumberStyles.HexNumber, null, out color))
+                {
+                    int.TryParse(colorString, out color);
+                }
+            }
+            return TO_COLORREF(color);
         }
-        private int TO_COLORREF(int c)
+
+        /// <summary>
+        /// Converts ARGB color value to Scintilla's Colour format (BGR)
+        /// </summary>
+        private int TO_COLORREF(int color)
         {
-            return (((c & 0xff0000) >> 16)+((c & 0x0000ff) << 16)+(c & 0x00ff00));
+            return ((color & 0xFF0000) >> 16) + (color & 0x00FF00) + ((color & 0x0000FF) << 16);
         }
         
         public int CaretForegroundColor
@@ -271,7 +267,7 @@ namespace ScintillaNet.Configuration
                 {
                     return ResolveColor(debuglineback);
                 }
-                return ResolveColor("0xffff00");
+                return ResolveColor("0xffa500");
             }
         }
 


### PR DESCRIPTION
Instead of directly accessing scintilla highlighting api from LintingHelper, let ResultsPanel manage all highlighting.

Also change the default colour of warning (`DebugLineBack`) to orange from yellow, since it was barely visible with a default white background.