### PR TITLE
Some fixes for inheritance navigation

### DIFF
--- a/External/Plugins/ASCompletion/PluginMain.cs
+++ b/External/Plugins/ASCompletion/PluginMain.cs
@@ -875,8 +875,10 @@ namespace ASCompletion
         {
             foreach (var document in PluginBase.MainForm.Documents)
             {
+                if (!document.IsEditable) continue;
+
                 UpdateMarkersFromCache(document.SplitSci1);
-                UpdateMarkersFromCache(document.SplitSci1);
+                UpdateMarkersFromCache(document.SplitSci2);
             }
         }
 
@@ -896,7 +898,6 @@ namespace ASCompletion
             sci.MarginClick -= Sci_MarginClick;
             sci.MarginClick += Sci_MarginClick;
 
-            UpdateMarkersFromCache(sci);
             UpdateMarkersFromCache(sci);
         }
 
@@ -957,7 +958,7 @@ namespace ASCompletion
                     {
                         sci.MarkerDelete(i, MarkerUp);
                         sci.MarkerDelete(i, MarkerDown);
-                        sci.MarkerDelete(i, MarkerUp);      //for some reason this needs to be done twice,
+                        sci.MarkerDelete(i, MarkerUp);      //this needs to be done twice, because a member could for example implement and override at the same time
                         sci.MarkerDelete(i, MarkerDown);    //otherwise some markers are not removed
 
                         sci.MarkerAdd(i, MarkerUpDown);

--- a/External/Plugins/ASCompletion/PluginMain.cs
+++ b/External/Plugins/ASCompletion/PluginMain.cs
@@ -1,4 +1,5 @@
 using System;
+using System.CodeDom;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -891,7 +892,7 @@ namespace ASCompletion
             sci.MarkerDefineRGBAImage(MarkerUp, upArrow);
             sci.MarkerDefineRGBAImage(MarkerUpDown, upDownArrow);
             //Setup margin
-            var mask = sci.GetMarginMaskN(Margin) | (1 << MarkerDown) | (1 << MarkerUp) | (1 << MarkerUpDown);
+            var mask = (1 << MarkerDown) | (1 << MarkerUp) | (1 << MarkerUpDown);
             sci.SetMarginMaskN(Margin, mask);
             sci.MarginSensitiveN(Margin, true);
 

--- a/External/Plugins/ASCompletion/PluginMain.cs
+++ b/External/Plugins/ASCompletion/PluginMain.cs
@@ -958,8 +958,8 @@ namespace ASCompletion
                     {
                         sci.MarkerDelete(i, MarkerUp);
                         sci.MarkerDelete(i, MarkerDown);
-                        sci.MarkerDelete(i, MarkerUp);      //this needs to be done twice, because a member could for example implement and override at the same time
-                        sci.MarkerDelete(i, MarkerDown);    //otherwise some markers are not removed
+                        sci.MarkerDelete(i, MarkerUp);      //this needs to be done twice,
+                        sci.MarkerDelete(i, MarkerDown);    //because a member could for example implement and override at the same time
 
                         sci.MarkerAdd(i, MarkerUpDown);
                     }

--- a/FlashDevelop/Managers/ScintillaManager.cs
+++ b/FlashDevelop/Managers/ScintillaManager.cs
@@ -300,6 +300,8 @@ namespace FlashDevelop.Managers
                 if (!useFolding && !viewBookmarks && !viewLineNumbers) sci.SetMarginWidthN(FoldingMargin, 0);
                 else if (useFolding) sci.SetMarginWidthN(FoldingMargin, ScaleArea(sci, 15));
                 else sci.SetMarginWidthN(FoldingMargin, ScaleArea(sci, 2));
+
+                sci.SetMarginWidthN(1, 0); //Inheritance Margin (see ASCompletion.PluginMain.Margin)
                 /**
                 * Adjust caret policy based on settings
                 */


### PR DESCRIPTION
- Documents without inheritance markers do not jump to the right anymore after opening
- Some double calls fixed
- Fixes a problem where breakpoint markers are shown in the inheritance margin