### PR TITLE
Fix strange race condition with PathModel.

### DIFF
--- a/External/Plugins/AS2Context/Context.cs
+++ b/External/Plugins/AS2Context/Context.cs
@@ -771,9 +771,9 @@ namespace AS2Context
             {
                 string path = Path.Combine(aPath.Path, fileName);
                 // cached file
-                if (aPath.HasFile(path))
+                FileModel nFile;
+                if (aPath.TryGetFile(path, out nFile))
                 {
-                    FileModel nFile = aPath.GetFile(path);
                     if (nFile.Context != this)
                     {
                         // not associated with this context -> refresh
@@ -785,7 +785,7 @@ namespace AS2Context
                 // non-cached existing file
                 else if (File.Exists(path))
                 {
-                    FileModel nFile = GetFileModel(path);
+                    nFile = GetFileModel(path);
                     if (nFile != null)
                     {
                         aPath.AddFile(nFile);

--- a/External/Plugins/AS3Context/PluginMain.cs
+++ b/External/Plugins/AS3Context/PluginMain.cs
@@ -304,24 +304,22 @@ namespace AS3Context
             AbcConverter.Convert(parser, path, contextInstance);
 
             string fileName = Path.Combine(container, virtualPath.Substring(p + 2).Replace('.', Path.DirectorySeparatorChar));
-            if (path.HasFile(fileName))
+            FileModel model;
+            if (path.TryGetFile(fileName, out model))
             {
-                FileModel model = path.GetFile(fileName);
                 ASComplete.OpenVirtualFile(model);
                 return true;
             }
             int split = fileName.LastIndexOf(Path.DirectorySeparatorChar) + 1;
             fileName = fileName.Substring(0, split) + "package.as";
-            if (path.HasFile(fileName))
+            if (path.TryGetFile(fileName, out model))
             {
-                FileModel model = path.GetFile(fileName);
                 ASComplete.OpenVirtualFile(model);
                 return true;
             }
             fileName = fileName.Substring(0, split) + "toplevel.as";
-            if (path.HasFile(fileName))
+            if (path.TryGetFile(fileName, out model))
             {
-                FileModel model = path.GetFile(fileName);
                 ASComplete.OpenVirtualFile(model);
                 return true;
             }

--- a/External/Plugins/ASCompletion/Context/ASContext.cs
+++ b/External/Plugins/ASCompletion/Context/ASContext.cs
@@ -833,9 +833,8 @@ namespace ASCompletion.Context
                 // check if in cache
                 foreach (PathModel aPath in classPath)
                 {
-                    if (aPath.HasFile(fileName))
+                    if (aPath.TryGetFile(fileName, out nFile))
                     {
-                        nFile = aPath.GetFile(fileName);
                         nFile.Check();
                         return nFile;
                     }

--- a/External/Plugins/ASCompletion/CustomControls/ModelsExplorer.cs
+++ b/External/Plugins/ASCompletion/CustomControls/ModelsExplorer.cs
@@ -370,9 +370,8 @@ namespace ASCompletion
                 return null;
             FileModel model = null;
             foreach (PathModel aPath in context.Classpath)
-                if (aPath.HasFile(filename))
+                if (aPath.TryGetFile(filename, out model))
                 {
-                    model = aPath.GetFile(filename);
                     break;
                 }
             if (model != null)

--- a/External/Plugins/ASCompletion/Model/PathExplorer.cs
+++ b/External/Plugins/ASCompletion/Model/PathExplorer.cs
@@ -326,9 +326,9 @@ namespace ASCompletion.Model
                 filename = foundFiles[i];
                 if (!File.Exists(filename))
                     continue;
-                if (pathModel.HasFile(filename))
+                FileModel cachedModel;
+                if (pathModel.TryGetFile(filename, out cachedModel))
                 {
-                    FileModel cachedModel = pathModel.GetFile(filename);
                     if (cachedModel.OutOfDate)
                     {
                         cachedModel.Check();
@@ -344,7 +344,6 @@ namespace ASCompletion.Model
                 // store model
                 if (aFile.Context.IsModelValid(aFile, pathModel))
                     pathModel.AddFile(aFile);
-                aFile = null;
                 cpt++;
                 // update status
                 if (stopExploration) return writeCache;

--- a/External/Plugins/ASCompletion/Model/PathModel.cs
+++ b/External/Plugins/ASCompletion/Model/PathModel.cs
@@ -41,14 +41,17 @@ namespace ASCompletion.Model
         /// </summary>
         static public void Compact()
         {
-            Dictionary<string, PathModel> clean = new Dictionary<string, PathModel>();
-            foreach (string key in pathes.Keys)
+            lock (pathes)
             {
-                PathModel model = pathes[key];
-                if (model.InUse) clean.Add(key, model);
-                else model.Cleanup();
+                Dictionary<string, PathModel> clean = new Dictionary<string, PathModel>();
+                foreach (string key in pathes.Keys)
+                {
+                    PathModel model = pathes[key];
+                    if (model.InUse) clean.Add(key, model);
+                    else model.Cleanup();
+                }
+                pathes = clean;
             }
-            pathes = clean;
         }
 
         /// <summary>

--- a/External/Plugins/ASCompletion/Model/PathModel.cs
+++ b/External/Plugins/ASCompletion/Model/PathModel.cs
@@ -41,19 +41,14 @@ namespace ASCompletion.Model
         /// </summary>
         static public void Compact()
         {
-            lock (pathes)
+            Dictionary<string, PathModel> clean = new Dictionary<string, PathModel>();
+            foreach (string key in pathes.Keys)
             {
-                //TimeSpan keep = TimeSpan.FromMinutes(5);
-                Dictionary<string, PathModel> clean = new Dictionary<string, PathModel>();
-                foreach (string key in pathes.Keys)
-                {
-                    PathModel model = pathes[key];
-                    //TimeSpan span = DateTime.Now.Subtract(model.LastAccess);
-                    if (model.InUse/* || span < keep*/) clean.Add(key, model);
-                    else model.Cleanup();
-                }
-                pathes = clean;
+                PathModel model = pathes[key];
+                if (model.InUse) clean.Add(key, model);
+                else model.Cleanup();
             }
+            pathes = clean;
         }
 
         /// <summary>
@@ -76,7 +71,6 @@ namespace ASCompletion.Model
                 {
                     pathes[modelName] = aPath = new PathModel(path, context);
                 }
-                else aPath.Touch();
             }
             else pathes[modelName] = aPath = new PathModel(path, context);
             return aPath;
@@ -85,7 +79,6 @@ namespace ASCompletion.Model
         public volatile bool Updating;
         public bool WasExplored;
         public bool IsTemporaryPath;
-        public DateTime LastAccess;
         public string Path;
         public IASContext Owner;
         public bool IsValid;
@@ -134,7 +127,6 @@ namespace ASCompletion.Model
             Path = path.TrimEnd(new char[] { '\\', '/' });
 
             files = new Dictionary<string, FileModel>();
-            LastAccess = DateTime.Now;
 
             if (Owner != null)
             {
@@ -525,6 +517,20 @@ namespace ASCompletion.Model
             }
         }
 
+        public bool TryGetFile(string fileName, out FileModel value)
+        {
+            if (!IsValid)
+            {
+                value = null;
+                return false;
+            }
+
+            lock (lockObject)
+            {
+                return files.TryGetValue(fileName.ToUpper(), out value);
+            }
+        }
+
         public FileModel GetFile(string fileName)
         {
             if (!IsValid)
@@ -536,7 +542,6 @@ namespace ASCompletion.Model
             }
             lock (lockObject)
             {
-                Touch();
                 return files[fileName.ToUpper()];
             }
         }
@@ -556,7 +561,6 @@ namespace ASCompletion.Model
             if (!IsValid) return;
             lock (lockObject)
             {
-                Touch();
                 files.Clear();
                 foreach (FileModel model in newFiles.Values)
                     files[model.FileName.ToUpper()] = model;
@@ -567,7 +571,6 @@ namespace ASCompletion.Model
         {
             lock (lockObject)
             {
-                Touch();
                 foreach (FileModel model in files.Values)
                     if (!callback(model)) break;
             }
@@ -582,11 +585,6 @@ namespace ASCompletion.Model
                 OnFileRemove?.Invoke(files[fn]);
                 files.Remove(fn);
             }
-        }
-
-        public void Touch()
-        {
-            LastAccess = DateTime.Now;
         }
 
         public void Cleanup()

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -865,23 +865,20 @@ namespace HaXeContext
                 {
                     var path = aPath.Path + dirSeparator + fileName;
 
-                    FileModel file = null;
+                    FileModel file;
                     // cached file
-                    if (aPath.HasFile(path))
+                    if (aPath.TryGetFile(path, out file))
                     {
-                        file = aPath.GetFile(path);
                         if (file.Context != this)
                         {
                             // not associated with this context -> refresh
                             file.OutOfDate = true;
                             file.Context = this;
                         }
-                    }
-                    if (file != null)
-                    {
+
                         // add all public classes of Haxe modules
                         foreach (ClassModel c in file.Classes)
-                            if (c.IndexType == null && c.Access == Visibility.Public) 
+                            if (c.IndexType == null && c.Access == Visibility.Public)
                                 imports.Add(c);
                         matched = true;
                     }

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -1239,8 +1239,8 @@ namespace HaXeContext
                 {
                     if (!it.IsValid || it.Updating || it.FilesCount == 0) continue;
                     var path = Path.Combine(it.Path, packagePath, "import.hx");
-                    if (!it.HasFile(path)) continue;
-                    var model = it.GetFile(path);
+                    FileModel model;
+                    if (!it.TryGetFile(path, out model)) continue;
                     result.Add(model.Imports);
                     break;
                 }

--- a/External/Plugins/HaXeContext/PluginMain.cs
+++ b/External/Plugins/HaXeContext/PluginMain.cs
@@ -335,8 +335,8 @@ namespace HaXeContext
                 parser.Run();
                 AbcConverter.Convert(parser, path, ctx);
                 var fileName = Path.Combine(container, virtualPath.Substring(p + 2).Replace('.', Path.DirectorySeparatorChar));
-                if (!path.HasFile(fileName)) return false;
-                var model = path.GetFile(fileName);
+                FileModel model;
+                if (!path.TryGetFile(fileName, out model)) return false;
                 ASComplete.OpenVirtualFile(model);
                 return true;
             }


### PR DESCRIPTION
I ran into some strange crash when starting FlashDevelop: `PathModel.HasFile` and `PathModel.GetFile` are 2 independent functions locking over the collection of files, so it's perfectly possible that between both calls a thread modifies the collection and causes unhandled exceptions. This was a really bizarre crash, and the application state at the moment of the crash made it unable for me to come up with the reason behind.

@elsassph since this is mostly your code it would be nice if you can validate and merge.