### PR TITLE
Update appman.xml: latest Flex SDK + AIR SDK, AIR SDK + ASC 2.0, Adob…

### DIFF
--- a/appman.xml
+++ b/appman.xml
@@ -32,8 +32,8 @@
 	<Entry>
 		<Id>flexairsdk</Id>
 		<Name>Flex SDK + AIR SDK</Name>
-		<Version>4.6.0+25.0.0</Version>
-		<Build>23201B+134</Build>
+		<Version>4.6.0+26.0.0</Version>
+		<Build>23201B+118</Build>
 		<Desc>Adobe Flex SDK merged with Adobe AIR SDK</Desc>
 		<Info>http://www.adobe.com/devnet/air.html</Info>
 		<Group>Compilers</Group>
@@ -42,15 +42,15 @@
 		</Bundles>
 		<Urls>
 			<Url>http://fpdownload.adobe.com/pub/flex/sdk/builds/flex4.6/flex_sdk_4.6.0.23201B.zip</Url>
-			<Url>http://airdownload.adobe.com/air/win/download/25.0/AdobeAIRSDK.zip</Url>
-			<Url>http://www.flashdevelop.org/appman/frameworks_flexsdk_9-25.zip</Url>
+			<Url>http://airdownload.adobe.com/air/win/download/26.0/AdobeAIRSDK.zip</Url>
+			<Url>http://www.flashdevelop.org/appman/frameworks_flexsdk_9-26.zip</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>ascsdk</Id>		
 		<Name>AIR SDK + ASC 2.0</Name>
-		<Version>25.0.0</Version>
-		<Build>134</Build>
+		<Version>26.0.0</Version>
+		<Build>118</Build>
 		<Desc>Adobe AIR SDK with ASC 2.0</Desc>
 		<Info>http://www.adobe.com/devnet/air.html</Info>
 		<Group>Compilers</Group>
@@ -58,8 +58,8 @@
 			<Bundle>AIR</Bundle>
 		</Bundles>
 		<Urls>
-			<Url>http://airdownload.adobe.com/air/win/download/25.0/AIRSDK_Compiler.zip</Url>
-			<Url>http://www.flashdevelop.org/appman/frameworks_flexsdk_9-25.zip</Url>
+			<Url>http://airdownload.adobe.com/air/win/download/26.0/AIRSDK_Compiler.zip</Url>
+			<Url>http://www.flashdevelop.org/appman/frameworks_flexsdk_9-26.zip</Url>
 		</Urls>
 	</Entry>
 	<Entry>
@@ -73,7 +73,7 @@
 			<Bundle>Flex</Bundle>
 		</Bundles>
 		<Type>Executable</Type>
-		<Info>http://flex.apache.org/index.html</Info>
+		<Info>http://flex.apache.org/</Info>
 		<Urls>
 			<Url>http://www.apache.org/dyn/closer.lua/flex/installer/3.2/binaries/apache-flex-sdk-installer-3.2.0-bin.exe</Url>
 		</Urls>
@@ -82,7 +82,7 @@
 		<Id>closure</Id>
 		<Name>Closure Compiler</Name>
 		<Version>1.0.0</Version>
-		<Build>v20150126</Build>
+		<Build>v20170626</Build>
 		<Desc>Google Closure Compiler for JavaScript</Desc>
 		<Group>Compilers</Group>
 		<Info>https://developers.google.com/closure/compiler/</Info>
@@ -93,8 +93,8 @@
 	<Entry>
 		<Id>airrt</Id>
 		<Name>Adobe AIR</Name>
-		<Version>25.0.0</Version>
-		<Build>134</Build>
+		<Version>26.0.0</Version>
+		<Build>127</Build>
 		<Desc>Adobe AIR for AIR applications installer</Desc>
 		<Group>Runtimes</Group>
 		<Bundles>
@@ -103,14 +103,14 @@
 		<Type>Executable</Type>
 		<Info>http://www.adobe.com/products/air.html</Info>
 		<Urls>
-			<Url>http://airdownload.adobe.com/air/win/download/25.0/AdobeAIRInstaller.exe</Url>
+			<Url>http://airdownload.adobe.com/air/win/download/26.0/AdobeAIRInstaller.exe</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>flashsa</Id>
 		<Name>Flash Player (SA)</Name>
-		<Version>25.0.0</Version>
-		<Build>127</Build>
+		<Version>26.0.0</Version>
+		<Build>137</Build>
 		<Desc>Standalone debug Flash Player</Desc>
 		<Group>Runtimes</Group>
 		<Bundles>
@@ -121,52 +121,52 @@
 		</Bundles>
 		<Info>http://www.adobe.com/support/flashplayer/downloads.html</Info>
 		<Urls>
-			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/25/flashplayer_25_sa_debug.exe</Url>
+			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/26/flashplayer_26_sa_debug.exe</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>flashie</Id>
 		<Name>Flash Player (AX)</Name>
