### PR TITLE
[ASComplete] Fixed 'ASComplete.EvalExpresion' for expression that ends with 'dot'

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -2619,7 +2619,7 @@ namespace ASCompletion.Completion
             if (asFunction && tokens.Length == 1) token += "(";
             if (context.SubExpressions != null && context.SubExpressions.Count == 1)
             {
-                var value = context.Value;
+                var value = token;
                 value = value.Replace(char.IsLetter(value[0]) ? ".#0~" : "#0~", context.SubExpressions.First());
                 type = ctx.ResolveToken(value, inClass.InFile);
             }

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -896,6 +896,10 @@
     <EmbeddedResource Include="Test Files\completion\haxe\GetExpressionType_Type_typecheck_2.hx" />
     <EmbeddedResource Include="Test Files\completion\haxe\GetExpressionType_Type_cast_2.hx" />
     <EmbeddedResource Include="Test Files\completion\as3\GetExpressionType_Type_as_2.as" />
+    <EmbeddedResource Include="Test Files\completion\as3\GetExpressionType_Type_arrayInitializer.as" />
+    <EmbeddedResource Include="Test Files\completion\as3\GetExpressionType_Type_stringInitializer.as" />
+    <EmbeddedResource Include="Test Files\completion\as3\GetExpressionType_Type_stringInitializer_2.as" />
+    <EmbeddedResource Include="Test Files\completion\as3\GetExpressionType_Type_objectInitializer.as" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -888,6 +888,14 @@
     <EmbeddedResource Include="Test Files\completion\as3\GetExpressionOfStringInitializer2.as" />
     <EmbeddedResource Include="Test Files\completion\as3\GetExpressionOfStringInitializer3.as" />
     <EmbeddedResource Include="Test Files\completion\as3\GetExpressionTypeOfVariable.as" />
+    <EmbeddedResource Include="Test Files\completion\as3\GetExpressionType_Type_as.as" />
+    <EmbeddedResource Include="Test Files\completion\as3\GetExpressionType_Type_is.as" />
+    <EmbeddedResource Include="Test Files\completion\haxe\GetExpressionType_Type_is.hx" />
+    <EmbeddedResource Include="Test Files\completion\haxe\GetExpressionType_Type_typecheck.hx" />
+    <EmbeddedResource Include="Test Files\completion\haxe\GetExpressionType_Type_cast.hx" />
+    <EmbeddedResource Include="Test Files\completion\haxe\GetExpressionType_Type_typecheck_2.hx" />
+    <EmbeddedResource Include="Test Files\completion\haxe\GetExpressionType_Type_cast_2.hx" />
+    <EmbeddedResource Include="Test Files\completion\as3\GetExpressionType_Type_as_2.as" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletion.Tests.csproj
@@ -900,6 +900,10 @@
     <EmbeddedResource Include="Test Files\completion\as3\GetExpressionType_Type_stringInitializer.as" />
     <EmbeddedResource Include="Test Files\completion\as3\GetExpressionType_Type_stringInitializer_2.as" />
     <EmbeddedResource Include="Test Files\completion\as3\GetExpressionType_Type_objectInitializer.as" />
