### PR TITLE
Improved work with the file parser.

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -4016,7 +4016,7 @@ namespace ASCompletion.Completion
             {
                 MemberModel cm = expression.ContextMember;
                 string functionBody = Regex.Replace(expression.FunctionBody, "function\\s*\\(", "function __anonfunc__("); // name anonymous functions
-                model = ASContext.Context.GetCodeModel(functionBody);
+                model = ASContext.Context.GetCodeModel(functionBody, true);
                 int memberCount = model.Members.Count;
                 for (int memberIndex = 0; memberIndex < memberCount; memberIndex++)
                 {

--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -1657,12 +1657,7 @@ namespace ASCompletion.Completion
 
                 ASContext.MainForm.OpenEditableDocument(funcResult.Type.InFile.FileName, true);
                 sci = ASContext.CurSciControl;
-
-                FileModel fileModel = new FileModel(funcResult.Type.InFile.FileName);
-                fileModel.Context = ASContext.Context;
-                ASFileParser parser = new ASFileParser();
-                parser.ParseSrc(fileModel, sci.Text);
-
+                var fileModel = ASContext.Context.GetFileModel(funcResult.Type.InFile.FileName);
                 foreach (ClassModel cm in fileModel.Classes)
                 {
                     if (cm.QualifiedName.Equals(funcResult.Type.QualifiedName))

--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -1612,7 +1612,7 @@ namespace ASCompletion.Completion
 
                 ASContext.MainForm.OpenEditableDocument(funcResult.InClass.InFile.FileName, true);
                 sci = ASContext.CurSciControl;
-                var fileModel = ASContext.Context.GetCodeModel(sci.Text, false);
+                var fileModel = ASContext.Context.GetCodeModel(sci.Text);
                 foreach (ClassModel cm in fileModel.Classes)
                 {
                     if (cm.QualifiedName.Equals(funcResult.InClass.QualifiedName))
@@ -2370,7 +2370,7 @@ namespace ASCompletion.Completion
                 ASContext.MainForm.OpenEditableDocument(varResult.RelClass.InFile.FileName, false);
                 sci = ASContext.CurSciControl;
                 isOtherClass = true;
-                var fileModel = ASContext.Context.GetCodeModel(sci.Text, false);
+                var fileModel = ASContext.Context.GetCodeModel(sci.Text);
                 foreach (ClassModel cm in fileModel.Classes)
                 {
                     if (cm.QualifiedName.Equals(varResult.RelClass.QualifiedName))
@@ -2872,7 +2872,7 @@ namespace ASCompletion.Completion
                 ASContext.MainForm.OpenEditableDocument(funcResult.RelClass.InFile.FileName, true);
                 sci = ASContext.CurSciControl;
                 isOtherClass = true;
-                var fileModel = ASContext.Context.GetCodeModel(sci.Text, false);
+                var fileModel = ASContext.Context.GetCodeModel(sci.Text);
                 foreach (ClassModel cm in fileModel.Classes)
                 {
                     if (cm.QualifiedName.Equals(funcResult.RelClass.QualifiedName))

--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -3149,7 +3149,7 @@ namespace ASCompletion.Completion
             expression = expression.TrimEnd(new char[] { '(', '[', '{', '<' });
             expression = expression.TrimStart(new char[] { ')', ']', '}', '>' });
 
-            var cFile = ASContext.Context.GetCodeModel(ASContext.Context.CurrentModel, sci.Text, false);
+            var cFile = ASContext.Context.GetCodeModel(ASContext.Context.CurrentModel, sci.Text);
             MemberModel current = cFile.Context.CurrentMember;
 
             string characterClass = ScintillaControl.Configuration.GetLanguage(sci.ConfigurationLanguage).characterclass.Characters;
@@ -3261,7 +3261,7 @@ namespace ASCompletion.Completion
             }
             InsertCode(sci.CurrentPos, template, sci);
 
-            ASContext.Context.GetCodeModel(ASContext.Context.CurrentModel, sci.Text, false);
+            ASContext.Context.GetCodeModel(ASContext.Context.CurrentModel, sci.Text);
             FoundDeclaration found = GetDeclarationAtLine(lineStart);
             if (found.Member == null) return;
 

--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -1818,8 +1818,7 @@ namespace ASCompletion.Completion
             var context = ASContext.Context;
             ClassModel aType = context.ResolveType(interf, context.CurrentModel);
             if (aType.IsVoid()) return;
-
-            FileModel fileModel = ASFileParser.ParseFile(context.CreateFileModel(aType.InFile.FileName));
+            var fileModel = ASContext.Context.GetFileModel(aType.InFile.FileName);
             foreach (ClassModel cm in fileModel.Classes)
             {
                 if (cm.QualifiedName.Equals(aType.QualifiedName))

--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -1612,12 +1612,7 @@ namespace ASCompletion.Completion
 
                 ASContext.MainForm.OpenEditableDocument(funcResult.InClass.InFile.FileName, true);
                 sci = ASContext.CurSciControl;
-
-                FileModel fileModel = new FileModel();
-                fileModel.Context = ASContext.Context;
-                ASFileParser parser = new ASFileParser();
-                parser.ParseSrc(fileModel, sci.Text);
-
+                var fileModel = ASContext.Context.GetCodeModel(sci.Text, false);
                 foreach (ClassModel cm in fileModel.Classes)
                 {
                     if (cm.QualifiedName.Equals(funcResult.InClass.QualifiedName))

--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -2873,11 +2873,7 @@ namespace ASCompletion.Completion
                 ASContext.MainForm.OpenEditableDocument(funcResult.RelClass.InFile.FileName, true);
                 sci = ASContext.CurSciControl;
                 isOtherClass = true;
-
-                var fileModel = new FileModel {Context = ASContext.Context};
-                var parser = new ASFileParser();
-                parser.ParseSrc(fileModel, sci.Text);
-
+                var fileModel = ASContext.Context.GetCodeModel(sci.Text, false);
                 foreach (ClassModel cm in fileModel.Classes)
                 {
                     if (cm.QualifiedName.Equals(funcResult.RelClass.QualifiedName))

--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -3262,10 +3262,7 @@ namespace ASCompletion.Completion
             }
             InsertCode(sci.CurrentPos, template, sci);
 
-            var cFile = ASContext.Context.CurrentModel;
-            ASFileParser parser = new ASFileParser();
-            parser.ParseSrc(cFile, sci.Text);
-
+            ASContext.Context.GetCodeModel(ASContext.Context.CurrentModel, sci.Text, false);
             FoundDeclaration found = GetDeclarationAtLine(lineStart);
             if (found.Member == null) return;
 

--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -2371,12 +2371,7 @@ namespace ASCompletion.Completion
                 ASContext.MainForm.OpenEditableDocument(varResult.RelClass.InFile.FileName, false);
                 sci = ASContext.CurSciControl;
                 isOtherClass = true;
-
-                FileModel fileModel = new FileModel();
-                fileModel.Context = ASContext.Context;
-                ASFileParser parser = new ASFileParser();
-                parser.ParseSrc(fileModel, sci.Text);
-
+                var fileModel = ASContext.Context.GetCodeModel(sci.Text, false);
                 foreach (ClassModel cm in fileModel.Classes)
                 {
                     if (cm.QualifiedName.Equals(varResult.RelClass.QualifiedName))

--- a/External/Plugins/ASCompletion/Completion/ASGenerator.cs
+++ b/External/Plugins/ASCompletion/Completion/ASGenerator.cs
@@ -3150,10 +3150,7 @@ namespace ASCompletion.Completion
             expression = expression.TrimEnd(new char[] { '(', '[', '{', '<' });
             expression = expression.TrimStart(new char[] { ')', ']', '}', '>' });
 
-            var cFile = ASContext.Context.CurrentModel;
-            ASFileParser parser = new ASFileParser();
-            parser.ParseSrc(cFile, sci.Text);
-
+            var cFile = ASContext.Context.GetCodeModel(ASContext.Context.CurrentModel, sci.Text, false);
             MemberModel current = cFile.Context.CurrentMember;
 
             string characterClass = ScintillaControl.Configuration.GetLanguage(sci.ConfigurationLanguage).characterclass.Characters;

--- a/External/Plugins/ASCompletion/Context/ASContext.cs
+++ b/External/Plugins/ASCompletion/Context/ASContext.cs
@@ -844,7 +844,7 @@ namespace ASCompletion.Context
             }
 
             // parse and add to cache
-            nFile = ASFileParser.ParseFile(CreateFileModel(fileName));
+            nFile = GetFileModel(fileName);
             if (classPath != null)
             {
                 string upName = fileName.ToUpper();

--- a/External/Plugins/ASCompletion/Context/ASContext.cs
+++ b/External/Plugins/ASCompletion/Context/ASContext.cs
@@ -956,7 +956,7 @@ namespace ASCompletion.Context
         public virtual FileModel GetCodeModel(string src) => GetCodeModel(src, true);
 
         /// <inheritdoc />
-        public virtual FileModel GetCodeModel(string src, bool scriptMode) => GetCodeModel(new FileModel(), src, scriptMode);
+        public virtual FileModel GetCodeModel(string src, bool scriptMode) => GetCodeModel(CreateFileModel(string.Empty), src, scriptMode);
 
         /// <inheritdoc />
         public virtual FileModel GetCodeModel(FileModel result, string src, bool scriptMode)

--- a/External/Plugins/ASCompletion/Context/ASContext.cs
+++ b/External/Plugins/ASCompletion/Context/ASContext.cs
@@ -959,6 +959,9 @@ namespace ASCompletion.Context
         public virtual FileModel GetCodeModel(string src, bool scriptMode) => GetCodeModel(CreateFileModel(string.Empty), src, scriptMode);
 
         /// <inheritdoc />
+        public virtual FileModel GetCodeModel(FileModel result, string src) => GetCodeModel(result, src, false);
+
+        /// <inheritdoc />
         public virtual FileModel GetCodeModel(FileModel result, string src, bool scriptMode)
         {
             var parser = GetCodeParser();
@@ -1002,7 +1005,7 @@ namespace ASCompletion.Context
         public virtual void UpdateCurrentFile(bool updateUI)
         {
             if (cFile == null || CurSciControl == null) return;
-            GetCodeModel(cFile, CurSciControl.Text, false);
+            GetCodeModel(cFile, CurSciControl.Text);
             cLine = CurSciControl.CurrentLine;
             UpdateContext(cLine);
 

--- a/External/Plugins/ASCompletion/Context/ASContext.cs
+++ b/External/Plugins/ASCompletion/Context/ASContext.cs
@@ -1002,8 +1002,7 @@ namespace ASCompletion.Context
         public virtual void UpdateCurrentFile(bool updateUI)
         {
             if (cFile == null || CurSciControl == null) return;
-            var parser = GetCodeParser();
-            parser.ParseSrc(cFile, CurSciControl.Text);
+            GetCodeModel(cFile, CurSciControl.Text, false);
             cLine = CurSciControl.CurrentLine;
             UpdateContext(cLine);
 
@@ -1478,13 +1477,7 @@ namespace ASCompletion.Context
                     dest = list[1];
                 }
             }
-            FileModel aFile;
-            if (src == null) aFile = cFile;
-            else
-            {
-                var parser = GetCodeParser();
-                aFile = parser.Parse(CreateFileModel(src));
-            }
+            var aFile = src == null ? cFile : GetCodeModel(src, false);
             if (aFile.Version == 0) return;
             //
             string code = aFile.GenerateIntrinsic(false);

--- a/External/Plugins/ASCompletion/Context/ASContext.cs
+++ b/External/Plugins/ASCompletion/Context/ASContext.cs
@@ -953,7 +953,7 @@ namespace ASCompletion.Context
         public virtual bool IsModelValid(FileModel aFile, PathModel pathModel) => (aFile != null);
 
         /// <inheritdoc />
-        public virtual FileModel GetCodeModel(string src) => GetCodeModel(src, true);
+        public virtual FileModel GetCodeModel(string src) => GetCodeModel(src, false);
 
         /// <inheritdoc />
         public virtual FileModel GetCodeModel(string src, bool scriptMode) => GetCodeModel(CreateFileModel(string.Empty), src, scriptMode);
@@ -1477,7 +1477,7 @@ namespace ASCompletion.Context
                     dest = list[1];
                 }
             }
-            var aFile = src == null ? cFile : GetCodeModel(src, false);
+            var aFile = src == null ? cFile : GetCodeModel(src);
             if (aFile.Version == 0) return;
             //
             string code = aFile.GenerateIntrinsic(false);

--- a/External/Plugins/ASCompletion/Context/ASContext.cs
+++ b/External/Plugins/ASCompletion/Context/ASContext.cs
@@ -955,21 +955,10 @@ namespace ASCompletion.Context
         /// <inheritdoc />
         public virtual FileModel GetCodeModel(string src) => GetCodeModel(src, true);
 
-        /// <summary>
-        /// Parse a raw source code
-        /// </summary>
-        /// <param name="src"></param>
-        /// <param name="scriptMode"></param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public virtual FileModel GetCodeModel(string src, bool scriptMode) => GetCodeModel(new FileModel(), src, scriptMode);
 
-        /// <summary>
-        /// Parse a raw source code
-        /// </summary>
-        /// <param name="result"></param>
-        /// <param name="src"></param>
-        /// <param name="scriptMode"></param>
-        /// <returns></returns>
+        /// <inheritdoc />
         public virtual FileModel GetCodeModel(FileModel result, string src, bool scriptMode)
         {
             var parser = GetCodeParser();
@@ -982,21 +971,7 @@ namespace ASCompletion.Context
         /// Set local code parser features
         /// </summary>
         /// <returns></returns>
-        protected virtual ASFileParser GetCodeParser()
-        {
-            ASFileParser parser = new ASFileParser();
-            parser.Features.varKey = Context.Features.varKey;
-            parser.Features.constKey = Context.Features.constKey;
-            parser.Features.functionKey = Context.Features.functionKey;
-            parser.Features.hasEcmaTyping = Context.Features.hasEcmaTyping;
-            parser.Features.hasConsts = Context.Features.hasConsts;
-            parser.Features.hasVars = Context.Features.hasVars;
-            parser.Features.hasMethods = Context.Features.hasMethods;
-            parser.Features.hasGenerics = Context.Features.hasGenerics;
-            parser.Features.hasCArrays = Context.Features.hasCArrays;
-            parser.Features.CArrayTemplate = Context.Features.CArrayTemplate;
-            return parser;
-        }
+        protected virtual ASFileParser GetCodeParser() => new ASFileParser(context.Features);
 
         /// <summary>
         /// Build the file DOM

--- a/External/Plugins/ASCompletion/Context/IASContext.cs
+++ b/External/Plugins/ASCompletion/Context/IASContext.cs
@@ -125,6 +125,14 @@ namespace ASCompletion.Context
         /// </summary>
         /// <param name="result">File model</param>
         /// <param name="src">Source code</param>
+        /// <returns></returns>
+        FileModel GetCodeModel(FileModel result, string src);
+
+        /// <summary>
+        /// Rebuild a file model with the source provided
+        /// </summary>
+        /// <param name="result">File model</param>
+        /// <param name="src">Source code</param>
         /// <param name="scriptMode"></param>
         /// <returns></returns>
         FileModel GetCodeModel(FileModel result, string src, bool scriptMode);

--- a/External/Plugins/ASCompletion/Context/IASContext.cs
+++ b/External/Plugins/ASCompletion/Context/IASContext.cs
@@ -108,9 +108,26 @@ namespace ASCompletion.Context
         /// <summary>
         /// Parse a raw source code
         /// </summary>
-        /// <param name="src"></param>
+        /// <param name="src">Source code</param>
         /// <returns></returns>
         FileModel GetCodeModel(string src);
+
+        /// <summary>
+        /// Parse a raw source code
+        /// </summary>
+        /// <param name="src">Source code</param>
+        /// <param name="scriptMode"></param>
+        /// <returns></returns>
+        FileModel GetCodeModel(string src, bool scriptMode);
+
+        /// <summary>
+        /// Rebuild a file model with the source provided
+        /// </summary>
+        /// <param name="result">File model</param>
+        /// <param name="src">Source code</param>
+        /// <param name="scriptMode"></param>
+        /// <returns></returns>
+        FileModel GetCodeModel(FileModel result, string src, bool scriptMode);
 
         /// <summary>
         /// Retrieve a fully qualified class in classpath

--- a/External/Plugins/ASCompletion/Context/IASContext.cs
+++ b/External/Plugins/ASCompletion/Context/IASContext.cs
@@ -133,6 +133,7 @@ namespace ASCompletion.Context
         /// <summary>
         /// Called if a FileModel needs filtering
         /// </summary>
+        /// <param name="fileName"></param>
         /// <param name="src"></param>
         /// <returns></returns>
         string FilterSource(string fileName, string src);
@@ -313,6 +314,7 @@ namespace ASCompletion.Context
         /// </summary>
         /// <param name="sci">Scintilla control</param>
         /// <param name="expression">Completion context</param>
+        /// <param name="autoHide">Auto-started completion (is false when pressing Ctrl+Space)</param>
         /// <returns>Null (not handled) or function signature</returns>
         MemberModel ResolveFunctionContext(ScintillaControl sci, ASExpr expression, bool autoHide);
 

--- a/External/Plugins/ASCompletion/Model/ASFileParser.cs
+++ b/External/Plugins/ASCompletion/Model/ASFileParser.cs
@@ -497,11 +497,13 @@ namespace ASCompletion.Model
 
         public bool ScriptMode;
 
-        public ContextFeatures Features => features;
-
-        public ASFileParser()
+        public ASFileParser() : this(new ContextFeatures())
         {
-            features = new ContextFeatures();
+        }
+
+        public ASFileParser(ContextFeatures features)
+        {
+            this.features = features;
         }
 
         /// <summary>

--- a/External/Plugins/ASCompletion/Model/ASFileParser.cs
+++ b/External/Plugins/ASCompletion/Model/ASFileParser.cs
@@ -421,17 +421,15 @@ namespace ASCompletion.Model
 
         #region public methods
 
-        static public FileModel ParseFile(FileModel fileModel)
+        public static FileModel ParseFile(FileModel fileModel)
         {
             // parse file
             if (fileModel.FileName.Length > 0)
             {
                 if (File.Exists(fileModel.FileName))
                 {
-                    var src = FileHelper.ReadFile(fileModel.FileName);
-                    ASFileParser parser = new ASFileParser();
-                    fileModel.LastWriteTime = File.GetLastWriteTime(fileModel.FileName);
-                    parser.ParseSrc(fileModel, src);
+                    var parser = new ASFileParser();
+                    parser.Parse(fileModel);
                 }
                 // the file is not available (for the moment?)
                 else if (Path.GetExtension(fileModel.FileName).Length > 0)
@@ -499,10 +497,7 @@ namespace ASCompletion.Model
 
         public bool ScriptMode;
 
-        public ContextFeatures Features
-        {
-            get { return features; }
-        }
+        public ContextFeatures Features => features;
 
         public ASFileParser()
         {
@@ -510,15 +505,24 @@ namespace ASCompletion.Model
         }
 
         /// <summary>
+        /// Rebuild a file model using the content of that file.
+        /// </summary>
+        /// <param name="fileModel">Model</param>
+        public FileModel Parse(FileModel fileModel)
+        {
+            fileModel.LastWriteTime = File.GetLastWriteTime(fileModel.FileName);
+            var src = FileHelper.ReadFile(fileModel.FileName);
+            ParseSrc(fileModel, src);
+            return fileModel;
+        }
+
+        /// <summary>
         /// Rebuild a file model with the source provided
         /// </summary>
         /// <param name="fileModel">Model</param>
-        /// <param name="ba">Source</param>
-        ///
-        public void ParseSrc(FileModel fileModel, string ba)
-        {
-            ParseSrc(fileModel, ba, true);
-        }
+        /// <param name="src">Source</param>
+        public void ParseSrc(FileModel fileModel, string src) => ParseSrc(fileModel, src, true);
+
         public void ParseSrc(FileModel fileModel, string ba, bool allowBaReExtract)
         {
             //TraceManager.Add("Parsing " + Path.GetFileName(fileModel.FileName));

--- a/External/Plugins/ASCompletion/Model/FileModel.cs
+++ b/External/Plugins/ASCompletion/Model/FileModel.cs
@@ -163,7 +163,7 @@ namespace ASCompletion.Model
             Package = "";
             Module = "";
             FileName = fileName ?? "";
-            haXe = (FileName.Length > 3) ? FileInspector.IsHaxeFile(FileName, Path.GetExtension(FileName)) : false;
+            haXe = (FileName.Length > 3) && FileInspector.IsHaxeFile(FileName, Path.GetExtension(FileName));
             //
             Namespaces = new Dictionary<string, Visibility>();
             //

--- a/External/Plugins/CodeRefactor/Commands/ExtractLocalVariableCommand.cs
+++ b/External/Plugins/CodeRefactor/Commands/ExtractLocalVariableCommand.cs
@@ -66,7 +66,7 @@ namespace CodeRefactor.Commands
         protected override void ExecutionImplementation()
         {
             var sci = PluginBase.MainForm.CurrentDocument.SciControl;
-            var fileModel = ASContext.Context.GetCodeModel(ASContext.Context.CurrentModel, sci.Text, false);
+            var fileModel = ASContext.Context.GetCodeModel(ASContext.Context.CurrentModel, sci.Text);
             var search = new FRSearch(sci.SelText) {SourceFile = sci.FileName};
             var matches = search.Matches(sci.Text);
             var currentMember = fileModel.Context.CurrentMember;

--- a/External/Plugins/CodeRefactor/Commands/ExtractLocalVariableCommand.cs
+++ b/External/Plugins/CodeRefactor/Commands/ExtractLocalVariableCommand.cs
@@ -66,20 +66,18 @@ namespace CodeRefactor.Commands
         protected override void ExecutionImplementation()
         {
             var sci = PluginBase.MainForm.CurrentDocument.SciControl;
-            var fileModel = ASContext.Context.CurrentModel;
-            var parser = new ASFileParser();
-            parser.ParseSrc(fileModel, sci.Text);
+            var fileModel = ASContext.Context.GetCodeModel(ASContext.Context.CurrentModel, sci.Text, false);
             var search = new FRSearch(sci.SelText) {SourceFile = sci.FileName};
-            var mathes = search.Matches(sci.Text);
+            var matches = search.Matches(sci.Text);
             var currentMember = fileModel.Context.CurrentMember;
             var lineFrom = currentMember.LineFrom;
             var lineTo = currentMember.LineTo;
-            mathes.RemoveAll(it => it.Line < lineFrom || it.Line > lineTo);
-            var target = mathes.FindAll(it => sci.MBSafePosition(it.Index) == sci.SelectionStart);
-            if (mathes.Count > 1)
+            matches.RemoveAll(it => it.Line < lineFrom || it.Line > lineTo);
+            var target = matches.FindAll(it => sci.MBSafePosition(it.Index) == sci.SelectionStart);
+            if (matches.Count > 1)
             {
                 CompletionList = new List<ICompletionListItem> {new CompletionListItem(target, sci, OnItemClick)};
-                CompletionList.Insert(0, new CompletionListItem(mathes, sci, OnItemClick));
+                CompletionList.Insert(0, new CompletionListItem(matches, sci, OnItemClick));
                 sci.DisableAllSciEvents = true;
                 PluginCore.Controls.CompletionList.Show(CompletionList, true);
             }

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -580,12 +580,9 @@ namespace HaXeContext
         /// <inheritdoc />
         public override FileModel GetCodeModel(string src)
         {
-            var parser = GetCodeParser();
-            parser.ScriptMode = true;
-            var result = new FileModel {haXe = true};
-            if (!string.IsNullOrEmpty(src))
+            var result = base.GetCodeModel(new FileModel {haXe = true}, src, true);
+            if (result.Members != null)
             {
-                parser.ParseSrc(result, src);
                 for (var i = 0; i < result.Members.Count; i++)
                 {
                     var member = result.Members[i];

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -578,9 +578,10 @@ namespace HaXeContext
         }
 
         /// <inheritdoc />
-        public override FileModel GetCodeModel(string src)
+        public override FileModel GetCodeModel(FileModel result, string src, bool scriptMode)
         {
-            var result = base.GetCodeModel(new FileModel {haXe = true}, src, true);
+            result.haXe = true;
+            base.GetCodeModel(result, src, scriptMode);
             if (result.Members != null)
             {
                 for (var i = 0; i < result.Members.Count; i++)

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletionTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletionTests.cs
@@ -103,7 +103,7 @@ namespace ASCompletion
             sci.Text = sourceText;
             SnippetHelper.PostProcessSnippets(sci, 0);
             var currentModel = ASContext.Context.CurrentModel;
-            ASContext.Context.GetCodeModel(currentModel, sci.Text, false);
+            ASContext.Context.GetCodeModel(currentModel, sci.Text);
             var line = sci.CurrentLine;
             var currentClass = currentModel.Classes.FirstOrDefault(line);
             ASContext.Context.CurrentClass.Returns(currentClass);

--- a/Tests/External/Plugins/ASCompletion.Tests/ASCompletionTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/ASCompletionTests.cs
@@ -103,7 +103,7 @@ namespace ASCompletion
             sci.Text = sourceText;
             SnippetHelper.PostProcessSnippets(sci, 0);
             var currentModel = ASContext.Context.CurrentModel;
-            new ASFileParser().ParseSrc(currentModel, sci.Text);
+            ASContext.Context.GetCodeModel(currentModel, sci.Text, false);
             var line = sci.CurrentLine;
             var currentClass = currentModel.Classes.FirstOrDefault(line);
             ASContext.Context.CurrentClass.Returns(currentClass);

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
@@ -2743,50 +2743,50 @@ namespace ASCompletion.Completion
                     get
                     {
                         yield return
-                            new TestCaseData(ReadAllTextAS3("BeforeChangeConstructorDeclaration_String"))
+                            new TestCaseData("BeforeChangeConstructorDeclaration_String")
                                 .Returns(ReadAllTextAS3("AfterChangeConstructorDeclaration_String"))
                                 .SetName("new Foo(\"\") -> function Foo(string:String)");
                         yield return
-                            new TestCaseData(ReadAllTextAS3("BeforeChangeConstructorDeclaration_String2"))
+                            new TestCaseData("BeforeChangeConstructorDeclaration_String2")
                                 .Returns(ReadAllTextAS3("AfterChangeConstructorDeclaration_String2"))
                                 .SetName("new Foo(\"\", \"\") -> function Foo(string:String, string1:String)");
                         yield return
-                            new TestCaseData(ReadAllTextAS3("BeforeChangeConstructorDeclaration_Digit"))
+                            new TestCaseData("BeforeChangeConstructorDeclaration_Digit")
                                 .Returns(ReadAllTextAS3("AfterChangeConstructorDeclaration_Digit"))
                                 .SetName("new Foo(1) -> function Foo(number:Number)");
                         yield return
-                            new TestCaseData(ReadAllTextAS3("BeforeChangeConstructorDeclaration_Boolean"))
+                            new TestCaseData("BeforeChangeConstructorDeclaration_Boolean")
                                 .Returns(ReadAllTextAS3("AfterChangeConstructorDeclaration_Boolean"))
                                 .SetName("new Foo(true) -> function Foo(boolean:Boolean)");
                         yield return
-                            new TestCaseData(ReadAllTextAS3("BeforeChangeConstructorDeclaration_ObjectInitializer"))
+                            new TestCaseData("BeforeChangeConstructorDeclaration_ObjectInitializer")
                                 .Returns(ReadAllTextAS3("AfterChangeConstructorDeclaration_ObjectInitializer"))
                                 .SetName("new Foo({}) -> function Foo(object:Object)");
                         yield return
-                            new TestCaseData(ReadAllTextAS3("BeforeChangeConstructorDeclaration_ArrayInitializer"))
+                            new TestCaseData("BeforeChangeConstructorDeclaration_ArrayInitializer")
                                 .Returns(ReadAllTextAS3("AfterChangeConstructorDeclaration_ArrayInitializer"))
                                 .SetName("new Foo([]) -> function Foo(array:Array)");
                         yield return
-                            new TestCaseData(ReadAllTextAS3("BeforeChangeConstructorDeclaration_VectorInitializer"))
+                            new TestCaseData("BeforeChangeConstructorDeclaration_VectorInitializer")
                                 .Returns(ReadAllTextAS3("AfterChangeConstructorDeclaration_VectorInitializer"))
                                 .SetName("new Foo(new <int>[]) -> function Foo(vector:Vector.<int>)");
                         yield return
-                            new TestCaseData(ReadAllTextAS3("BeforeChangeConstructorDeclaration_TwoDimensionalVectorInitializer"))
+                            new TestCaseData("BeforeChangeConstructorDeclaration_TwoDimensionalVectorInitializer")
                                 .Returns(ReadAllTextAS3("AfterChangeConstructorDeclaration_TwoDimensionalVectorInitializer"))
                                 .SetName("new Foo(new <Vector.<Vector.<int>>[new <int>[]]) -> function Foo(vector:Vector.<Vector.<int>>)");
                         yield return
-                            new TestCaseData(ReadAllTextAS3("BeforeChangeConstructorDeclaration_ItemOfTwoDimensionalVectorInitializer"))
+                            new TestCaseData("BeforeChangeConstructorDeclaration_ItemOfTwoDimensionalVectorInitializer")
                                 .Returns(ReadAllTextAS3("AfterChangeConstructorDeclaration_ItemOfTwoDimensionalVectorInitializer"))
                                 .SetName("new Foo(strings[0][0]) -> function Foo(string:String)");
                         yield return
-                            new TestCaseData(ReadAllTextAS3("BeforeChangeConstructorDeclaration_Function"))
+                            new TestCaseData("BeforeChangeConstructorDeclaration_Function")
                                 .Returns(ReadAllTextAS3("AfterChangeConstructorDeclaration_Function"))
                                 .SetName("new Foo(function():void {}) -> function Foo(functionValue:Function)");
                     }
                 }
 
                 [Test, TestCaseSource(nameof(AS3TestCases))]
-                public string AS3(string sourceText) => AS3Impl(sourceText, sci);
+                public string AS3(string fileName) => AS3Impl(fileName, sci);
 
                 public IEnumerable<TestCaseData> HaxeTestCases
                 {
@@ -2832,10 +2832,11 @@ namespace ASCompletion.Completion
                 [Test, TestCaseSource(nameof(HaxeTestCases))]
                 public string Haxe(string fileName) => HaxeImpl(fileName, sci);
 
-                internal string AS3Impl(string sourceText, ScintillaControl sci)
+                internal string AS3Impl(string fileName, ScintillaControl sci)
                 {
                     SetAs3Features(sci);
-                    return Common(sourceText, sci);
+                    SetCurrentFileName(GetFullPathAS3(fileName));
+                    return Common(ReadAllTextAS3(fileName), sci);
                 }
 
                 internal string HaxeImpl(string fileName, ScintillaControl sci)

--- a/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Completion/ASGeneratorTests.cs
@@ -2424,14 +2424,8 @@ namespace ASCompletion.Completion
 
                 static string Common(string sourceText, string ofClassName, string memberName, FlagType memberFlags, ScintillaControl sci)
                 {
-                    sci.Text = sourceText;
-                    SnippetHelper.PostProcessSnippets(sci, 0);
-                    var currentModel = ASContext.Context.CurrentModel;
-                    new ASFileParser().ParseSrc(currentModel, sci.Text);
-                    var currentLine = sci.CurrentLine;
-                    var currentClass = currentModel.Classes.Find(it => currentLine >= it.LineFrom && currentLine < it.LineTo);
-                    ASContext.Context.CurrentClass.Returns(currentClass);
-                    var ofClass = currentModel.Classes.Find(model => model.Name == ofClassName);
+                    SetSrc(sci, sourceText);
+                    var ofClass = ASContext.Context.CurrentModel.Classes.Find(model => model.Name == ofClassName);
                     if (ofClass == null)
                     {
                         foreach (var classpath in ASContext.Context.Classpath)

--- a/Tests/External/Plugins/ASCompletion.Tests/Generators/DocumentationGeneratorTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Generators/DocumentationGeneratorTests.cs
@@ -1,12 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using ASCompletion.Context;
-using ASCompletion.Model;
 using ASCompletion.TestUtils;
 using NSubstitute;
 using NUnit.Framework;
 using PluginCore;
-using PluginCore.Helpers;
 using ScintillaNet;
 
 namespace ASCompletion.Generators
@@ -14,6 +12,10 @@ namespace ASCompletion.Generators
     [TestFixture]
     public class DocumentationGeneratorTests : ASCompletionTests
     {
+        protected static string ReadAllTextAS3(string fileName) => TestFile.ReadAllText(GetFullPathAS3(fileName));
+
+        protected static string GetFullPathAS3(string fileName) => $"{nameof(ASCompletion)}.Test_Files.generated.as3.documentation.{fileName}.as";
+
         public class ContextualGeneratorTests : DocumentationGeneratorTests
         {
             [TestFixtureSetUp]
@@ -74,20 +76,6 @@ namespace ASCompletion.Generators
                 else Assert.IsNull(item);
                 return sci.Text;
             }
-        }
-
-        protected static string ReadAllTextAS3(string fileName) => TestFile.ReadAllText(GetFullPathAS3(fileName));
-
-        protected static string GetFullPathAS3(string fileName) => $"{nameof(ASCompletion)}.Test_Files.generated.as3.documentation.{fileName}.as";
-
-        protected new static void SetSrc(ScintillaControl sci, string sourceText)
-        {
-            sci.Text = sourceText;
-            SnippetHelper.PostProcessSnippets(sci, 0);
-            var currentModel = ASContext.Context.CurrentModel;
-            new ASFileParser().ParseSrc(currentModel, sci.Text);
-            var line = sci.CurrentLine;
-            ASContext.Context.CurrentClass.Returns(currentModel.Classes.FirstOrDefault(line));
         }
     }
 }

--- a/Tests/External/Plugins/ASCompletion.Tests/Model/ASFileParserTests.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/Model/ASFileParserTests.cs
@@ -74,7 +74,7 @@ namespace ASCompletion.Model
                 var context = new AS3Context.Context(new AS3Context.AS3Settings());
                 Context.ASContext.GlobalInit(plugin);
                 Context.ASContext.Context = context;
-                var model = context.GetCodeModel(ReadAllText("CompletionErrorTest"));
+                var model = context.GetCodeModel(ReadAllText("CompletionErrorTest"), true);
 
                 Assert.AreEqual(2, model.Members.Count); // First member = function itself
 
@@ -941,7 +941,7 @@ namespace ASCompletion.Model
                 var context = new HaXeContext.Context(new HaXeContext.HaXeSettings());
                 Context.ASContext.GlobalInit(plugin);
                 Context.ASContext.Context = context;
-                var model = context.GetCodeModel(ReadAllText("RegExTest"));
+                var model = context.GetCodeModel(ReadAllText("RegExTest"), true);
 
                 Assert.AreEqual(4, model.Members.Count); // First member = function itself
 
@@ -1094,7 +1094,7 @@ namespace ASCompletion.Model
                 var context = new HaXeContext.Context(new HaXeContext.HaXeSettings());
                 Context.ASContext.GlobalInit(plugin);
                 Context.ASContext.Context = context;
-                var model = context.GetCodeModel(ReadAllText("FunctionTypesTest"));
+                var model = context.GetCodeModel(ReadAllText("FunctionTypesTest"), true);
 
                 Assert.AreEqual(3, model.Members.Count);
 
@@ -1251,7 +1251,7 @@ namespace ASCompletion.Model
                 var context = new HaXeContext.Context(new HaXeContext.HaXeSettings());
                 Context.ASContext.GlobalInit(plugin);
                 Context.ASContext.Context = context;
-                var model = context.GetCodeModel(ReadAllText("FunctionTypesWithSubTypesTest"));
+                var model = context.GetCodeModel(ReadAllText("FunctionTypesWithSubTypesTest"), true);
 
                 Assert.AreEqual(5, model.Members.Count);
 
@@ -1308,7 +1308,7 @@ namespace ASCompletion.Model
                 var context = new HaXeContext.Context(new HaXeContext.HaXeSettings());
                 Context.ASContext.GlobalInit(plugin);
                 Context.ASContext.Context = context;
-                var model = context.GetCodeModel(ReadAllText("MultipleVarsAtOnceTest"));
+                var model = context.GetCodeModel(ReadAllText("MultipleVarsAtOnceTest"), true);
 
                 Assert.AreEqual(7, model.Members.Count);
 
@@ -1741,7 +1741,7 @@ namespace ASCompletion.Model
                 var context = new HaXeContext.Context(new HaXeContext.HaXeSettings());
                 Context.ASContext.GlobalInit(plugin);
                 Context.ASContext.Context = context;
-                var model = context.GetCodeModel(ReadAllText("NotGenericTest"));
+                var model = context.GetCodeModel(ReadAllText("NotGenericTest"), true);
 
                 Assert.AreEqual(3, model.Members.Count); // First member = function itself
 

--- a/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
@@ -53,7 +53,7 @@ namespace ASCompletion.TestUtils
             mock.GetCodeModel(null, null, Arg.Any<bool>()).ReturnsForAnyArgs(x =>
             {
                 var src = x[1] as string;
-                return string.IsNullOrEmpty(src) ? null : context.GetCodeModel(x.ArgAt<FileModel>(0), src, x.ArgAt<bool>(1));
+                return string.IsNullOrEmpty(src) ? null : context.GetCodeModel(x.ArgAt<FileModel>(0), src, x.ArgAt<bool>(2));
             });
             mock.IsImported(null, Arg.Any<int>()).ReturnsForAnyArgs(it =>
             {

--- a/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
@@ -45,10 +45,15 @@ namespace ASCompletion.TestUtils
                 var src = x[0] as string;
                 return string.IsNullOrEmpty(src) ? null : context.GetCodeModel(src);
             });
-            mock.GetCodeModel(null, Arg.Any<bool>()).ReturnsForAnyArgs(x =>
+            mock.GetCodeModel(Arg.Any<string>(), Arg.Any<bool>()).ReturnsForAnyArgs(x =>
             {
                 var src = x[0] as string;
                 return string.IsNullOrEmpty(src) ? null : context.GetCodeModel(src, x.ArgAt<bool>(1));
+            });
+            mock.GetCodeModel(Arg.Any<FileModel>(), Arg.Any<string>()).ReturnsForAnyArgs(x =>
+            {
+                var src = x[1] as string;
+                return string.IsNullOrEmpty(src) ? null : context.GetCodeModel(x.ArgAt<FileModel>(0), src);
             });
             mock.GetCodeModel(null, null, Arg.Any<bool>()).ReturnsForAnyArgs(x =>
             {

--- a/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
@@ -104,7 +104,7 @@ namespace ASCompletion.TestUtils
                     {
                         foreach (var fileName in Directory.GetFiles(path, searchPattern, SearchOption.AllDirectories))
                         {
-                            it.AddFile(ASFileParser.ParseFile(new FileModel(fileName) {Context = context, Version = 3}));
+                            it.AddFile(context.GetFileModel(fileName));
                         }
                     }
                     context.RefreshContextCache(path);

--- a/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
@@ -45,6 +45,16 @@ namespace ASCompletion.TestUtils
                 var src = x[0] as string;
                 return string.IsNullOrEmpty(src) ? null : context.GetCodeModel(src);
             });
+            mock.GetCodeModel(null, Arg.Any<bool>()).ReturnsForAnyArgs(x =>
+            {
+                var src = x[0] as string;
+                return string.IsNullOrEmpty(src) ? null : context.GetCodeModel(src, x.ArgAt<bool>(1));
+            });
+            mock.GetCodeModel(null, null, Arg.Any<bool>()).ReturnsForAnyArgs(x =>
+            {
+                var src = x[1] as string;
+                return string.IsNullOrEmpty(src) ? null : context.GetCodeModel(x.ArgAt<FileModel>(0), src, x.ArgAt<bool>(1));
+            });
             mock.IsImported(null, Arg.Any<int>()).ReturnsForAnyArgs(it =>
             {
                 var member = it.ArgAt<MemberModel>(0) ?? ClassModel.VoidClass;
@@ -55,8 +65,7 @@ namespace ASCompletion.TestUtils
             mock.ResolveDotContext(null, null, false).ReturnsForAnyArgs(it =>
             {
                 var expr = it.ArgAt<ASExpr>(1);
-                if (expr == null) return null;
-                return context.ResolveDotContext(it.ArgAt<ScintillaControl>(0), expr, it.ArgAt<bool>(2));
+                return expr == null ? null : context.ResolveDotContext(it.ArgAt<ScintillaControl>(0), expr, it.ArgAt<bool>(2));
             });
             mock.IsFileValid.Returns(context.IsFileValid);
             mock.GetDefaultValue(null).ReturnsForAnyArgs(it => context.GetDefaultValue(it.ArgAt<string>(0)));

--- a/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
@@ -55,6 +55,11 @@ namespace ASCompletion.TestUtils
                 var src = x[1] as string;
                 return string.IsNullOrEmpty(src) ? null : context.GetCodeModel(x.ArgAt<FileModel>(0), src, x.ArgAt<bool>(2));
             });
+            mock.GetFileModel(null).ReturnsForAnyArgs(it =>
+            {
+                var fileName = it[0] as string;
+                return fileName == null ? null : context.GetFileModel(fileName);
+            });
             mock.IsImported(null, Arg.Any<int>()).ReturnsForAnyArgs(it =>
             {
                 var member = it.ArgAt<MemberModel>(0) ?? ClassModel.VoidClass;

--- a/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
@@ -128,7 +128,7 @@ namespace ASCompletion.TestUtils
                 {
                     foreach (var fileName in Directory.GetFiles(path, searchPattern, SearchOption.AllDirectories))
                     {
-                        it.AddFile(ASFileParser.ParseFile(new FileModel(fileName) {Context = context, haXe = true, Version = 4}));
+                        it.AddFile(context.GetFileModel(fileName));
                     }
                 }
                 context.RefreshContextCache(path);

--- a/Tests/External/Plugins/HaxeContext.Tests/Generators/DocumentationGeneratorTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/Generators/DocumentationGeneratorTests.cs
@@ -3,13 +3,11 @@ using System.IO;
 using ASCompletion;
 using ASCompletion.Context;
 using ASCompletion.Generators;
-using ASCompletion.Model;
 using ASCompletion.TestUtils;
 using HaXeContext.TestUtils;
 using NSubstitute;
 using NUnit.Framework;
 using PluginCore;
-using PluginCore.Helpers;
 using ScintillaNet;
 
 namespace HaXeContext.Generators
@@ -18,6 +16,10 @@ namespace HaXeContext.Generators
 
     public class DocumentationGeneratorTests : ASCompletionTests
     {
+        protected static string ReadAllText(string fileName) => TestFile.ReadAllText(GetFullPath(fileName));
+
+        protected static string GetFullPath(string fileName) => $"{nameof(HaXeContext)}.Test_Files.generators.documentation.{fileName}.hx";
+
         [TestFixtureSetUp]
         public void DocumentationGeneratorSetUp() => ASContext.Context.SetHaxeFeatures();
 
@@ -122,20 +124,6 @@ namespace HaXeContext.Generators
                 [Test, TestCaseSource(nameof(TestCases))]
                 public string Haxe(string fileName, DocumentationGeneratorJobType job) => Impl(sci, fileName, job, false, true);
             }
-        }
-
-        protected static string ReadAllText(string fileName) => TestFile.ReadAllText(GetFullPath(fileName));
-
-        protected static string GetFullPath(string fileName) => $"{nameof(HaXeContext)}.Test_Files.generators.documentation.{fileName}.hx";
-
-        protected new static void SetSrc(ScintillaControl sci, string sourceText)
-        {
-            sci.Text = sourceText;
-            SnippetHelper.PostProcessSnippets(sci, 0);
-            var currentModel = ASContext.Context.CurrentModel;
-            new ASFileParser().ParseSrc(currentModel, sci.Text);
-            var line = sci.CurrentLine;
-            ASContext.Context.CurrentClass.Returns(currentModel.Classes.FirstOrDefault(line));
         }
     }
 }


### PR DESCRIPTION
Now you can use:
----------------------------------------------------------------------------------------
```csharp
var fileModel = ASContext.Context.GetCodeModel(text);
```
instead of
```csharp
var fileModel = new ASFileParser().ParseSrc(new FileModel {Context = ASContext.Context, haXe = true}, text);
```
----------------------------------------------------------------------------------------
```csharp
var fileModel = ASContext.Context.GetCodeModel(fileModel, text);
```
instead of
```csharp
var fileModel = new ASFileParser().ParseSrc(fileModel, text);
```
----------------------------------------------------------------------------------------
```csharp
var fileModel = ASContext.Context.GetFileModel(fileName);
```
instead of
```csharp
var fileModel = ASFileParser.ParseFile(ASContext.Context.CreateFileModel(fileName));
```