### PR TITLE
[Haxe][ASComplete][Documentation] Fixed display of documentation of constructor

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -4498,16 +4498,18 @@ namespace ASCompletion.Completion
             {
                 return ClassModel.ClassDeclaration(result.InClass) + GetToolTipDoc(result.InClass);
             }
-            else if (result.Type != null)
+            if (result.Type != null)
             {
                 if (result.Context.WordBefore == "new")
                 {
-                    var member = result.Type.Members.Search(result.Type.Name, FlagType.Constructor, 0);
+                    var constructorKey = result.Type.InFile.Context.Features.ConstructorKey;
+                    var name = string.IsNullOrEmpty(constructorKey) ? result.Type.Name : constructorKey;
+                    var member = result.Type.Members.Search(name, 0, 0);
                     if (member != null) return MemberTooltipText(member, result.Type) + GetToolTipDoc(member);
                 }
                 return ClassModel.ClassDeclaration(result.Type) + GetToolTipDoc(result.Type);
             }
-            else return null;
+            return null;
         }
 
         private static string GetToolTipDoc(MemberModel model)


### PR DESCRIPTION
Before: 
![haxe_showdocumentationofconstructor_before_fix](https://user-images.githubusercontent.com/1700940/34594600-128f18fa-f1e3-11e7-9220-12bc5b239d61.png)
After:
![haxe_showdocumentationofconstructor_after_fix](https://user-images.githubusercontent.com/1700940/34594602-16c057f4-f1e3-11e7-9d33-9e9f9e3ee0e3.png)