+    <EmbeddedResource Include="Test Files\completion\haxe\GetExpressionType_Type_arrayInitializer.hx" />
+    <EmbeddedResource Include="Test Files\completion\haxe\GetExpressionType_Type_mapInitializer.hx" />
+    <EmbeddedResource Include="Test Files\completion\haxe\GetExpressionType_Type_stringInitializer.hx" />
+    <EmbeddedResource Include="Test Files\completion\haxe\GetExpressionType_Type_stringInitializer_2.hx" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASCompleteTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASCompleteTests.cs
@@ -241,6 +241,42 @@ namespace ASCompletion.Completion
                                 Access = Visibility.Public
                             })
                             .SetName("('s' is String).");
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_arrayInitializer"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "Array",
+                                Flags = FlagType.Class,
+                                Access = Visibility.Public
+                            })
+                            .SetName("[].");
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_stringInitializer"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "String",
+                                Flags = FlagType.Class,
+                                Access = Visibility.Public
+                            })
+                            .SetName("\"\".");
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_stringInitializer_2"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "String",
+                                Flags = FlagType.Class,
+                                Access = Visibility.Public
+                            })
+                            .SetName("''.");
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_objectInitializer"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "Object",
+                                Flags = FlagType.Class,
+                                Access = Visibility.Public
+                            })
+                            .SetName("{}.");
                 }
             }
 

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASCompleteTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASCompleteTests.cs
@@ -720,6 +720,38 @@ namespace ASCompletion.Completion
                                 Flags = FlagType.Class
                             })
                             .SetName("('s' is String).");
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_arrayInitializer"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "Array<T>",
+                                Flags = FlagType.Class
+                            })
+                            .SetName("[].");
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_mapInitializer"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "Map<K, V>",
+                                Flags = FlagType.Class
+                            })
+                            .SetName("[1=>1].");
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_stringInitializer"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "String",
+                                Flags = FlagType.Class
+                            })
+                            .SetName("\"\".");
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_stringInitializer_2"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "String",
+                                Flags = FlagType.Class
+                            })
+                            .SetName("''.");
                 }
             }
 

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASCompleteTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASCompleteTests.cs
@@ -14,11 +14,10 @@ namespace ASCompletion.Completion
     [TestFixture]
     public class ASCompleteTests : ASCompletionTests
     {
-        internal static MemberModel GetExpressionType(ScintillaControl sci, string sourceText)
+        internal static ASResult GetExpressionType(ScintillaControl sci, string sourceText)
         {
             SetSrc(sci, sourceText);
-            var result = ASComplete.GetExpressionType(sci, sci.WordEndPosition(sci.CurrentPos, true)).Member;
-            return result;
+            return ASComplete.GetExpressionType(sci, sci.WordEndPosition(sci.CurrentPos, true));
         }
 
         internal static string GetExpression(ScintillaControl sci, string sourceText)
@@ -113,7 +112,7 @@ namespace ASCompletion.Completion
                 Assert.AreEqual(4, result.Context.LocalVars.Count);
             }
 
