### PR TITLE
Update appman.xml

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -2626,7 +2626,7 @@ namespace ASCompletion.Completion
                 value = context.WordBefore + " " + value;
 
             var type = ctx.ResolveToken(value, inClass.InFile);
-            if (!type.IsVoid()) return new ASResult {Type = type, Context = context, InClass = type, InFile = type.InFile, Path = context.Value, IsStatic = true};
+            if (!type.IsVoid()) return new ASResult {Type = type, Context = context, InClass = type, InFile = type.InFile, Path = context.Value};
             if (expression.StartsWithOrdinal(features.dot))
             {
                 if (expression.StartsWithOrdinal(features.dot + "#")) expression = expression.Substring(1);

--- a/appman.xml
+++ b/appman.xml
@@ -48,8 +48,8 @@
 	<Entry>
 		<Id>flexairsdk</Id>
 		<Name>Flex SDK + AIR SDK</Name>
-		<Version>4.6.0+28.0.0</Version>
-		<Build>23201B+125</Build>
+		<Version>4.6.0+29.0.0</Version>
+		<Build>23201B+122</Build>
 		<Desc>Adobe Flex SDK merged with Adobe AIR SDK</Desc>
 		<Info>http://www.adobe.com/devnet/air.html</Info>
 		<Group>Compilers</Group>
@@ -58,15 +58,15 @@
 		</Bundles>
 		<Urls>
 			<Url>http://fpdownload.adobe.com/pub/flex/sdk/builds/flex4.6/flex_sdk_4.6.0.23201B.zip</Url>
-			<Url>http://airdownload.adobe.com/air/win/download/28.0/AdobeAIRSDK.zip</Url>
+			<Url>http://airdownload.adobe.com/air/win/download/29.0/AdobeAIRSDK.zip</Url>
 			<Url>http://www.flashdevelop.org/appman/frameworks_flexsdk_9-28.zip</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>ascsdk</Id>		
 		<Name>AIR SDK + ASC 2.0</Name>
-		<Version>28.0.0</Version>
-		<Build>125</Build>
+		<Version>29.0.0</Version>
+		<Build>122</Build>
 		<Desc>Adobe AIR SDK with ASC 2.0</Desc>
 		<Info>http://www.adobe.com/devnet/air.html</Info>
 		<Group>Compilers</Group>
@@ -74,14 +74,14 @@
 			<Bundle>AIR</Bundle>
 		</Bundles>
 		<Urls>
-			<Url>http://airdownload.adobe.com/air/win/download/28.0/AIRSDK_Compiler.zip</Url>
+			<Url>http://airdownload.adobe.com/air/win/download/29.0/AIRSDK_Compiler.zip</Url>
 			<Url>http://www.flashdevelop.org/appman/frameworks_flexsdk_9-28.zip</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>aflexsdk</Id>
 		<Name>Apache Flex SDK</Name>
-		<Version>3.2.0</Version>
+		<Version>3.3.1</Version>
 		<Build>1</Build>
 		<Desc>Apache Flex SDK and dependencies installer</Desc>
 		<Group>Compilers</Group>
@@ -91,7 +91,7 @@
 		<Type>Executable</Type>
 		<Info>http://flex.apache.org/</Info>
 		<Urls>
-			<Url>http://www.apache.org/dyn/closer.lua/flex/installer/3.2/binaries/apache-flex-sdk-installer-3.2.0-bin.exe</Url>
+			<Url>http://ftp.byfly.by/pub/apache.org/flex/installer/3.3.1/binaries/apache-flex-sdk-installer-3.3.1-bin.exe</Url>
 		</Urls>
 	</Entry>
 	<Entry>
@@ -109,8 +109,8 @@
 	<Entry>
 		<Id>airrt</Id>
 		<Name>Adobe AIR</Name>
-		<Version>28.0.0</Version>
-		<Build>127</Build>
+		<Version>29.0.0</Version>
+		<Build>122</Build>
 		<Desc>Adobe AIR for AIR applications installer</Desc>
 		<Group>Runtimes</Group>
 		<Bundles>
@@ -119,14 +119,14 @@
 		<Type>Executable</Type>
 		<Info>http://www.adobe.com/products/air.html</Info>
 		<Urls>
-			<Url>http://airdownload.adobe.com/air/win/download/28.0/AdobeAIRInstaller.exe</Url>
+			<Url>http://airdownload.adobe.com/air/win/download/29.0/AdobeAIRInstaller.exe</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>flashsa</Id>
 		<Name>Flash Player (SA)</Name>
-		<Version>28.0.0</Version>
-		<Build>126</Build>
+		<Version>29.0.0</Version>
+		<Build>140</Build>
 		<Desc>Standalone debug Flash Player</Desc>
 		<Group>Runtimes</Group>
 		<Bundles>
@@ -137,52 +137,52 @@
 		</Bundles>
 		<Info>http://www.adobe.com/support/flashplayer/downloads.html</Info>
 		<Urls>
-			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/28/flashplayer_28_sa_debug.exe</Url>
+			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/29/flashplayer_29_sa_debug.exe</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>flashie</Id>
 		<Name>Flash Player (AX)</Name>
-		<Version>28.0.0</Version>
-		<Build>126</Build>
+		<Version>29.0.0</Version>
+		<Build>140</Build>
 		<Desc>Debug Flash Player plugin for Internet Explorer - ActiveX</Desc>
 		<Group>Runtimes</Group>
 		<Type>Executable</Type>
 		<Info>http://www.adobe.com/support/flashplayer/downloads.html</Info>
 		<Urls>
-			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/28/flashplayer_28_ax_debug.exe</Url>
+			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/29/flashplayer_29_ax_debug.exe</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>flashnpapi</Id>
 		<Name>Flash Player (NPAPI)</Name>
-		<Version>28.0.0</Version>
-		<Build>126</Build>
+		<Version>29.0.0</Version>
+		<Build>140</Build>
 		<Desc>Debug Flash Player plugin for Firefox - NPAPI</Desc>
 		<Group>Runtimes</Group>
 		<Type>Executable</Type>
 		<Info>http://www.adobe.com/support/flashplayer/downloads.html</Info>
 		<Urls>
-			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/28/flashplayer_28_plugin_debug.exe</Url>
+			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/29/flashplayer_29_plugin_debug.exe</Url>
     </Urls>
 	</Entry>
 	<Entry>
 		<Id>flashppapi</Id>
 		<Name>Flash Player (PPAPI)</Name>
-		<Version>28.0.0</Version>
-		<Build>126</Build>
+		<Version>29.0.0</Version>
+		<Build>140</Build>
 		<Desc>Debug Flash Player plugin for Opera and Chromium based applications - PPAPI</Desc>
 		<Group>Runtimes</Group>
 		<Type>Executable</Type>
 		<Info>http://www.adobe.com/support/flashplayer/downloads.html</Info>
 		<Urls>
-			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/28/flashplayer_28_ppapi_debug.exe</Url>
+			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/29/flashplayer_29_ppapi_debug.exe</Url>
     </Urls>
 	</Entry>
 	<Entry>
 		<Id>torgit</Id>
 		<Name>TortoiseGit (x86)</Name>
-		<Version>2.5.0.0</Version>
+		<Version>2.6.0</Version>
 		<Build>1</Build>
 		<Desc>Git client 32-bit installer</Desc>
 		<Group>Source Control</Group>
@@ -192,13 +192,13 @@
 		<Type>Executable</Type>
 		<Info>https://tortoisegit.org/</Info>
 		<Urls>
-			<Url>https://download.tortoisegit.org/tgit/2.5.0.0/TortoiseGit-2.5.0.0-32bit.msi</Url>
+			<Url>https://download.tortoisegit.org/tgit/2.6.0.0/TortoiseGit-2.6.0.0-32bit.msi</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>torgit64</Id>
 		<Name>TortoiseGit (x64)</Name>
-		<Version>2.5.0.0</Version>
+		<Version>2.6.0</Version>
 		<Build>1</Build>
 		<Desc>Git client 64-bit installer</Desc>
 		<Group>Source Control</Group>
@@ -208,14 +208,14 @@
 		<Type>Executable</Type>
 		<Info>https://tortoisegit.org/</Info>
 		<Urls>
-			<Url>https://download.tortoisegit.org/tgit/2.5.0.0/TortoiseGit-2.5.0.0-64bit.msi</Url>
+			<Url>https://download.tortoisegit.org/tgit/2.6.0.0/TortoiseGit-2.6.0.0-64bit.msi</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>git4win</Id>
 		<Name>Git For Windows (x86)</Name>
-		<Version>2.15.1</Version>
-		<Build>2</Build>
+		<Version>2.17.0</Version>
+		<Build>1</Build>
 		<Desc>Git command line client 32-bit installer</Desc>
 		<Group>Source Control</Group>
 		<Bundles>
@@ -224,14 +224,14 @@
 		<Type>Executable</Type>
 		<Info>https://git-for-windows.github.io/</Info>
 		<Urls>
-			<Url>https://github.com/git-for-windows/git/releases/download/v2.16.1.windows.4/Git-2.16.1.4-32-bit.exe</Url>
+			<Url>https://github.com/git-for-windows/git/releases/download/v2.17.0.windows.1/Git-2.17.0-32-bit.exe</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>git4win64</Id>
 		<Name>Git For Windows (x64)</Name>
-		<Version>2.15.1</Version>
-		<Build>2</Build>
+		<Version>2.17.0</Version>
+		<Build>1</Build>
 		<Desc>Git command line client 64-bit installer</Desc>
 		<Group>Source Control</Group>
 		<Bundles>
@@ -240,14 +240,14 @@
 		<Type>Executable</Type>
 		<Info>https://git-for-windows.github.io/</Info>
 		<Urls>
-			<Url>https://github.com/git-for-windows/git/releases/download/v2.16.1.windows.4/Git-2.16.1.4-64-bit.exe</Url>
+			<Url>https://github.com/git-for-windows/git/releases/download/v2.17.0.windows.1/Git-2.17.0-64-bit.exe</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>torsvn</Id>
 		<Name>TortoiseSVN (x86)</Name>
-		<Version>1.9.7</Version>
-		<Build>27907</Build>
+		<Version>1.10.0</Version>
+		<Build>1</Build>
 		<Desc>Subversion client 32-bit installer</Desc>
 		<Group>Source Control</Group>
 		<Bundles>
@@ -256,14 +256,14 @@
 		<Type>Executable</Type>
 		<Info>http://tortoisesvn.net/</Info>
 		<Urls>
-      <Url>https://netcologne.dl.sourceforge.net/project/tortoisesvn/1.9.7/Application/TortoiseSVN-1.9.7.27907-win32-svn-1.9.7.msi</Url>
+      <Url>https://osdn.net/projects/tortoisesvn/storage/1.10.0/Application/TortoiseSVN-1.10.0.28176-win32-svn-1.10.0.msi</Url>
 		</Urls>
 	</Entry>
 	<Entry>
 		<Id>torsvn64</Id>
 		<Name>TortoiseSVN (x64)</Name>
-		<Version>1.9.7</Version>
-		<Build>27907</Build>
+		<Version>1.10.0</Version>
+		<Build>1</Build>
 		<Desc>Subversion client 64-bit installer</Desc>
 		<Group>Source Control</Group>
 		<Bundles>
@@ -272,7 +272,7 @@
 		<Type>Executable</Type>
 		<Info>http://tortoisesvn.net/</Info>
 		<Urls>
-			<Url>https://netcologne.dl.sourceforge.net/project/tortoisesvn/1.9.7/Application/TortoiseSVN-1.9.7.27907-x64-svn-1.9.7.msi</Url>
+			<Url>https://osdn.net/projects/tortoisesvn/storage/1.10.0/Application/TortoiseSVN-1.10.0.28176-x64-svn-1.10.0.msi</Url>
 		</Urls>
 	</Entry>
 	<Entry>

--- a/appman.xml
+++ b/appman.xml
@@ -164,7 +164,7 @@
 		<Info>http://www.adobe.com/support/flashplayer/downloads.html</Info>
 		<Urls>
 			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/29/flashplayer_29_plugin_debug.exe</Url>
-    </Urls>
+	</Urls>
 	</Entry>
 	<Entry>
 		<Id>flashppapi</Id>
@@ -177,7 +177,7 @@
 		<Info>http://www.adobe.com/support/flashplayer/downloads.html</Info>
 		<Urls>
 			<Url>https://fpdownload.macromedia.com/pub/flashplayer/updaters/29/flashplayer_29_ppapi_debug.exe</Url>
-    </Urls>
+	</Urls>
 	</Entry>
 	<Entry>
 		<Id>torgit</Id>
@@ -256,7 +256,7 @@
 		<Type>Executable</Type>
 		<Info>http://tortoisesvn.net/</Info>
 		<Urls>
-      <Url>https://osdn.net/projects/tortoisesvn/storage/1.10.0/Application/TortoiseSVN-1.10.0.28176-win32-svn-1.10.0.msi</Url>
+			<Url>https://osdn.net/projects/tortoisesvn/storage/1.10.0/Application/TortoiseSVN-1.10.0.28176-win32-svn-1.10.0.msi</Url>
 		</Urls>
 	</Entry>
 	<Entry>
@@ -464,7 +464,7 @@
 	</Entry>
 	<Entry>
 		<Id>quicknavigate</Id>
-    		<Name>QuickNavigate</Name>
+		<Name>QuickNavigate</Name>
 		<Version>3.0</Version>
 		<Build>89</Build>
 		<Checksum>b9bdc3f75c8743cba2668e39d5ef1d6</Checksum>


### PR DESCRIPTION
- Bump AIR SDK to 29.0.0.122
- Bump Apache Flex SDK Installer to 3.3.1
- Bump Adobe AIR to 29.0.0.122
- Bump Adobe Flash Player to 29.0.0.140
- Bump TortoiseGit to 2.6.0.1
- Bump Git for Windows to 2.17.0
- Bump TortoiseSVN to 1.10.0

@Meychi hi. Can you update http://www.flashdevelop.org/appman/frameworks_flexsdk_9-28.zip for v. 29?
https://www.adobe.com/support/flashplayer/debug_downloads.html