### PR TITLE
Fixed nasty crash that may happen with diagnostics support.

### DIFF
--- a/External/Plugins/HaXeContext/Completion/CompletionServerCompletionHandler.cs
+++ b/External/Plugins/HaXeContext/Completion/CompletionServerCompletionHandler.cs
@@ -20,9 +20,9 @@ namespace HaXeContext
         private bool listening;
         private bool failure;
 
-        public CompletionServerCompletionHandler(Process haxeProcess, int port)
+        public CompletionServerCompletionHandler(ProcessStartInfo haxeProcessStartInfo, int port)
         {
-            this.haxeProcess = haxeProcess;
+            this.haxeProcess = new Process {StartInfo = haxeProcessStartInfo, EnableRaisingEvents = true};
             this.port = port;
             Environment.SetEnvironmentVariable("HAXE_SERVER_PORT", "" + port);
         }

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -267,8 +267,9 @@ namespace HaXeContext
         {
             features.metadata = new Dictionary<string, string>();
 
-            Process process = CreateHaxeProcess("--help-metas");
-            if (process == null) return;
+            ProcessStartInfo processInfo = CreateHaxeProcessInfo("--help-metas");
+            if (processInfo == null) return;
+            var process = new Process {StartInfo = processInfo, EnableRaisingEvents = true};
             process.Start();
 
             String metaList = process.StandardOutput.ReadToEnd();
@@ -1242,18 +1243,18 @@ namespace HaXeContext
             switch (haxeSettings.CompletionMode)
             {
                 case HaxeCompletionModeEnum.Compiler:
-                    completionModeHandler = new CompilerCompletionHandler(CreateHaxeProcess(""));
+                    completionModeHandler = new CompilerCompletionHandler(CreateHaxeProcessInfo(""));
                     break;
                 case HaxeCompletionModeEnum.CompletionServer:
                     if (haxeSettings.CompletionServerPort < 1024)
-                        completionModeHandler = new CompilerCompletionHandler(CreateHaxeProcess(""));
+                        completionModeHandler = new CompilerCompletionHandler(CreateHaxeProcessInfo(""));
                     else
                     {
                         completionModeHandler =
                             new CompletionServerCompletionHandler(
-                                CreateHaxeProcess("--wait " + haxeSettings.CompletionServerPort),
+                                CreateHaxeProcessInfo("--wait " + haxeSettings.CompletionServerPort),
                                 haxeSettings.CompletionServerPort);
-                        (completionModeHandler as CompletionServerCompletionHandler).FallbackNeeded += new FallbackNeededHandler(Context_FallbackNeeded);
+                        ((CompletionServerCompletionHandler) completionModeHandler).FallbackNeeded += Context_FallbackNeeded;
                     }
                     break;
             }
@@ -1267,13 +1268,13 @@ namespace HaXeContext
                 completionModeHandler.Stop();
                 completionModeHandler = null;
             }
-            completionModeHandler = new CompilerCompletionHandler(CreateHaxeProcess(""));
+            completionModeHandler = new CompilerCompletionHandler(CreateHaxeProcessInfo(""));
         }
 
         /**
-         * Starts a haxe.exe process with the given arguments.
+         * Gets the needed information to create a haxe.exe process with the given arguments.
          */
-        internal Process CreateHaxeProcess(string args)
+        internal ProcessStartInfo CreateHaxeProcessInfo(string args)
         {
             // compiler path
             var hxPath = currentSDK ?? ""; 
@@ -1282,16 +1283,15 @@ namespace HaXeContext
                 return null;
 
             // Run haxe compiler
-            Process proc = new Process();
-            proc.StartInfo.FileName = process;
-            proc.StartInfo.Arguments = args;
-            proc.StartInfo.UseShellExecute = false;
-            proc.StartInfo.RedirectStandardOutput = true;
-            proc.StartInfo.RedirectStandardError = true;
-            proc.StartInfo.CreateNoWindow = true;
-            proc.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-            proc.EnableRaisingEvents = true;
-            return proc;
+            var procInfo = new ProcessStartInfo();
+            procInfo.FileName = process;
+            procInfo.Arguments = args;
+            procInfo.UseShellExecute = false;
+            procInfo.RedirectStandardOutput = true;
+            procInfo.RedirectStandardError = true;
+            procInfo.CreateNoWindow = true;
+            procInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            return procInfo;
         }
 
         internal HaxeComplete GetHaxeComplete(ScintillaControl sci, ASExpr expression, bool autoHide, HaxeCompilerService compilerService)

