### PR TITLE
Minor

### DIFF
--- a/External/Plugins/ResultsPanel/ResultsPanel.csproj
+++ b/External/Plugins/ResultsPanel/ResultsPanel.csproj
@@ -110,6 +110,7 @@
     <ProjectReference Include="..\..\..\PluginCore\PluginCore.csproj">
       <Project>{61885f70-b4dc-4b44-852d-5d6d03f2a734}</Project>
       <Name>PluginCore</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -4147,6 +4147,8 @@ namespace FlashDevelop
         /// </summary>
         public Boolean CallCommand(String command, String args)
         {
+            if (this.IsDisposed) return false;
+
             try
             {
                 var method = this.GetType().GetMethod(command);


### PR DESCRIPTION
Do not copy PluginCore together with ResultsPanel.
On edge cases it's possible some plugin call a command after the MainForm is disposed but not fully freed from memory. This is not a big problem, but it's annoying to get an alert when closing the application and anyway it doesn't hurt.