-            public IEnumerable<TestCaseData> GetExpressionTypeTestCases
+            static IEnumerable<TestCaseData> GetExpressionTypeTestCases
             {
                 get
                 {
@@ -205,9 +204,54 @@ namespace ASCompletion.Completion
             }
 
             [Test, TestCaseSource(nameof(GetExpressionTypeTestCases))]
-            public MemberModel GetExpressionType(string sourceText) => GetExpressionType(sci, sourceText);
+            public MemberModel GetExpressionType_Member(string sourceText)
+            {
+                var expr = GetExpressionType(sci, sourceText);
+                return expr.Member;
+            }
 
-            public IEnumerable<TestCaseData> GetExpressionTestCases
+            static IEnumerable<TestCaseData> GetExpressionType_TypeTestCases
+            {
+                get
+                {
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_as"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "String",
+                                Flags = FlagType.Class,
+                                Access = Visibility.Public
+                            })
+                            .SetName("('s' as String).");
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_as_2"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "String",
+                                Flags = FlagType.Class,
+                                Access = Visibility.Public
+                            })
+                            .SetName("return ('s' as String).");
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_is"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "Boolean",
+                                Flags = FlagType.Class,
+                                Access = Visibility.Public
+                            })
+                            .SetName("('s' is String).");
+                }
+            }
+
+            [Test, TestCaseSource(nameof(GetExpressionType_TypeTestCases))]
+            public ClassModel GetExpressionType_Type(string sourceText)
+            {
+                var expr = GetExpressionType(sci, sourceText);
+                return expr.Type;
+            }
+
+            static IEnumerable<TestCaseData> GetExpressionTestCases
             {
                 get
                 {
@@ -414,7 +458,7 @@ namespace ASCompletion.Completion
             [Test, TestCaseSource(nameof(GetExpressionTestCases))]
             public string GetExpression(string sourceText) => GetExpression(sci, sourceText);
 
-            public IEnumerable<TestCaseData> DisambiguateComaTestCases
+            static IEnumerable<TestCaseData> DisambiguateComaTestCases
             {
                 get
                 {
@@ -432,7 +476,7 @@ namespace ASCompletion.Completion
             [Test, TestCaseSource(nameof(DisambiguateComaTestCases))]
             public ComaExpression DisambiguateComa(string sourceText) => DisambiguateComa(sci, sourceText);
 
-            public IEnumerable<TestCaseData> ExpressionEndPositionTestCases
+            static IEnumerable<TestCaseData> ExpressionEndPositionTestCases
             {
                 get
                 {
@@ -490,7 +534,7 @@ namespace ASCompletion.Completion
                 sci.ConfigurationLanguage = "haxe";
             }
 
-            public IEnumerable<TestCaseData> GetExpressionTypeTestCases
+            static IEnumerable<TestCaseData> GetExpressionTypeTestCases
             {
                 get
                 {
@@ -590,7 +634,65 @@ namespace ASCompletion.Completion
             }
 
             [Test, TestCaseSource(nameof(GetExpressionTypeTestCases))]
-            public MemberModel GetExpressionType(string sourceText) => GetExpressionType(sci, sourceText);
+            public MemberModel GetExpressionType_Member(string sourceText)
+            {
+                var expr = GetExpressionType(sci, sourceText);
+                return expr.Member;
+            }
+
+            static IEnumerable<TestCaseData> GetExpressionType_TypeTestCases
+            {
+                get
+                {
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_typecheck"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "String",
+                                Flags = FlagType.Class
+                            })
+                            .SetName("('s':String).");
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_typecheck_2"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "String",
+                                Flags = FlagType.Class
+                            })
+                            .SetName("return ('s':String).");
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_cast"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "String",
+                                Flags = FlagType.Class
+                            })
+                            .SetName("cast('s', String).");
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_cast"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "String",
+                                Flags = FlagType.Class
+                            })
+                            .SetName("return cast('s', String).");
+                    yield return
+                        new TestCaseData(ReadAllText("GetExpressionType_Type_is"))
+                            .Returns(new ClassModel
+                            {
+                                Name = "Bool",
+                                Flags = FlagType.Class
+                            })
+                            .SetName("('s' is String).");
+                }
+            }
+
+            [Test, TestCaseSource(nameof(GetExpressionType_TypeTestCases))]
+            public ClassModel GetExpressionType_Type(string sourceText)
+            {
+                var expr = GetExpressionType(sci, sourceText);
+                return expr.Type;
+            }
 
             [Test]
             public void Issue1867()
@@ -600,7 +702,7 @@ namespace ASCompletion.Completion
                 Assert.AreEqual(new ClassModel {Name = "Function", InFile = new FileModel {Package = "haxe.Constraints"}}, expr.Type);
             }
 
