### PR TITLE
Fix new results panel affecting other panel's layout

### DIFF
--- a/FlashDevelop/Docking/DockablePanel.cs
+++ b/FlashDevelop/Docking/DockablePanel.cs
@@ -24,7 +24,6 @@ namespace FlashDevelop.Docking
             this.HideOnClose = true;
             this.Controls.Add(ctrl);
             Globals.MainForm.ThemeControls(this);
-            this.Show();
         }
 
         /// <summary>

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -576,6 +576,7 @@ namespace FlashDevelop
             try
             {
                 DockablePanel dockablePanel = new DockablePanel(ctrl, guid);
+                dockablePanel.Show();
                 dockablePanel.Image = image;
                 dockablePanel.DockState = defaultDockState;
                 LayoutManager.PluginPanels.Add(dockablePanel);
@@ -600,6 +601,7 @@ namespace FlashDevelop
                 dockablePanel.DockState = defaultDockState;
                 LayoutManager.SetContentLayout(dockablePanel, dockablePanel.GetPersistString());
                 LayoutManager.PluginPanels.Add(dockablePanel);
+                dockablePanel.Show(); //show after setting correct dockstate, because otherwise it can affect the rest of the layout
                 return dockablePanel;
             }
             catch (Exception e)


### PR DESCRIPTION
When a new DockablePanel is added, it shown immediately before it's DockState is set. This causes it to be added to the right (where the Outline, Project, etc. panel are in the default layout) and then moved to the correct place immediately. However, this means, the focus of the "tabbed" panels on the right will change to the first one (instead of where it was before).
This PR should fix this behaviour.