### PR TITLE
Prevent dynamic persist panel from force-activating

### DIFF
--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -576,7 +576,6 @@ namespace FlashDevelop
             try
             {
                 DockablePanel dockablePanel = new DockablePanel(ctrl, guid);
-                dockablePanel.Show();
                 dockablePanel.Image = image;
                 dockablePanel.DockState = defaultDockState;
                 LayoutManager.PluginPanels.Add(dockablePanel);
@@ -601,7 +600,6 @@ namespace FlashDevelop
                 dockablePanel.DockState = defaultDockState;
                 LayoutManager.SetContentLayout(dockablePanel, dockablePanel.GetPersistString());
                 LayoutManager.PluginPanels.Add(dockablePanel);
-                dockablePanel.Show(); //show after setting correct dockstate, because otherwise it can affect the rest of the layout
                 return dockablePanel;
             }
             catch (Exception e)

--- a/FlashDevelop/Managers/LayoutManager.cs
+++ b/FlashDevelop/Managers/LayoutManager.cs
@@ -108,7 +108,7 @@ namespace FlashDevelop.Managers
                     dockablePanel.AutoHidePortion = pluginPanel.AutoHidePortion;
                     dockablePanel.IsFloat = pluginPanel.IsFloat;
                     dockablePanel.Pane = pluginPanel.Pane;
-                    break;
+                    return;
                 }
             }
             for (int i = 0; i < dynamicContentTemplates.Count; i++)
@@ -124,9 +124,10 @@ namespace FlashDevelop.Managers
                     // No need for a template if a new window exists.
                     dynamicContentTemplates.RemoveAt(i);
                     template.Close();
-                    break;
+                    return;
                 }
             }
+            dockablePanel.Show();
         }
         
         /// <summary>

--- a/FlashDevelop/Managers/LayoutManager.cs
+++ b/FlashDevelop/Managers/LayoutManager.cs
@@ -114,7 +114,7 @@ namespace FlashDevelop.Managers
             for (int i = 0; i < dynamicContentTemplates.Count; i++)
             {
                 var template = dynamicContentTemplates[i];
-                if (template.GetPersistString() == dockablePanel.GetPersistString())
+                if (template.GetPersistString() == persistString)
                 {
                     dockablePanel.DockPanel = template.DockPanel;
                     dockablePanel.AutoHidePortion = template.AutoHidePortion;


### PR DESCRIPTION
Copy paste from the commit message:

>Panels created using CreateDockablePanel() are expected to be created
during plugin initialization, which is right before
LayoutManager.BuildLayoutSystems(). That method ensures that all panels
are in the correct place, and shows unregistered panels as floating,
essentially making the call to Show() in CreateDockablePanel()
unnecessary.
Panels created using CreateDynamicPersistDockablePanel() are also called
LayoutManager.SetContentLayout(), which ensures the panel is in the
correct place if registered. Adding Show() at the end ensures the panel
is shown when the panel information isn't stored in the layout file.

`dockablePanel.Show()` in `CreateDynamicPersistDockablePanel()` was causing the panel to be activated upon creation, even when the panel was registered.