### PR TITLE
ScintillaControl.DeleteForward() should call Clear()

### DIFF
--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -4238,8 +4238,7 @@ namespace ScintillaNet
         /// </summary>
         public void DeleteForward()
         {
-            SetSel(CurrentPos + 1, CurrentPos + 1);
-            DeleteBack();
+            Clear();
         }
 
         /// <summary>


### PR DESCRIPTION
`Clear()` is the method that gets executed when Del key is pressed.