-            public IEnumerable<TestCaseData> GetExpressionTestCases
+            static IEnumerable<TestCaseData> GetExpressionTestCases
             {
                 get
                 {
@@ -711,7 +813,7 @@ namespace ASCompletion.Completion
             [Test, TestCaseSource(nameof(GetExpressionTestCases))]
             public string GetExpression(string sourceText) => GetExpression(sci, sourceText);
 
-            public IEnumerable<TestCaseData> DisambiguateComaHaxeTestCases
+            static IEnumerable<TestCaseData> DisambiguateComaHaxeTestCases
             {
                 get
                 {
@@ -742,7 +844,7 @@ namespace ASCompletion.Completion
             [Test, TestCaseSource(nameof(DisambiguateComaHaxeTestCases))]
             public ComaExpression DisambiguateComa(string sourceText) => DisambiguateComa(sci, sourceText);
 
-            public IEnumerable<TestCaseData> FindParameterIndexTestCases
+            static IEnumerable<TestCaseData> FindParameterIndexTestCases
             {
                 get
                 {
@@ -832,7 +934,7 @@ namespace ASCompletion.Completion
                 return result.Comments;
             }
 
-            public IEnumerable<TestCaseData> ExpressionEndPositionTestCases
+            static IEnumerable<TestCaseData> ExpressionEndPositionTestCases
             {
                 get
                 {

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/as3/GetExpressionType_Type_arrayInitializer.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/as3/GetExpressionType_Type_arrayInitializer.as
@@ -1,0 +1,7 @@
+package {
+	public class Foo {
+		public function foo() : void {
+			[].$(EntryPoint)
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/as3/GetExpressionType_Type_as.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/as3/GetExpressionType_Type_as.as
@@ -1,0 +1,7 @@
+package {
+	public class Foo {
+		public function foo() : void {
+			("1" as String).$(EntryPoint)
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/as3/GetExpressionType_Type_as_2.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/as3/GetExpressionType_Type_as_2.as
@@ -1,0 +1,7 @@
+package {
+	public class Foo {
+		public function foo() : void {
+			return ("1" as String).$(EntryPoint)
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/as3/GetExpressionType_Type_is.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/as3/GetExpressionType_Type_is.as
@@ -1,0 +1,7 @@
+package {
+	public class Foo {
+		public function foo() : void {
+			("1" is String).$(EntryPoint)
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/as3/GetExpressionType_Type_objectInitializer.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/as3/GetExpressionType_Type_objectInitializer.as
@@ -1,0 +1,7 @@
+package {
+	public class Foo {
+		public function foo() : void {
+			{}.$(EntryPoint)
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/as3/GetExpressionType_Type_stringInitializer.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/as3/GetExpressionType_Type_stringInitializer.as
@@ -1,0 +1,7 @@
+package {
+	public class Foo {
+		public function foo() : void {
+			"".$(EntryPoint)
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/as3/GetExpressionType_Type_stringInitializer_2.as
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/as3/GetExpressionType_Type_stringInitializer_2.as
@@ -1,0 +1,7 @@
+package {
+	public class Foo {
+		public function foo() : void {
+			''.$(EntryPoint)
+		}
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_arrayInitializer.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_arrayInitializer.hx
@@ -1,0 +1,6 @@
+package;
+public class Foo {
+	public function foo() {
+		[].$(EntryPoint)
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_cast.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_cast.hx
@@ -1,0 +1,6 @@
+package;
+public class Foo {
+	public function foo() {
+		cast('s', String).$(EntryPoint)
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_cast_2.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_cast_2.hx
@@ -1,0 +1,6 @@
+package;
+public class Foo {
+	public function foo() {
+		return cast('s', String).$(EntryPoint)
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_is.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_is.hx
@@ -1,0 +1,6 @@
+package;
+public class Foo {
+	public function foo() {
+		('s' is String).$(EntryPoint)
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_mapInitializer.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_mapInitializer.hx
@@ -1,0 +1,6 @@
+package;
+public class Foo {
+	public function foo() {
+		[1=>1].$(EntryPoint)
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_stringInitializer.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_stringInitializer.hx
@@ -1,0 +1,6 @@
+package;
+public class Foo {
+	public function foo() {
+		"".$(EntryPoint)
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_stringInitializer_2.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_stringInitializer_2.hx
@@ -1,0 +1,6 @@
+package;
+public class Foo {
+	public function foo() {
+		''.$(EntryPoint)
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_typecheck.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_typecheck.hx
@@ -1,0 +1,6 @@
+package;
+public class Foo {
+	public function foo() {
+		('s':String).$(EntryPoint)
+	}
+}

--- a/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_typecheck_2.hx
+++ b/Tests/External/Plugins/ASCompletion.Tests/Test Files/completion/haxe/GetExpressionType_Type_typecheck_2.hx
@@ -1,0 +1,6 @@
+package;
+public class Foo {
+	public function foo() {
+		return ('s':String).$(EntryPoint)
+	}
+}


### PR DESCRIPTION
fixes #1916
fixes https://github.com/SlavaRa/AdvancedHaxeContext/issues/3