### PR TITLE
OpenResource dialog improvements

### DIFF
--- a/External/Plugins/ProjectManager/Controls/OpenResourceForm.cs
+++ b/External/Plugins/ProjectManager/Controls/OpenResourceForm.cs
@@ -558,8 +558,8 @@ namespace ProjectManager.Controls
                 matchedItems.Add(result);
             }
 
-            //sort results in following priority: score, folderScore, length (score being the most important one)
-            var sortedMatches = matchedItems.OrderByDescending(r => r.score).ThenByDescending(r => r.folderScore).ThenBy(r => r.value.Length);
+            //sort results in following priority: folderScore, score, length (folderScore being the most important one)
+            var sortedMatches = matchedItems.OrderByDescending(r => r.folderScore).ThenByDescending(r => r.score).ThenBy(r => r.value.Length);
 
             var results = new List<string>();
             foreach (var r in sortedMatches)

--- a/External/Plugins/ProjectManager/Controls/OpenResourceForm.cs
+++ b/External/Plugins/ProjectManager/Controls/OpenResourceForm.cs
@@ -544,9 +544,9 @@ namespace ProjectManager.Controls
                 if (AdvancedSearchMatch(file, searchFile))
                     score = 1000.0;
                 else
-                    score = Score(file, searchText, pathSeparator[0]);
+                    score = Score(file, searchFile, pathSeparator[0]);
 
-                score /= file.Length; //divide by length to prefer shorter results
+                //score /= file.Length; //divide by length to prefer shorter results
 
                 if (score <= 0) continue;
 
@@ -559,7 +559,7 @@ namespace ProjectManager.Controls
                 {
                     Score = score,
                     FolderScore = folderScore,
-                    Value = $"{item} {folderScore} {score}"//item
+                    Value = item
                 };
                 matchedItems.Add(result);
             }
@@ -579,6 +579,8 @@ namespace ProjectManager.Controls
 
         static bool AdvancedSearchMatch(string file, string searchText)
         {
+            if (!string.Equals(searchText.ToUpperInvariant(), searchText)) return false;
+
             int i = 0; int j = 0;
             if (file.Length < searchText.Length) return false;
             var text = file.ToCharArray();
@@ -616,8 +618,11 @@ namespace ProjectManager.Controls
         {
             double score = 0;
 
+            if (str.StartsWith(query, StringComparison.OrdinalIgnoreCase)) //Starts with bonus
+                return query.Length + 1;
+
             if (str.ToLower().Contains(query.ToLower())) //Contains bonus
-                return 1;
+                return query.Length;
 
             int strIndex = 0;
 

--- a/External/Plugins/ProjectManager/Controls/OpenResourceForm.cs
+++ b/External/Plugins/ProjectManager/Controls/OpenResourceForm.cs
@@ -532,21 +532,20 @@ namespace ProjectManager.Controls
                 var searchFile = Path.GetFileName(searchText);
                 var searchDir = Path.GetDirectoryName(searchText);
 
+                //score file name
                 if (AdvancedSearchMatch(file, searchFile, pathSeparator))
-                    score = 1000.0 / item.Length;
+                    score = 1000.0;
                 else
-                    score = SimpleSearchMatch(file, searchFile, pathSeparator) / item.Length;
+                    score = SimpleSearchMatch(file, searchFile, pathSeparator);
+
+                score /= item.Length; //divide by length to prefer shorter results over longer ones
 
                 if (score <= 0) continue;
 
-                double folderScore = 0;
+                //score folder path
+                var folderScore = 0.0;
                 if (!string.IsNullOrEmpty(searchDir))
-                {
-                    if (AdvancedSearchMatch(dir, searchDir, pathSeparator))
-                        folderScore = 1000.0;
-                    else
-                        folderScore = SimpleSearchMatch(dir, searchDir, pathSeparator);
-                }
+                    folderScore = SimpleSearchMatch(dir, searchDir, pathSeparator);
 
                 var result = new SearchResult
                 {
@@ -557,6 +556,7 @@ namespace ProjectManager.Controls
                 matchedItems.Add(result);
             }
 
+            //sort results by folderScore and score (score being more important)
             var sortedMatches = matchedItems.OrderBy(r => r.folderScore).ThenBy(r => r.score).Reverse();
 
             var results = new List<string>();
@@ -571,12 +571,10 @@ namespace ProjectManager.Controls
 
         private static bool AdvancedSearchMatch(string file, string searchText, string pathSeparator)
         {
-            if (searchText.ToUpperInvariant() != searchText) return false;
-
             int i = 0; int j = 0;
             if (file.Length < searchText.Length) return false;
-            Char[] text = Path.GetFileName(file).ToCharArray();
-            Char[] pattern = searchText.ToCharArray();
+            char[] text = file.ToCharArray();
+            char[] pattern = searchText.ToCharArray();
             while (i < pattern.Length)
             {
                 while (i < pattern.Length && j < text.Length && pattern[i] == text[j])
@@ -585,15 +583,15 @@ namespace ProjectManager.Controls
                     j++;
                 }
                 if (i == pattern.Length) return true;
-                if (Char.IsLower(pattern[i])) return false;
-                while (j < text.Length && Char.IsLower(text[j]))
+                if (char.IsLower(pattern[i])) return false;
+                while (j < text.Length && char.IsLower(text[j]))
                 {
                     j++;
                 }
                 if (j == text.Length) return false;
                 if (pattern[i] != text[j]) return false;
             }
-            return (i == pattern.Length);
+            return i == pattern.Length;
         }
 
         private static double SimpleSearchMatch(string file, string searchText, string pathSeparator)

--- a/External/Plugins/ProjectManager/Controls/OpenResourceForm.cs
+++ b/External/Plugins/ProjectManager/Controls/OpenResourceForm.cs
@@ -533,7 +533,7 @@ namespace ProjectManager.Controls
                 var searchDir = Path.GetDirectoryName(searchText);
 
                 //score file name
-                if (AdvancedSearchMatch(file, searchFile, pathSeparator))
+                if (AdvancedSearchMatch(file, searchFile))
                     score = 1000.0;
                 else
                     score = SimpleSearchMatch(file, searchFile, pathSeparator);
@@ -569,7 +569,7 @@ namespace ProjectManager.Controls
             return results;
         }
 
