### PR TITLE
[CodeRefactor][Rename][Haxe] Small improvement renaming of expressions whose type is some Enum

### DIFF
--- a/External/Plugins/CodeRefactor/Provider/RefactoringHelper.cs
+++ b/External/Plugins/CodeRefactor/Provider/RefactoringHelper.cs
@@ -107,7 +107,8 @@ namespace CodeRefactor.Provider
         {
             var type = target.Type;
             var member = target.Member;
-            if (type.IsEnum() || !type.IsVoid() && target.IsStatic && (member == null || (member.Flags & FlagType.Constructor) > 0))
+            if ((type.IsEnum() && member == null)
+                || (!type.IsVoid() && target.IsStatic && (member == null || (member.Flags & FlagType.Constructor) > 0)))
                 return type;
             return member;
         }


### PR DESCRIPTION
before fix:
<img width="412" alt="coderefactor_rename_varenum_beforefix" src="https://user-images.githubusercontent.com/1700940/33627026-4f8d5d54-da0d-11e7-8b26-8f6df68b17d4.png">

after fix:
<img width="424" alt="coderefactor_rename_varenum_afterfix" src="https://user-images.githubusercontent.com/1700940/33627036-56cebaf4-da0d-11e7-83fd-64691c2f16e5.png">

I will do make unit tests for this in next week