### PR TITLE
Put the caret at the start of the found region before selecting it.

### DIFF
--- a/FlashDevelop/Utilities/FRDialogGenerics.cs
+++ b/FlashDevelop/Utilities/FRDialogGenerics.cs
@@ -54,6 +54,7 @@ namespace FlashDevelop.Utilities
             Int32 end = start + sci.MBSafeTextLength(match.Value); // wchar to byte text length
             Int32 line = sci.LineFromPosition(start);
             sci.EnsureVisibleEnforcePolicy(line);
+            sci.SetSel(start, start);
             sci.SetSel(start, end);
         }
 


### PR DESCRIPTION
Fix #2157.

Thanks,

--Tom