-        private static bool AdvancedSearchMatch(string file, string searchText, string pathSeparator)
+        static bool AdvancedSearchMatch(string file, string searchText)
         {
             int i = 0; int j = 0;
             if (file.Length < searchText.Length) return false;
@@ -594,12 +594,10 @@ namespace ProjectManager.Controls
             return i == pattern.Length;
         }
 
-        private static double SimpleSearchMatch(string file, string searchText, string pathSeparator)
+        static double SimpleSearchMatch(string file, string searchText, string pathSeparator)
         {
             if (file.StartsWith(searchText, StringComparison.OrdinalIgnoreCase)) //Equality bonus
-            {
                 return ((file.Length + 1d) / file.Length + (file.Length + 1d) / searchText.Length) / 2;
-            }
 
             var score = Score(file, searchText, pathSeparator[0]);
 
@@ -610,14 +608,12 @@ namespace ProjectManager.Controls
         /**
          * Ported from: https://github.com/atom/fuzzaldrin/
          */
-        private static double Score(string str, string query, char pathSeparator)
+        static double Score(string str, string query, char pathSeparator)
         {
             double score = 0;
 
             if (str.ToLower().Contains(query.ToLower())) //Contains bonus
-            {
                 score = 1;
-            }
 
             int strIndex = 0;
 
@@ -628,28 +624,19 @@ namespace ProjectManager.Controls
                 var index = str.IndexOf(character, strIndex, StringComparison.OrdinalIgnoreCase);
 
                 if (index == -1)
-                {
                     return 0;
-                }
 
-                double charScore = 0.1;
+                var charScore = 0.1;
 
                 if (str[index] == query[i]) //same case bonus
-                {
                     charScore += 0.1;
-                }
 
                 if (index == 0 || str[index - 1] == pathSeparator) //start of string bonus
-                {
                     charScore += 0.8;
-                }
                 else if (i == index) //equivalent position bonus
-                {
                     charScore += 0.5;
-                }
 
                 score += charScore;
-
                 strIndex = index + 1;
             }
 

--- a/External/Plugins/ProjectManager/Controls/OpenResourceForm.cs
+++ b/External/Plugins/ProjectManager/Controls/OpenResourceForm.cs
@@ -538,7 +538,7 @@ namespace ProjectManager.Controls
                 else
                     score = SimpleSearchMatch(file, searchFile, pathSeparator);
 
-                score /= item.Length; //divide by length to prefer shorter results over longer ones
+                score /= file.Length; //divide by length to prefer shorter results over longer ones
 
                 if (score <= 0) continue;
 
@@ -546,6 +546,8 @@ namespace ProjectManager.Controls
                 var folderScore = 0.0;
                 if (!string.IsNullOrEmpty(searchDir))
                     folderScore = SimpleSearchMatch(dir, searchDir, pathSeparator);
+
+                folderScore /= dir.Length;
 
                 var result = new SearchResult
                 {
@@ -556,8 +558,8 @@ namespace ProjectManager.Controls
                 matchedItems.Add(result);
             }
 
-            //sort results by folderScore and score (score being more important)
-            var sortedMatches = matchedItems.OrderBy(r => r.folderScore).ThenBy(r => r.score).Reverse();
+            //sort results in following priority: score, folderScore, length (score being the most important one)
+            var sortedMatches = matchedItems.OrderByDescending(r => r.score).ThenByDescending(r => r.folderScore).ThenBy(r => r.value.Length);
 
             var results = new List<string>();
             foreach (var r in sortedMatches)

--- a/Tests/External/Plugins/ProjectManager.Test/Controls/OpenResourceFormTests.cs
+++ b/Tests/External/Plugins/ProjectManager.Test/Controls/OpenResourceFormTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 
 namespace ProjectManager.Controls
@@ -90,44 +91,15 @@ namespace ProjectManager.Controls
                     "src\\com\\module\\test\\TestModule.hx"
                 });
 
