### PR TITLE
Add more exceptions to UITools.HandleEvent to not hide CompletionList.

### DIFF
--- a/PluginCore/PluginCore/Controls/UITools.cs
+++ b/PluginCore/PluginCore/Controls/UITools.cs
@@ -151,6 +151,7 @@ namespace PluginCore.Controls
 
                 case EventType.Command:
                     string cmd = (e as DataEvent).Action;
+                    // EventType.Command handlind should quite probably disappear when merging the "Decoupled CompletionList". This is too hacky and error-prone...
                     if (cmd.IndexOfOrdinal("ProjectManager") > 0
                         || cmd.IndexOfOrdinal("Changed") > 0
                         || cmd.IndexOfOrdinal("Context") > 0
@@ -159,8 +160,11 @@ namespace PluginCore.Controls
                         || cmd.IndexOfOrdinal("Get") > 0
                         || cmd.IndexOfOrdinal("Set") > 0
                         || cmd.IndexOfOrdinal("SDK") > 0
+                        || cmd == "ASCompletion.FileModelUpdated"
+                        || cmd == "ASCompletion.PathExplorerFinished"
+                        || cmd == "ASCompletion.ContextualGenerator.AddOptions"
                         || cmd == "ResultsPanel.ClearResults"
-                        || cmd == "LintingManager.FilesLinted")
+                        || cmd.IndexOfOrdinal("LintingManager.") == 0)
                         return; // ignore notifications
                     break;
             }


### PR DESCRIPTION
The existing logic is hacky, and should be completely replaced by something else... this topic was already raised 1.5 years ago.

I see this list was updated recently, but I never realized about how bad it is.

If the decoupled completion list is ever merged (I should update the PR with all my latest work...), this logic could be completely removed I think.

Unless we remove this check, we should be careful with any PR or even plugins dispatching "Command" events.