### PR TITLE
Some Resources form changes (fixes #1810)

### DIFF
--- a/External/Plugins/ProjectManager/Controls/OpenResourceForm.cs
+++ b/External/Plugins/ProjectManager/Controls/OpenResourceForm.cs
@@ -129,6 +129,7 @@ namespace ProjectManager.Controls
             this.Text = "Open Resource";
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.OpenResourceKeyDown);
             this.Load += new EventHandler(OpenResourceFormLoad);
+            this.Activated += new EventHandler(OpenResourceFormActivated);
             this.ResumeLayout(false);
             this.PerformLayout();
         }
@@ -137,9 +138,6 @@ namespace ProjectManager.Controls
 
         #region Methods And Event Handlers
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void InitializeGraphics()
         {
             ImageList imageList = new ImageList();
@@ -150,9 +148,6 @@ namespace ProjectManager.Controls
             this.refreshButton.ImageIndex = 0;
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void InitializeLocalization()
         {
             this.cbInClasspathsOnly.Text = TextHelper.GetString("Label.InClasspathsOnly");
@@ -160,53 +155,42 @@ namespace ProjectManager.Controls
             this.Text = " " + TextHelper.GetString("Title.OpenResource");
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void RefreshButtonClick(Object sender, EventArgs e)
         {
             this.CreateFileList();
             this.RefreshListBox();
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void CbInClasspathsOnlyCheckedChanged(Object sender, EventArgs e)
         {
             this.CreateFileList();
             this.RefreshListBox();
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void CheckBoxCheckedChanged(Object sender, EventArgs e)
         {
             this.CreateFileList();
             this.RefreshListBox();
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void OpenResourceFormLoad(Object sender, EventArgs e)
         {
-            if (openedFiles == null) this.CreateFileList();
-            else
-            {
-                this.textBox.Focus();
-                this.textBox.Text = previousSearch;
-                this.textBox.SelectAll();
-                this.UpdateOpenFiles();
-                this.textBox.Focus();
-            }
+            this.CreateFileList();
             this.RefreshListBox();
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
+        private void OpenResourceFormActivated(Object sender, EventArgs e)
+        {
+            this.textBox.Focus();
+            this.textBox.SelectAll();
+            if (previousSearch != null)
+            {
+                previousSearch = null;
+                this.UpdateOpenFiles();
+                this.textBox.Focus();
+            }
+        }
+
         private void ListBoxDrawItem(Object sender, DrawItemEventArgs e)
         {
             Boolean selected = (e.State & DrawItemState.Selected) == DrawItemState.Selected;
@@ -239,9 +223,6 @@ namespace ProjectManager.Controls
             }
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void RefreshListBox()
         {
             this.listBox.BeginUpdate();
@@ -254,9 +235,6 @@ namespace ProjectManager.Controls
             this.listBox.EndUpdate();
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void FillListBox()
         {
             List<String> matchedFiles;
@@ -304,9 +282,6 @@ namespace ProjectManager.Controls
             }
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void CreateFileList()
         {
             List<String> open = this.GetOpenFiles();
@@ -419,9 +394,6 @@ namespace ProjectManager.Controls
             return (info.Attributes & FileAttributes.Hidden) > 0;
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void Navigate()
         {
             if (this.listBox.SelectedItem != null)
@@ -435,9 +407,6 @@ namespace ProjectManager.Controls
             }
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void OpenResourceKeyDown(Object sender, KeyEventArgs e)
         {
             if (e.KeyCode == Keys.Escape) this.Close();
@@ -446,11 +415,14 @@ namespace ProjectManager.Controls
                 e.Handled = true;
                 this.Navigate();
             }
+            else if (e.KeyData == (Keys.Control | Keys.R))
+            {
+                e.SuppressKeyPress = true;
+                this.CreateFileList();
+                this.RefreshListBox();
+            }
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void TextBoxKeyDown(Object sender, KeyEventArgs e)
         {
             if (e.KeyCode == Keys.Down && this.listBox.SelectedIndex < this.listBox.Items.Count - 1)
@@ -475,33 +447,21 @@ namespace ProjectManager.Controls
             }
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void TextBoxTextChanged(Object sender, EventArgs e)
         {
             this.RefreshListBox();
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void ListBoxDoubleClick(Object sender, EventArgs e)
         {
             this.Navigate();
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         private void ListBoxResize(Object sender, EventArgs e)
         {
             this.listBox.Refresh();
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
         protected override void OnClosed(EventArgs e)
         {
             base.OnClosed(e);


### PR DESCRIPTION
Focus textbox on Resources form when activating.
Add Ctrl+R shortcut for refreshing resource form.

This is similar to what was on previous FD versions, but slightly more optimized. Also added shortcut, that was not on the original issue, but also requested by Gene and I guess makes sense.