### PR TITLE
Fix a couple of crashes I experienced.

### DIFF
--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -1046,7 +1046,7 @@ namespace HaXeContext
                 {
                     if (import.Name == cname)
                     {
-                        if (import.Type.Length > import.Name.Length)
+                        if (import.Type != null && import.Type.Length > import.Name.Length)
                         {
                             var type = import.Type;
                             int temp = type.IndexOf('<');

--- a/FlashDevelop/Managers/FilePollManager.cs
+++ b/FlashDevelop/Managers/FilePollManager.cs
@@ -38,7 +38,7 @@ namespace FlashDevelop.Managers
         private static void CheckFileChange(ITabbedDocument document)
         {
             TabbedDocument casted = document as TabbedDocument;
-            if (casted.IsEditable && casted.CheckFileChange())
+            if (casted != null && casted.IsEditable && casted.CheckFileChange())
             {
                 if (Globals.Settings.AutoReloadModifiedFiles)
                 {


### PR DESCRIPTION
I've been working on a project with the binary build of HaxeDevelop from the website (which claims to be https://github.com/fdorg/flashdevelop/commit/436add6fc7), with no problems.

I tried the same project with latest FlashDevelop, and got a couple of crashes when compiling, seemingly due to things being null. Perhaps there's some deeper problem at work here? - I'm not sure. But I added in a couple of null checks, and that fixed my immediate problem, so here they are.

Thanks,

--Tom

P.S. one of the nulls seemed to be due to an import, with the problem import in question being this one, imported from its class with a wildcard (`import blah.blah.Maths.*`, that sort of thing):
```haxe
public static function lerp(a:Float, b:Float, t:Float) {
	return a + (b - a) * t;
}
```
Despite the `return`, this does have no return type specified - my mistake, which I'll fix - but I do declare that if the compiler accepts it, then FlashDevelop should accept it too.