-		<Version>25.0.0</Version>
-		<Build>127</Build>
+		<Version>26.0.0</Version>
+		<Build>137</Build>
 		<Desc>Debug Flash Player plugin for Internet Explorer - ActiveX</Desc>
 		<Group>Runtimes</Group>
 		<Type>Executable</Type>
 		<Info>http://www.adobe.com/support/flashplayer/downloads.html</Info>
 		<Urls>
-			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/25/flashplayer_25_ax_debug.exe</Url>
+			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/26/flashplayer_26_ax_debug.exe</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>flashnpapi</Id>
 		<Name>Flash Player (NPAPI)</Name>
-		<Version>25.0.0</Version>
-		<Build>127</Build>
+		<Version>26.0.0</Version>
+		<Build>137</Build>
 		<Desc>Debug Flash Player plugin for Firefox - NPAPI</Desc>
 		<Group>Runtimes</Group>
 		<Type>Executable</Type>
 		<Info>http://www.adobe.com/support/flashplayer/downloads.html</Info>
 		<Urls>
-			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/24/flashplayer_24_plugin_debug.exe</Url>
+			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/26/flashplayer_26_plugin_debug.exe</Url>
     </Urls>
 	</Entry>
 	<Entry>
 		<Id>flashppapi</Id>
 		<Name>Flash Player (PPAPI)</Name>
-		<Version>25.0.0</Version>
-		<Build>127</Build>
+		<Version>26.0.0</Version>
+		<Build>137</Build>
 		<Desc>Debug Flash Player plugin for Opera and Chromium based applications - PPAPI</Desc>
 		<Group>Runtimes</Group>
 		<Type>Executable</Type>
 		<Info>http://www.adobe.com/support/flashplayer/downloads.html</Info>
 		<Urls>
-			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/25/flashplayer_25_ppapi_debug.exe</Url>
+			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/26/flashplayer_26_ppapi_debug.exe</Url>
     </Urls>
 	</Entry>
 	<Entry>
 		<Id>torgit</Id>
 		<Name>TortoiseGit (x86)</Name>
-		<Version>2.3.0</Version>
+		<Version>2.4.0.2</Version>
 		<Build>1</Build>
 		<Desc>Git client 32-bit installer</Desc>
 		<Group>Source Control</Group>
@@ -174,15 +174,15 @@
 			<Bundle>Git</Bundle>
 		</Bundles>
 		<Type>Executable</Type>
-		<Info>https://code.google.com/p/tortoisegit/</Info>
+		<Info>https://tortoisegit.org/</Info>
 		<Urls>
-			<Url>https://download.tortoisegit.org/tgit/2.3.0.0/TortoiseGit-2.3.0.0-32bit.msi</Url>
+			<Url>https://download.tortoisegit.org/tgit/2.4.0.0/TortoiseGit-2.4.0.2-32bit.msi</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>torgit64</Id>
 		<Name>TortoiseGit (x64)</Name>
-		<Version>2.3.0</Version>
+		<Version>2.4.0.2</Version>
 		<Build>1</Build>
 		<Desc>Git client 64-bit installer</Desc>
 		<Group>Source Control</Group>
@@ -190,15 +190,15 @@
 			<Bundle>Git</Bundle>
 		</Bundles>
 		<Type>Executable</Type>
-		<Info>https://code.google.com/p/tortoisegit/</Info>
+		<Info>https://tortoisegit.org/</Info>
 		<Urls>
-			<Url>https://download.tortoisegit.org/tgit/2.3.0.0/TortoiseGit-2.3.0.0-64bit.msi</Url>
+			<Url>https://download.tortoisegit.org/tgit/2.4.0.0/TortoiseGit-2.4.0.2-64bit.msi</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>git4win</Id>
 		<Name>Git For Windows (x86)</Name>
-		<Version>2.11.0</Version>
+		<Version>2.13.3</Version>
 		<Build>1</Build>
 		<Desc>Git command line client 32-bit installer</Desc>
 		<Group>Source Control</Group>
@@ -206,15 +206,15 @@
 			<Bundle>Git</Bundle>
 		</Bundles>
 		<Type>Executable</Type>
-		<Info>http://msysgit.github.io/</Info>
+		<Info>https://git-for-windows.github.io/</Info>
 		<Urls>
-			<Url>https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/Git-2.11.0-32-bit.exe</Url>
+			<Url>https://github.com/git-for-windows/git/releases/download/v2.13.3.windows.1/Git-2.13.3-32-bit.exe</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>git4win64</Id>
 		<Name>Git For Windows (x64)</Name>
-		<Version>2.11.0</Version>
+		<Version>2.13.3</Version>
 		<Build>1</Build>
 		<Desc>Git command line client 64-bit installer</Desc>
 		<Group>Source Control</Group>
@@ -222,16 +222,16 @@
 			<Bundle>Git</Bundle>
 		</Bundles>
 		<Type>Executable</Type>
