### PR TITLE
Fixed NPE. Context.IsImported always returns false for Class.VoidClass. fixes #1930

### DIFF
--- a/External/Plugins/AS2Context/Context.cs
+++ b/External/Plugins/AS2Context/Context.cs
@@ -451,6 +451,7 @@ namespace AS2Context
         /// <param name="atLine">Position in the file</param>
         public override bool IsImported(MemberModel member, int atLine)
         {
+            if (member == ClassModel.VoidClass) return false;
             FileModel cFile = Context.CurrentModel;
             string fullName = member.Type;
             string name = member.Name;

--- a/External/Plugins/AS3Context/Context.cs
+++ b/External/Plugins/AS3Context/Context.cs
@@ -862,6 +862,7 @@ namespace AS3Context
         /// <param name="atLine">Position in the file</param>
         public override bool IsImported(MemberModel member, int atLine)
         {
+            if (member == ClassModel.VoidClass) return false;
             FileModel cFile = Context.CurrentModel;
             // same package is auto-imported
             string package = member.Type.Length > member.Name.Length 

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -871,6 +871,7 @@ namespace HaXeContext
         /// <param name="atLine">Position in the file</param>
         public override bool IsImported(MemberModel member, int atLine)
         {
+            if (member == ClassModel.VoidClass) return false;
             int p = member.Name.IndexOf('#');
             if (p > 0)
             {

--- a/Tests/External/Plugins/AS3Context.Tests/AS3Context.Tests.csproj
+++ b/Tests/External/Plugins/AS3Context.Tests/AS3Context.Tests.csproj
@@ -75,6 +75,7 @@
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestUtils\TestFile.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">
@@ -116,6 +117,7 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+    <EmbeddedResource Include="Test Files\parser\IsImported_case1.as" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Tests/External/Plugins/AS3Context.Tests/ContextTests.cs
+++ b/Tests/External/Plugins/AS3Context.Tests/ContextTests.cs
@@ -1,5 +1,9 @@
 ﻿using System.Collections.Generic;
+using AS3Context.TestUtils;
 using ASCompletion.Completion;
+using ASCompletion.Context;
+using ASCompletion.Model;
+using ASCompletion.TestUtils;
 using NUnit.Framework;
 
 namespace AS3Context
@@ -7,10 +11,17 @@ namespace AS3Context
     [TestFixture]
     class ContextTests : ASCompleteTests
     {
-        Context context;
+
+        protected static string ReadAllText(string fileName) => TestFile.ReadAllText(GetFullPath(fileName));
+
+        protected static string GetFullPath(string fileName) => $"{nameof(AS3Context)}.Test_Files.parser.{fileName}.as";
 
         [TestFixtureSetUp]
-        public new void FixtureSetUp() => context = new Context(new AS3Settings());
+        public new void FixtureSetUp()
+        {
+            ASContext.Context.SetAs3Features();
+            sci.ConfigurationLanguage = "as3";
+        }
 
         IEnumerable<TestCaseData> DecomposeTypesTestCases
         {
@@ -35,6 +46,33 @@ namespace AS3Context
         }
 
         [Test, TestCaseSource(nameof(DecomposeTypesTestCases))]
-        public IEnumerable<string> DecomposeTypes(IEnumerable<string> types) => context.DecomposeTypes(types);
+        public IEnumerable<string> DecomposeTypes(IEnumerable<string> types) => ASContext.Context.DecomposeTypes(types);
+
+        static IEnumerable<TestCaseData> IsImportedTestCases
+        {
+            get
+            {
+                yield return new TestCaseData(ReadAllText("IsImported_case1"))
+                    .Returns(true);
+                yield return new TestCaseData(null)
+                    .Returns(false)
+                    .SetName("ClassModel.VoidClass")
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/1930");
+            }
+        }
+
+        [Test, TestCaseSource(nameof(IsImportedTestCases))]
+        public bool IsImported(string sourceText)
+        {
+            MemberModel member;
+            if (sourceText != null)
+            {
+                SetSrc(sci, sourceText);
+                var type = sci.GetWordFromPosition(sci.CurrentPos);
+                member = new MemberModel(type, type, FlagType.Class, Visibility.Public);
+            }
+            else member = ClassModel.VoidClass;
+            return ASContext.Context.IsImported(member, sci.CurrentLine);
+        }
     }
 }

--- a/Tests/External/Plugins/AS3Context.Tests/Test Files/parser/IsImported_case1.as
+++ b/Tests/External/Plugins/AS3Context.Tests/Test Files/parser/IsImported_case1.as
@@ -1,0 +1,6 @@
+﻿package {
+	import flash.utils.Timer;
+	public class EFoo {
+		public var t:Tim$(EntryPoint)er;
+	}
+}

--- a/Tests/External/Plugins/AS3Context.Tests/TestUtils/TestFile.cs
+++ b/Tests/External/Plugins/AS3Context.Tests/TestUtils/TestFile.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Text;
+
+namespace AS3Context.TestUtils
+{
+    class TestFile : IDisposable
+    {
+        public string ResourceFile { get; }
+
+        public string DestinationFile { get; }
+
+        public TestFile(string resourceFile) : this(resourceFile, GetTempFileName(resourceFile))
+        {
+        }
+
+        public TestFile(string resourceFile, string destinationFile)
+        {
+            DestinationFile = destinationFile;
+            ResourceFile = resourceFile;
+            File.WriteAllBytes(destinationFile, ReadAllBytes(resourceFile));
+        }
+
+        static string GetTempFileName(string baseFileName)
+        {
+            var temp = Path.GetTempFileName();
+            return Path.GetFileNameWithoutExtension(temp) + Path.GetExtension(baseFileName);
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(DestinationFile))
+                File.Delete(DestinationFile);
+        }
+
+        public static string ReadAllText(string resourceFile)
+        {
+            return ReadAllText(resourceFile, Encoding.UTF8);
+        }
+
+        public static string ReadAllText(string resourceFile, Encoding encoding)
+        {
+            var buffer = ReadAllBytes(resourceFile);
+            return encoding.GetString(buffer);
+        }
+
+        public static byte[] ReadAllBytes(string resourceFile)
+        {
+            var asm = Assembly.GetExecutingAssembly();
+            using (var stream = asm.GetManifestResourceStream(resourceFile))
+            {
+                var buffer = new byte[stream.Length];
+                stream.Read(buffer, 0, buffer.Length);
+                return buffer;
+            }
+        }
+    }
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
@@ -45,8 +45,8 @@ namespace ASCompletion.TestUtils
             });
             mock.IsImported(null, Arg.Any<int>()).ReturnsForAnyArgs(it =>
             {
-                var member = it.ArgAt<MemberModel>(0);
-                return member != null && context.IsImported(member, it.ArgAt<int>(1));
+                var member = it.ArgAt<MemberModel>(0) ?? ClassModel.VoidClass;
+                return context.IsImported(member, it.ArgAt<int>(1));
             });
             mock.ResolveType(null, null).ReturnsForAnyArgs(x => context.ResolveType(x.ArgAt<string>(0), x.ArgAt<FileModel>(1)));
             mock.ResolveDotContext(null, null, false).ReturnsForAnyArgs(it =>

--- a/Tests/External/Plugins/HaxeContext.Tests/ContextTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/ContextTests.cs
@@ -12,9 +12,9 @@ namespace HaXeContext
     [TestFixture]
     class ContextTests : ASCompleteTests
     {
-        protected static string ReadAllTextHaxe(string fileName) => TestFile.ReadAllText(GetFullPathHaxe(fileName));
+        protected static string ReadAllText(string fileName) => TestFile.ReadAllText(GetFullPath(fileName));
 
-        protected static string GetFullPathHaxe(string fileName) => $"{nameof(HaXeContext)}.Test_Files.parser.{fileName}.hx";
+        protected static string GetFullPath(string fileName) => $"{nameof(HaXeContext)}.Test_Files.parser.{fileName}.hx";
 
         [TestFixtureSetUp]
         public void ContextTestsSetUp()
@@ -75,19 +75,19 @@ namespace HaXeContext
         [Test, TestCaseSource(nameof(DecomposeTypesTestCases))]
         public IEnumerable<string> DecomposeTypes(IEnumerable<string> types) => ASContext.Context.DecomposeTypes(types);
 
-        IEnumerable<TestCaseData> ParseFile_Issue1849TestCases
+        static IEnumerable<TestCaseData> ParseFile_Issue1849TestCases
         {
             get
             {
-                yield return new TestCaseData(ReadAllTextHaxe("Issue1849_1"))
+                yield return new TestCaseData(ReadAllText("Issue1849_1"))
                     .Returns("Dynamic<T>")
                     .SetName("implements Dynamic<T>")
                     .SetDescription("https://github.com/fdorg/flashdevelop/issues/1849");
-                yield return new TestCaseData(ReadAllTextHaxe("Issue1849_2"))
+                yield return new TestCaseData(ReadAllText("Issue1849_2"))
                     .Returns("IStruct<T>")
                     .SetName("implements IStruct<T>")
                     .SetDescription("https://github.com/fdorg/flashdevelop/issues/1849");
-                yield return new TestCaseData(ReadAllTextHaxe("Issue1849_3"))
+                yield return new TestCaseData(ReadAllText("Issue1849_3"))
                     .Returns("IStruct<K,V>")
                     .SetName("implements IStruct<K,V>")
                     .SetDescription("https://github.com/fdorg/flashdevelop/issues/1849");
@@ -102,26 +102,26 @@ namespace HaXeContext
             return interfaceType.Type;
         }
 
-        IEnumerable<TestCaseData> ResolveDotContext_issue750TestCases
+        static IEnumerable<TestCaseData> ResolveDotContext_issue750TestCases
         {
             get
             {
-                yield return new TestCaseData(ReadAllTextHaxe("ResolveDotContext_Issue1916_1"))
+                yield return new TestCaseData(ReadAllText("ResolveDotContext_Issue1916_1"))
                     .Returns(null)
                     .SetName("case 1");
-                yield return new TestCaseData(ReadAllTextHaxe("ResolveDotContext_Issue1916_2"))
+                yield return new TestCaseData(ReadAllText("ResolveDotContext_Issue1916_2"))
                     .Returns(new MemberModel("code", "Int", FlagType.Getter, Visibility.Public))
                     .SetName("case 2");
-                yield return new TestCaseData(ReadAllTextHaxe("ResolveDotContext_Issue1916_3"))
+                yield return new TestCaseData(ReadAllText("ResolveDotContext_Issue1916_3"))
                     .Returns(new MemberModel("code", "Int", FlagType.Getter, Visibility.Public))
                     .SetName("case 3");
-                yield return new TestCaseData(ReadAllTextHaxe("ResolveDotContext_Issue1916_4"))
+                yield return new TestCaseData(ReadAllText("ResolveDotContext_Issue1916_4"))
                     .Returns(null)
                     .SetName("case 4");
-                yield return new TestCaseData(ReadAllTextHaxe("ResolveDotContext_Issue1916_5"))
+                yield return new TestCaseData(ReadAllText("ResolveDotContext_Issue1916_5"))
                     .Returns(new MemberModel("code", "Int", FlagType.Getter, Visibility.Public))
                     .SetName("case 5");
-                yield return new TestCaseData(ReadAllTextHaxe("ResolveDotContext_Issue1916_6"))
+                yield return new TestCaseData(ReadAllText("ResolveDotContext_Issue1916_6"))
                     .Returns(new MemberModel("code", "Int", FlagType.Getter, Visibility.Public))
                     .SetName("case 6");
             }
@@ -135,6 +135,35 @@ namespace HaXeContext
             var expr = ASComplete.GetExpression(sci, sci.CurrentPos);
             var list = ASContext.Context.ResolveDotContext(sci, expr, false);
             return list?.Search("code", FlagType.Getter, Visibility.Public);
+        }
+
+        static IEnumerable<TestCaseData> IsImportedTestCases
+        {
+            get
+            {
+                yield return new TestCaseData(ReadAllText("IsImported_case1"))
+                    .Returns(true);
+                yield return new TestCaseData(ReadAllText("IsImported_case2"))
+                    .Returns(false);
+                yield return new TestCaseData(null)
+                    .Returns(false)
+                    .SetName("ClassModel.VoidClass")
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/1930");
+            }
+        }
+
+        [Test, TestCaseSource(nameof(IsImportedTestCases))]
+        public bool IsImported(string sourceText)
+        {
+            MemberModel member;
+            if (sourceText != null)
+            {
+                SetSrc(sci, sourceText);
+                var type = sci.GetWordFromPosition(sci.CurrentPos);
+                member = new MemberModel(type, type, FlagType.Class, Visibility.Public);
+            }
+            else member = ClassModel.VoidClass;
+            return ASContext.Context.IsImported(member, sci.CurrentLine);
         }
     }
 }

--- a/Tests/External/Plugins/HaxeContext.Tests/HaxeContext.Tests.csproj
+++ b/Tests/External/Plugins/HaxeContext.Tests/HaxeContext.Tests.csproj
@@ -156,6 +156,8 @@
     <EmbeddedResource Include="Test Files\parser\ResolveDotContext_Issue1916_4.hx" />
     <EmbeddedResource Include="Test Files\parser\ResolveDotContext_Issue1916_5.hx" />
     <EmbeddedResource Include="Test Files\parser\ResolveDotContext_Issue1916_6.hx" />
+    <EmbeddedResource Include="Test Files\parser\IsImported_case1.hx" />
+    <EmbeddedResource Include="Test Files\parser\IsImported_case2.hx" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/parser/IsImported_case1.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/parser/IsImported_case1.hx
@@ -1,0 +1,5 @@
+﻿package;
+import haxe.Timer;
+enum EFoo {
+	var Foo(t:Tim$(EntryPoint)er);
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/parser/IsImported_case2.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/parser/IsImported_case2.hx
@@ -1,0 +1,4 @@
+﻿package;
+enum EFoo {
+	var Foo(t:Poin$(EntryPoint)ter);
+}


### PR DESCRIPTION
now you can write `context.IsImported(type ?? ClassModel.VoidClass, line)` instead of `type != null && type != Class.VoidClass && context.IsImported(type, line)`