### PR TITLE
 [ProjectManager] PropertiesDialog theming fixes...

### DIFF
--- a/External/Plugins/ProjectManager/Controls/PropertiesDialog.cs
+++ b/External/Plugins/ProjectManager/Controls/PropertiesDialog.cs
@@ -625,8 +625,8 @@ namespace ProjectManager.Controls
             // 
             // propertyGrid
             // 
-            this.propertyGrid.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
-            this.propertyGrid.Location = new System.Drawing.Point(3, 3);
+            this.propertyGrid.Dock = System.Windows.Forms.DockStyle.Fill; this.propertyGrid.Location = new System.Drawing.Point(3, 3);
+            this.propertyGrid.LineColor = System.Drawing.SystemColors.ScrollBar;
             this.propertyGrid.Name = "propertyGrid";
             this.propertyGrid.Size = new System.Drawing.Size(328, 266);
             this.propertyGrid.TabIndex = 0;

--- a/External/Plugins/ProjectManager/Controls/PropertiesDialog.cs
+++ b/External/Plugins/ProjectManager/Controls/PropertiesDialog.cs
@@ -625,14 +625,14 @@ namespace ProjectManager.Controls
             // 
             // propertyGrid
             // 
-            this.propertyGrid.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.propertyGrid.LineColor = System.Drawing.SystemColors.ScrollBar;
+            this.propertyGrid.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
             this.propertyGrid.Location = new System.Drawing.Point(3, 3);
             this.propertyGrid.Name = "propertyGrid";
             this.propertyGrid.Size = new System.Drawing.Size(328, 266);
             this.propertyGrid.TabIndex = 0;
             this.propertyGrid.ToolbarVisible = false;
             this.propertyGrid.PropertyValueChanged += new System.Windows.Forms.PropertyValueChangedEventHandler(this.propertyGrid_PropertyValueChanged);
+            this.propertyGrid.Font = this.Font;
             // 
             // sdkTabPage
             // 


### PR DESCRIPTION
Before fix:
<img width="345" alt="before" src="https://user-images.githubusercontent.com/1700940/33228304-d9b5eae8-d1c8-11e7-8331-dc2eb1e2a789.png">
After:
<img width="345" alt="after" src="https://user-images.githubusercontent.com/1700940/33228305-df52ee88-d1c8-11e7-9dbc-c6b5bc3c6abe.png">