-                var results = SearchUtil.getMatchedItems(files, "test", "\\", 0);
+                var results = SearchUtil.getMatchedItems(files, "test\\test", "\\", 0);
 
                 //"test\\TestModule.hx" should be first, because it has test in the path and also in the beginning of the file name
                 Assert.AreEqual("src\\com\\module\\test\\TestModule.hx", results[0]);
-                Assert.AreEqual("src\\com\\module\\TestModule.hx", results[1]);
-                Assert.AreEqual("src\\com\\module\\test\\ITestModule.hx", results[2]);
+                Assert.AreEqual("src\\com\\module\\test\\ITestModule.hx", results[1]);
+                //these have no test in the path
+                Assert.AreEqual("src\\com\\module\\TestModule.hx", results[2]);
                 Assert.AreEqual("src\\com\\module\\ITestModule.hx", results[3]);
             }
-
-            [Test]
-            public void ExactTest()
-            {
-                List<string> files = new List<string>();
-                files.AddRange(new string[] {
-                    "src\\StaticClass.hx",
-                    "src\\com\\module\\ITestModule.hx",
-                    "src\\com\\module\\TestModule.hx",
-                    "src\\com\\module\\example\\ExampleModule.hx",
-                    "src\\com\\module\\example\\IExampleModule.hx",
-                    "src\\com\\module\\test\\ITestModule.hx",
-                    "src\\com\\module\\test\\TestModule.hx"
-                });
-
-                var excpected = new string[]
-                {
-                    "src\\com\\module\\TestModule.hx",
-                    "src\\com\\module\\ITestModule.hx",
-                    "src\\com\\module\\test\\TestModule.hx",
-                    "src\\com\\module\\test\\ITestModule.hx",
-                    "src\\com\\module\\example\\ExampleModule.hx",
-                    "src\\com\\module\\example\\IExampleModule.hx",
-                };
-                var results = SearchUtil.getMatchedItems(files, "src\\com\\module", "\\", 0);
-
-                CollectionAssert.AreEqual(excpected, results);
-
-            }
-
         }
     }
 }


### PR DESCRIPTION
You can now fuzzy match folders too.
They are scored independently and the folder is higher priority.
Example:
![example fuzzy search](https://user-images.githubusercontent.com/4466937/29623434-a8842cdc-8826-11e7-93a0-f5389fcb367e.png)
