### PR TITLE
EventManager refactored

### DIFF
--- a/PluginCore/PluginCore/Managers/EventManager.cs
+++ b/PluginCore/PluginCore/Managers/EventManager.cs
@@ -9,17 +9,15 @@ namespace PluginCore.Managers
     /// </summary>
     public static class EventManager
     {
-        private const int PriorityCount = 3;
-        private static List<EventObject>[] eventObjects;
+        private static List<EventObject> highObjects;
+        private static List<EventObject> normalObjects;
+        private static List<EventObject> lowObjects;
 
         static EventManager()
         {
-            eventObjects = new List<EventObject>[PriorityCount]
-            {
-                new List<EventObject>(),
-                new List<EventObject>(),
-                new List<EventObject>(),
-            };
+            highObjects = new List<EventObject>();
+            normalObjects = new List<EventObject>();
+            lowObjects = new List<EventObject>();
         }
 
         /// <summary>
@@ -35,7 +33,7 @@ namespace PluginCore.Managers
         /// </summary>
         public static void AddEventHandler(IEventHandler handler, EventType mask, HandlingPriority priority)
         {
-            GetObjects(priority).Add(new EventObject(handler, mask, priority));
+            GetEventObjects(priority).Add(new EventObject(handler, mask, priority));
         }
 
         /// <summary>
@@ -43,14 +41,15 @@ namespace PluginCore.Managers
         /// </summary>
         public static void RemoveEventHandler(IEventHandler handler)
         {
-            for (int i = 0; i < PriorityCount; i++)
+            var eventObjectsList = new[] { highObjects, normalObjects, lowObjects };
+            for (int i = 0; i < eventObjectsList.Length; i++)
             {
-                var objects = eventObjects[i];
-                for (int j = 0; j < objects.Count; j++)
+                var eventObjects = eventObjectsList[i];
+                for (int j = 0; j < eventObjects.Count; j++)
                 {
-                    if (objects[j].Handler == handler)
+                    if (eventObjects[j].Handler == handler)
                     {
-                        objects.RemoveAt(j);
+                        eventObjects.RemoveAt(j);
                         break;
                     }
                 }
@@ -62,16 +61,16 @@ namespace PluginCore.Managers
         /// </summary>
         public static void RemoveEventHandler(IEventHandler handler, EventType mask, HandlingPriority priority)
         {
-            var objects = GetObjects(priority);
-            for (int i = 0; i < objects.Count; i++)
+            var eventObjects = GetEventObjects(priority);
+            for (int i = 0; i < eventObjects.Count; i++)
             {
-                var obj = objects[i];
+                var obj = eventObjects[i];
                 if (obj.Handler == handler)
                 {
                     obj.Mask &= ~mask;
                     if (obj.Mask == 0)
                     {
-                        objects.RemoveAt(i);
+                        eventObjects.RemoveAt(i);
                     }
                     break;
                 }
@@ -83,23 +82,27 @@ namespace PluginCore.Managers
         /// </summary>
         public static void DispatchEvent(object sender, NotifyEvent e)
         {
-            for (int i = 0; i < PriorityCount; i++)
+            var eventObjects = new EventObject[highObjects.Count + normalObjects.Count + lowObjects.Count];
+            highObjects.CopyTo(eventObjects);
+            normalObjects.CopyTo(eventObjects, highObjects.Count);
+            lowObjects.CopyTo(eventObjects, highObjects.Count + normalObjects.Count);
+
+            for (int i = 0; i < eventObjects.Length; i++)
             {
-                var objects = eventObjects[i];
-                for (int j = 0; j < objects.Count; j++)
+                var obj = eventObjects[i];
+                if ((obj.Mask & e.Type) > e.Type)
                 {
-                    var obj = objects[j];
-                    if ((obj.Mask & e.Type) == e.Type)
+                    try
                     {
-                        try
-                        {
-                            obj.Handler.HandleEvent(sender, e, obj.Priority);
-                        }
-                        catch (Exception ex)
-                        {
-                            ErrorManager.ShowError(ex);
-                        }
-                        if (e.Handled) return;
+                        obj.Handler.HandleEvent(sender, e, obj.Priority);
+                    }
+                    catch (Exception ex)
+                    {
+                        ErrorManager.ShowError(ex);
+                    }
+                    if (e.Handled)
+                    {
+                        break;
                     }
                 }
             }
@@ -108,14 +111,16 @@ namespace PluginCore.Managers
         /// <summary>
         /// Gets the list of event objects with the specified priority.
         /// </summary>
-        private static List<EventObject> GetObjects(HandlingPriority priority)
+        private static List<EventObject> GetEventObjects(HandlingPriority priority)
         {
             switch (priority)
             {
                 case HandlingPriority.High:
+                    return highObjects;
                 case HandlingPriority.Normal:
+                    return normalObjects;
                 case HandlingPriority.Low:
-                    return eventObjects[(int) priority];
+                    return lowObjects;
                 default:
                     throw new InvalidEnumArgumentException(nameof(priority), (int) priority, typeof(HandlingPriority));
             }


### PR DESCRIPTION
Fixes the bug on `RemoveEventHandler()` which checks for equality of two instances of `EventObject` which would never be `true`.
Also, the `try...catch` block is moved to wrap each `HandleEvent()` calls to prevent an exception from stopping the whole event dispatch process.
Includes some more refactoring.