### PR TITLE
#2103 add support for lix and haxeshim

### DIFF
--- a/External/Plugins/HaXeContext/Completion/CompilerCompletionHandler.cs
+++ b/External/Plugins/HaXeContext/Completion/CompilerCompletionHandler.cs
@@ -11,7 +11,7 @@ namespace HaXeContext
 
         public CompilerCompletionHandler(ProcessStartInfo haxeProcessStartInfo)
         {
-            this.haxeProcessStartInfo = new ThreadLocal<ProcessStartInfo>(haxeProcessStartInfo.Clone);
+            this.haxeProcessStartInfo = haxeProcessStartInfo != null ? new ThreadLocal<ProcessStartInfo>(haxeProcessStartInfo.Clone) : null;
             Environment.SetEnvironmentVariable("HAXE_SERVER_PORT", "0");
         }
 

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -171,7 +171,7 @@ namespace HaXeContext
         {
             try
             {
-                return GetCurrentSDK().IsHaxeShim ? LookupLixLibrary(lib) : LookupHaxeLibLibrary(lib);
+                return (GetCurrentSDK()?.IsHaxeShim ?? false) ? LookupLixLibrary(lib) : LookupHaxeLibLibrary(lib);
             }
             catch (Exception)
             {
@@ -432,7 +432,7 @@ namespace HaXeContext
                 }
 
                 InstalledSDK installedSDK = GetCurrentSDK();
-                string haxeCP = installedSDK.IsHaxeShim ? installedSDK.ClassPath : Path.Combine(hxPath, "std");
+                string haxeCP = (installedSDK != null && installedSDK.IsHaxeShim) ? installedSDK.ClassPath : Path.Combine(hxPath, "std");
                 if (Directory.Exists(haxeCP))
                 {
                     if (Directory.Exists(Path.Combine(haxeCP, "flash9")))
@@ -676,7 +676,7 @@ namespace HaXeContext
         #endregion
 
         #region SDK
-        public InstalledSDK GetCurrentSDK()
+        private InstalledSDK GetCurrentSDK()
         {
             return hxsettings.InstalledSDKs?.FirstOrDefault(sdk => sdk.Path == currentSDK);
         }
@@ -2075,7 +2075,7 @@ namespace HaXeContext
 
         internal void InstallLibrary(Dictionary<string, string> nameToVersion)
         {
-            if (GetCurrentSDK().IsHaxeShim) InstallLixLibrary(nameToVersion);
+            if (GetCurrentSDK()?.IsHaxeShim ?? false) InstallLixLibrary(nameToVersion);
             else InstallHaxeLibLibrary(nameToVersion);
         }
 

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -181,6 +181,7 @@ namespace HaXeContext
                 {
                     if (hxPath != currentEnv) SetHaxeEnvironment(hxPath);
                     haxelib = Path.Combine(hxPath, haxelib);
+                    if (File.Exists(haxelib + ".exe")) haxelib += ".exe";
                 }
                 
                 ProcessStartInfo pi = new ProcessStartInfo();

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -229,12 +229,17 @@ namespace HaXeContext
         private List<string> LookupLixLibrary(string lib)
         {
             var haxePath = PathHelper.ResolvePath(GetCompilerPath());
-            if (!Directory.Exists(haxePath) && !File.Exists(haxePath))
+            if (Directory.Exists(haxePath))
+            {
+                string path = haxePath;
+                haxePath = Path.Combine(path, "haxe.exe");
+                if (!File.Exists(haxePath)) haxePath = Path.Combine(path, PlatformHelper.IsRunningOnWindows() ? "haxe.cmd" : "haxe");
+            }
+            if (!File.Exists(haxePath))
             {
                 ErrorManager.ShowInfo(TextHelper.GetString("Info.InvalidHaXePath"));
                 return null;
             }
-            if (Directory.Exists(haxePath)) haxePath = Path.Combine(haxePath, "haxe.exe");
 
             string projectDir = PluginBase.CurrentProject != null ? Path.GetDirectoryName(PluginBase.CurrentProject.ProjectPath) : "";
             Process p = StartHiddenProcess(haxePath, "--run resolve-args -lib " + lib, projectDir);
@@ -1482,6 +1487,8 @@ namespace HaXeContext
             // compiler path
             var hxPath = currentSDK ?? ""; 
             var process = Path.Combine(hxPath, "haxe.exe");
+            if (!File.Exists(process) && (GetCurrentSDK()?.IsHaxeShim ?? false))
+                process = Path.Combine(hxPath, PlatformHelper.IsRunningOnWindows() ? "haxe.cmd" : "haxe");
             if (!File.Exists(process))
                 return null;
 

--- a/External/Plugins/HaXeContext/PluginMain.cs
+++ b/External/Plugins/HaXeContext/PluginMain.cs
@@ -403,6 +403,7 @@ namespace HaXeContext
             bool result = false;
 
             string haxePath = Path.Combine(path, "haxe.exe");
+            if (!File.Exists(haxePath)) haxePath = Path.Combine(path, PlatformHelper.IsRunningOnWindows() ? "haxe.cmd" : "haxe");
             if (File.Exists(haxePath))
             {
                 Process p = StartHiddenProcess(haxePath, "--run show-version", projectPath);

--- a/External/Plugins/HaXeContext/PluginMain.cs
+++ b/External/Plugins/HaXeContext/PluginMain.cs
@@ -215,6 +215,8 @@ namespace HaXeContext
                         }
                     }
                     var text = TextHelper.GetString("Info.MissingLib");
+                    // TODO: Show information about which libraries are missing in a single dialog?
+                    // TODO: Prevent showing multiple dialogs about the same library.
                     var result = MessageBox.Show(PluginBase.MainForm, text, string.Empty, MessageBoxButtons.OKCancel);
                     if (result == DialogResult.OK) contextInstance.InstallLibrary(nameToVersion);
                     break;

--- a/External/Plugins/HaXeContext/PluginMain.cs
+++ b/External/Plugins/HaXeContext/PluginMain.cs
@@ -184,7 +184,8 @@ namespace HaXeContext
                     var patterns = new[]
                     {
                         "Library \\s*(?<name>[^ ]+)\\s*?(\\s*version (?<version>[^ ]+))?",
-                        "Could not find haxelib\\s*(?<name>\"[^ ]+\")?(\\s*version \"(?<version>[^ ]+)\")?"//openfl project
+                        "Could not find haxelib\\s*(?<name>\"[^ ]+\")?(\\s*version \"(?<version>[^ ]+)\")?", // openfl project
+                        "Cannot resolve `-lib\\s*(?<name>[^ ]+)`" // lix library
                     };
                     var nameToVersion = new Dictionary<string, string>();
                     for (; logCount < count; logCount++)

--- a/External/Plugins/ProjectManager/Controls/TreeView/OtherNodes.cs
+++ b/External/Plugins/ProjectManager/Controls/TreeView/OtherNodes.cs
@@ -117,6 +117,7 @@ namespace ProjectManager.Controls.TreeView
             string[] parts = text.Split(sep);
             List<string> label = new List<string>();
             Regex reVersion = new Regex("^[0-9]+[.,-][0-9]+");
+            Regex reSHAHash = new Regex("^[0-9a-f]+$");
 
             if (parts.Length > 0)
             {
@@ -126,6 +127,7 @@ namespace ProjectManager.Controls.TreeView
                     if (part != "" && part != "." && part != ".." && Array.IndexOf(excludes, part.ToLower()) == -1)
                     {
                         if (Char.IsDigit(part[0]) && reVersion.IsMatch(part)) label.Add(part);
+                        else if (part.Length == 40 && reSHAHash.IsMatch(part)) label.Add(part);
                         else
                         {
                             label.Add(part);

--- a/External/Plugins/ProjectManager/Settings.cs
+++ b/External/Plugins/ProjectManager/Settings.cs
@@ -36,7 +36,7 @@ namespace ProjectManager
         string[] excludedFileTypes = new string[] { ".p", ".abc", ".bak", ".tmp" };
         string[] excludedDirectories = new string[] { ".svn", "_svn", ".cvs", "_cvs", "cvs", "_sgbak", ".git", ".hg", "node_modules" };
         string[] executableFileTypes = new string[] { ".exe", ".lnk", ".fla", ".flump", ".doc", ".pps", ".psd", ".png", ".jpg", ".gif", ".xls", ".docproj", ".ttf", ".otf", ".wav", ".mp3", ".ppt", ".pptx", ".docx", ".xlsx", ".ai", ".pdf", ".zip", ".rar" };
-        string[] filteredDirectoryNames = new string[] { "src", "source", "sources", "as", "as2", "as3", "actionscript", "flash", "classes", "trunk", "svn", "git", "hg", "..", "." };
+        string[] filteredDirectoryNames = new string[] { "src", "source", "sources", "as", "as2", "as3", "actionscript", "flash", "classes", "trunk", "svn", "git", "hg", "github", "gitlab", "haxelib", "library", "..", "." };
 
         HighlightType tabHighlightType = HighlightType.ExternalFiles;
 

--- a/PluginCore/PluginCore/DataClasses.cs
+++ b/PluginCore/PluginCore/DataClasses.cs
@@ -91,10 +91,6 @@ namespace PluginCore
     {
         static public readonly InstalledSDK INVALID_SDK = new InstalledSDK(null);
 
-        public const string HAXE_SHIM_NAME = "Haxe Shim";
-        public const string UNKNOWN_NAME = "Haxe ?";
-        public const string UNKNOWN_VERSION = "0.0.0";
-
         private String path;
         private String name;
         private String version;
@@ -150,7 +146,7 @@ namespace PluginCore
         [Browsable(false)]
         public bool IsHaxeShim
         {
-            get { return this.name == HAXE_SHIM_NAME; }
+            get { return this.classPath != null; }
         }
 
         [Browsable(false)]

--- a/PluginCore/PluginCore/DataClasses.cs
+++ b/PluginCore/PluginCore/DataClasses.cs
@@ -91,9 +91,14 @@ namespace PluginCore
     {
         static public readonly InstalledSDK INVALID_SDK = new InstalledSDK(null);
 
+        public const string HAXE_SHIM_NAME = "Haxe Shim";
+        public const string UNKNOWN_NAME = "Haxe ?";
+        public const string UNKNOWN_VERSION = "0.0.0";
+
         private String path;
         private String name;
         private String version;
+        private String classPath;
         private bool isValid;
 
         [field: NonSerialized]
@@ -140,6 +145,19 @@ namespace PluginCore
                 catch { return false; }
                 return true;
             }
+        }
+
+        [Browsable(false)]
+        public bool IsHaxeShim
+        {
+            get { return this.name == HAXE_SHIM_NAME; }
+        }
+
+        [Browsable(false)]
+        public string ClassPath
+        {
+            get { return this.classPath; }
+            set { this.classPath = value; }
         }
 
         [Browsable(false)]

--- a/PluginCore/PluginCore/Utilities/SemVer.cs
+++ b/PluginCore/PluginCore/Utilities/SemVer.cs
@@ -2,6 +2,7 @@
 {
     /// <summary>
     /// Represents a semantic version, see http://semver.org/
+    /// Follows Semantic Versioning 2.0.0
     /// </summary>
     public class SemVer
     {
@@ -17,9 +18,11 @@
 
         public SemVer(string version)
         {
-            // ignore the pre-release denotation if present
+            // ignore the pre-release and build metadata denotation if present
             int hyphenIndex = version.IndexOf('-');
             if (hyphenIndex >= 0) version = version.Substring(0, hyphenIndex);
+            int plusIndex = version.IndexOf('+');
+            if (plusIndex >= 0) version = version.Substring(0, plusIndex);
 
             string[] numbers = version.Split('.');
 


### PR DESCRIPTION
Closes #2103.

Testing is needed!

Summary of changes:
- Haxe SDK validation checks if `haxe.exe` is in fact haxeshim, if not, uses `haxe.exe -version` to determine the version, and finally falls back to the original code that extracts the version from `CHANGES.txt`.
When using a `haxeshim` SDK:
- Re-check the haxe version on every project create/open/close event. It would probably be nice to also do it when opening then closing project properties.
- Support lix-managed libraries (completion works)
- Support for installing missing libraries via lix

Potential improvements:
- Because library A might require library B which is missing, and library B is also specified as a dependency, multiple "missing library" dialogs might be shown for the same library. This is exacerbated by linting diagnostics helper which can also trigger the "missing library" dialog. It would be nice to improve the whole "missing library" feature in the future, e.g. avoiding multiple dialogs for the same library, showing which library is missing in the dialog. Personally I would prefer to see all the missing libraries in a single dialog, with a button to install them all at once. It especially makes sense when using `lix` since a single `lix download` command should get all the dependencies. It's rather pointless to install them one by one, at least in this case.
- ? Use cache with some form of smart invalidation for lix library class paths (currently it is disabled) ?
- Fix any discovered bugs