### PR TITLE
Open Resource form: Allow `/` as path separator

### DIFF
--- a/External/Plugins/ProjectManager/Controls/OpenResourceForm.cs
+++ b/External/Plugins/ProjectManager/Controls/OpenResourceForm.cs
@@ -261,9 +261,10 @@ namespace ProjectManager.Controls
             List<String> matchedFiles;
             if (this.textBox.Text.Length > 0)
             {
-                matchedFiles = SearchUtil.getMatchedItems(this.openedFiles, this.textBox.Text, "\\", 0);
+                String searchText = this.textBox.Text.Replace("\\", "/");
+                matchedFiles = SearchUtil.getMatchedItems(this.openedFiles, searchText, "/", 0);
                 if (matchedFiles.Capacity > 0) matchedFiles.Add(ITEM_SPACER);
-                matchedFiles.AddRange(SearchUtil.getMatchedItems(this.projectFiles, this.textBox.Text, "\\", this.MAX_ITEMS));
+                matchedFiles.AddRange(SearchUtil.getMatchedItems(this.projectFiles, searchText, "/", this.MAX_ITEMS));
             }
             else matchedFiles = openedFiles;
             foreach (String file in matchedFiles)


### PR DESCRIPTION
These days many Windows tools support both `\` and `/` as the path separator - including even `Explorer` and `cmd`. On my US layout keyboards `/` is more conveniently located, also using `/` is a die-hard Linux habit of mine. Can't see any cons to making this change.