--- a/External/Plugins/HaXeContext/HaXeContext.csproj
+++ b/External/Plugins/HaXeContext/HaXeContext.csproj
@@ -131,6 +131,7 @@
     <Compile Include="HaXeSettings.cs" />
     <Compile Include="ExternalToolchain.cs" />
     <Compile Include="Helpers\FlagEnumEditor.cs" />
+    <Compile Include="Helpers\ProcessExtensions.cs" />
     <Compile Include="Linters\DiagnosticsLinter.cs" />
     <Compile Include="PluginMain.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/External/Plugins/LintingHelper/ILintProvider.cs
+++ b/External/Plugins/LintingHelper/ILintProvider.cs
@@ -1,8 +1,5 @@
 ﻿using PluginCore;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace LintingHelper
 {
@@ -10,7 +7,7 @@ namespace LintingHelper
 
     public interface ILintProvider
     {
-        void LintAsync(string[] files, LintCallback callback);
+        void LintAsync(IEnumerable<string> files, LintCallback callback);
         void LintProjectAsync(IProject project, LintCallback callback);
     }
 }

--- a/External/Plugins/LintingHelper/Managers/LintingManager.cs
+++ b/External/Plugins/LintingHelper/Managers/LintingManager.cs
@@ -71,7 +71,7 @@ namespace LintingHelper.Managers
         /// </summary>
         /// <param name="files">the files to lint</param>
         /// <param name="language">the language to use</param>