-		<Info>http://msysgit.github.io/</Info>
+		<Info>https://git-for-windows.github.io/</Info>
 		<Urls>
-			<Url>https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/Git-2.11.0-64-bit.exe</Url>
+			<Url>https://github.com/git-for-windows/git/releases/download/v2.13.3.windows.1/Git-2.13.3-64-bit.exe</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>torsvn</Id>
 		<Name>TortoiseSVN (x86)</Name>
-		<Version>1.9.5</Version>
-		<Build>1</Build>
+		<Version>1.9.6</Version>
+		<Build>27867</Build>
 		<Desc>Subversion client 32-bit installer</Desc>
 		<Group>Source Control</Group>
 		<Bundles>
@@ -240,14 +240,14 @@
 		<Type>Executable</Type>
 		<Info>http://tortoisesvn.net/</Info>
 		<Urls>
-      <Url>https://netcologne.dl.sourceforge.net/project/tortoisesvn/1.9.5/Application/TortoiseSVN-1.9.5.27581-win32-svn-1.9.5.msi</Url>
+      <Url>https://netcologne.dl.sourceforge.net/project/tortoisesvn/1.9.6/Application/TortoiseSVN-1.9.6.27867-win32-svn-1.9.6.msi</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>torsvn64</Id>
 		<Name>TortoiseSVN (x64)</Name>
-		<Version>1.9.5</Version>
-		<Build>1</Build>
+		<Version>1.9.6</Version>
+		<Build>27867</Build>
 		<Desc>Subversion client 64-bit installer</Desc>
 		<Group>Source Control</Group>
 		<Bundles>
@@ -256,13 +256,13 @@
 		<Type>Executable</Type>
 		<Info>http://tortoisesvn.net/</Info>
 		<Urls>
-			<Url>https://netcologne.dl.sourceforge.net/project/tortoisesvn/1.9.5/Application/TortoiseSVN-1.9.5.27581-x64-svn-1.9.5.msi</Url>
+			<Url>https://netcologne.dl.sourceforge.net/project/tortoisesvn/1.9.6/Application/TortoiseSVN-1.9.6.27867-x64-svn-1.9.6.msi</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>sliksvn</Id>
 		<Name>SlikSVN Client (x86)</Name>
-		<Version>1.9.5</Version>
+		<Version>1.9.6</Version>
 		<Build>1</Build>
 		<Desc>Subversion command line client 32-bit installer</Desc>
 		<Group>Source Control</Group>
@@ -272,13 +272,13 @@
 		<Type>Executable</Type>
 		<Info>http://www.sliksvn.com/en/download/</Info>
 		<Urls>
-			<Url>https://sliksvn.com/pub/Slik-Subversion-1.9.5-win32.msi</Url>
+			<Url>https://sliksvn.com/pub/Slik-Subversion-1.9.6-win32.zip</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>sliksvn64</Id>
 		<Name>SlikSVN Client (x64)</Name>
-		<Version>1.9.5</Version>
+		<Version>1.9.6</Version>
 		<Build>1</Build>
 		<Desc>Subversion command line client 64-bit installer</Desc>
 		<Group>Source Control</Group>
@@ -288,7 +288,7 @@
 		<Type>Executable</Type>
 		<Info>http://www.sliksvn.com/en/download/</Info>
 		<Urls>
-			<Url>https://sliksvn.com/pub/Slik-Subversion-1.9.5-x64.msi</Url>
+			<Url>https://sliksvn.com/pub/Slik-Subversion-1.9.6-x64.msi</Url>
 		</Urls>
 	</Entry>
 	<Entry>


### PR DESCRIPTION
…e AIR, Flash Player (*), TortoiseGit, Git For Windows, TortoiseSVN, SlikSVN

Note 1: here's the updated [frameworks_flexsdk_9-26.zip](https://github.com/fdorg/flashdevelop/files/1158631/frameworks_flexsdk_9-26.zip) which should be deployed to http://www.flashdevelop.org/appman/frameworks_flexsdk_9-26.zip

Note 2: For Flex SDK (OLD), should we use to `http://www.flashdevelop.org/appman/frameworks_flexsdk_9-26.zip`? Currently it uses `http://www.flashdevelop.org/appman/frameworks_flexsdk_9-21.zip`. I suppose people who still use the old Flex SDK may still want to target the latest player version.

Note 3: I didn't update TortoiseHg (latest is 4.2.2) because I'm not sure which build to use. Currently it's pointing to Mercurial-4.0.1-*.exe, however I'm not sure if that version includes TortoiseHg. Mercurial downloads page lists an msi installer as the one including TortoiseHg, but I can't check it at the moment.

Note 4: For some downloads e.g. Flash Player, it's rather pointless to mention a build number, since the download link stays the same even if Adobe releases a new build of the same version, the info in appman.xml would then be outdated.