-        public static void LintFiles(string[] files, string language)
+        public static void LintFiles(IEnumerable<string> files, string language)
         {
             language = language.ToLower();
 
@@ -88,7 +88,7 @@ namespace LintingHelper.Managers
         /// <summary>
         /// Lint <paramref name="files"/> trying to autodetect the language(s).
         /// </summary>
-        public static void LintFiles(string[] files)
+        public static void LintFiles(IEnumerable<string> files)
         {
             //detect languages
             var filesByLang = new Dictionary<string, List<string>>();
@@ -102,7 +102,7 @@ namespace LintingHelper.Managers
             
             foreach (var lang in filesByLang.Keys)
             {
-                LintFiles(filesByLang[lang].ToArray(), lang);
+                LintFiles(filesByLang[lang], lang);
             }
         }
 
@@ -128,7 +128,7 @@ namespace LintingHelper.Managers
 
         public static void LintDocument(ITabbedDocument doc)
         {
-            var files = new string[] { doc.FileName };
+            var files = new [] { doc.FileName };
             var language = doc.SciControl.ConfigurationLanguage;
 
             LintFiles(files, language);

--- a/External/Plugins/ProjectManager/PluginMain.cs
+++ b/External/Plugins/ProjectManager/PluginMain.cs
@@ -45,6 +45,7 @@ namespace ProjectManager
         public const string Menu = "ProjectManager.Menu";
         public const string ToolBar = "ProjectManager.ToolBar";
         public const string Project = "ProjectManager.Project";
+        public const string ProjectSetUp = "ProjectManager.ProjectSetUp";
         public const string CleanProject = "ProjectManager.CleanProject";
         public const string TestProject = "ProjectManager.TestingProject";
         public const string BuildProject = "ProjectManager.BuildingProject";
@@ -679,6 +680,7 @@ namespace ProjectManager
             BuildActions.GetCompilerPath(project); // detect project's SDK
             BroadcastProjectInfo(project);
             projectActions.UpdateASCompletion(MainForm, project);
+            BroadcastProjectSetUp(project);
 
             // ui
             pluginUI.SetProject(project);
@@ -1232,6 +1234,12 @@ namespace ProjectManager
         public void BroadcastProjectInfo(Project project)
         {
             DataEvent de = new DataEvent(EventType.Command, ProjectManagerEvents.Project, project);
+            EventManager.DispatchEvent(this, de);
+        }
+
+        private void BroadcastProjectSetUp(Project project)
+        {
+            DataEvent de = new DataEvent(EventType.Command, ProjectManagerEvents.ProjectSetUp, project);
             EventManager.DispatchEvent(this, de);
         }
 

--- a/FlashDevelop/Docking/TabbedDocument.cs
+++ b/FlashDevelop/Docking/TabbedDocument.cs
@@ -86,14 +86,7 @@ namespace FlashDevelop.Docking
         /// <summary>
         /// Do we contain a ScintillaControl?
         /// </summary>
-        public Boolean IsEditable
-        {
-            get
-            {
-                if (this.SciControl == null) return false;
-                else return true;
-            }
-        }
+        public Boolean IsEditable => this.SciControl != null;
 
         /// <summary>
         /// Are we splitted in to two sci controls?
@@ -119,10 +112,7 @@ namespace FlashDevelop.Docking
         /// <summary>
         /// Does this document have any bookmarks?
         /// </summary>
-        public Boolean HasBookmarks
-        {
-            get { return bookmarks.Count > 0; }
-        }
+        public Boolean HasBookmarks => bookmarks.Count > 0;
 
         /// <summary>
         /// Does this document's pane have any other documents?
@@ -171,39 +161,18 @@ namespace FlashDevelop.Docking
         /// <summary>
         /// First splitted ScintillaControl 
         /// </summary>
-        public ScintillaControl SplitSci1
-        {
-            get
-            {
-                if (this.editor != null) return this.editor;
-                else return null;
-            }
-        }
+        public ScintillaControl SplitSci1 => editor;
 
         /// <summary>
         /// Second splitted ScintillaControl
         /// </summary>
-        public ScintillaControl SplitSci2
-        {
-            get
-            {
-                if (this.editor2 != null) return this.editor2;
-                else return null;
-            }
-        }
+        public ScintillaControl SplitSci2 => editor2;
 
         /// <summary>
         /// SplitContainer of the document
         /// </summary>
-        public SplitContainer SplitContainer
-        {
-            get
-            {
-                if (this.splitContainer != null) return this.splitContainer;
-                else return null;
-            }
-        }
-            
+        public SplitContainer SplitContainer => splitContainer;
+
         /// <summary>
         /// Gets if the file is untitled
         /// </summary>

--- a/PluginCore/PluginCore/Helpers/ProcessHelper.cs
+++ b/PluginCore/PluginCore/Helpers/ProcessHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Runtime.Remoting.Messaging;
 using PluginCore.Managers;
 
 namespace PluginCore.Helpers
@@ -11,8 +12,18 @@ namespace PluginCore.Helpers
         /// </summary>
         public static void StartAsync(String path)
         {
-            StartDelegate1 dlgt = new StartDelegate1(Start);
-            dlgt.BeginInvoke(path, null, null);
+            StartDelegate1 dlgt = Start;
+            dlgt.BeginInvoke(path, ar =>
+            {
+                try
+                {
+                    dlgt.EndInvoke(ar);
+                }
+                catch (Exception ex)
+                {
+                    // Something wrong, handling for possible leaks
+                }
+            }, null);
         }
         
         /// <summary>
@@ -20,8 +31,18 @@ namespace PluginCore.Helpers
         /// </summary>
         public static void StartAsync(String path, String arguments)
         {
-            StartDelegate2 dlgt = new StartDelegate2(Start);
-            dlgt.BeginInvoke(path, arguments, null, null);
+            StartDelegate2 dlgt = Start;
+            dlgt.BeginInvoke(path, arguments, ar =>
+            {
+                try
+                {
+                    dlgt.EndInvoke(ar);
+                }
+                catch (Exception ex)
+                {
+                    // Something wrong, handling for possible leaks
+                }
+            }, null);
         }
 
         /// <summary>
@@ -30,7 +51,18 @@ namespace PluginCore.Helpers
         public static void StartAsync(ProcessStartInfo psi)
         {
             StartDelegate3 dlgt = new StartDelegate3(Start);
-            dlgt.BeginInvoke(psi, null, null);
+            dlgt.BeginInvoke(psi, ar =>
+                {
+                    try
+                    {
+                        dlgt.EndInvoke(ar);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Something wrong, handling for possible leaks
+                    }
+                },
+            null);
         }
 
         /// <summary>


### PR DESCRIPTION
Changed Haxe process creation so calling the compiler on normal compiler completion mode is thread safe.
New ProjectSetUp event.
Changed the signature of ILintProvider to use IEnumerable<string> instead of string[] as it's not really needed and is less convenient. Also done some small optimizations.
Some better handling of starting async processes.
When linting the open files on project change, send all files together instead of individually. This has the advantage of less interruption of the main UI thread, but the problem of having to wait more for getting diagnostics. I would like to do some performance profiling in the future. I also considered using global diagnostics, but it has the problem of not taking into account files not added still in the project... but maybe this could be solved on our side? not 100% sure.

The reason for the nasty crash was that the "Project" event means that a project is now active, but not fully setup (mainly `context.BuildClassPath` didn't run yet), so when the diagnostics logic was triggering there were high chances of not having the completion handler set yet, and since the error was on a subthread without error handling the whole application was dying. Why this error doesn't happen all the time? Because for example if the user ever had open a .hx file (which happens to be the case most times) `context.BuildClassPath` is run.