### PR TITLE
[Haxe][CodeComplete][SwitchCaseCompletion] Added code completion after `|` and `,` e.g. `case EnumValue1 |  <complete>`

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -4056,12 +4056,9 @@ namespace ASCompletion.Completion
                                 else if (")}]>".Contains(c)) groupCount++;
                                 position--;
                             }
-
                             word1 = GetWordLeft(sci, ref position);
                         }
-
-                        if (word1 == features.functionKey)
-                            return ComaExpression.FunctionDeclaration; // anonymous function
+                        if (word1 == features.functionKey) return ComaExpression.FunctionDeclaration; // anonymous function
                         var word2 = GetWordLeft(sci, ref position);
                         if (word2 == features.functionKey || word2 == features.setKey || word2 == features.getKey)
                             return ComaExpression.FunctionDeclaration; // function declaration
@@ -4093,10 +4090,8 @@ namespace ASCompletion.Completion
                                     return ComaExpression.VarDeclaration;
                                 }
                             }
-
                             return ComaExpression.AnonymousObjectParam;
                         }
-
                         if (c != ')' && c != '}' && !char.IsLetterOrDigit(c)) return ComaExpression.AnonymousObject;
                         break;
                     }
@@ -4113,7 +4108,7 @@ namespace ASCompletion.Completion
                             // Function optional argument
                             return coma;
                         }
-                        else if (coma == ComaExpression.VarDeclaration)
+                        if (coma == ComaExpression.VarDeclaration)
                         {
                             // Possible anonymous structure optional field. Check we are not in a ternary operator
                             position--;
@@ -4122,7 +4117,6 @@ namespace ASCompletion.Completion
                             if (c == ',' || c == '{') return coma;
                         }
                     }
-
                     return ComaExpression.AnonymousObject;
                 }
                 position--;

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -4102,10 +4102,7 @@ namespace ASCompletion.Completion
                         break;
                     }
                 }
-                else if (c == '}')
-                {
-                    braceCount++;
-                }
+                else if (c == '}') braceCount++;
                 else if (c == '?')
                 {
                     //TODO: Change to ASContext.Context.CurrentModel
@@ -4129,7 +4126,6 @@ namespace ASCompletion.Completion
 
                     return ComaExpression.AnonymousObject;
                 }
-
                 position--;
             }
             return ComaExpression.None;

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -1741,16 +1741,17 @@ namespace ASCompletion.Completion
         internal static int FindParameterIndex(ScintillaControl sci, ref int position)
         {
             var characterClass = ScintillaControl.Configuration.GetLanguage(sci.ConfigurationLanguage).characterclass.Characters;
-            var context = ASContext.Context;
+            var ctx = ASContext.Context;
             var parCount = 0;
             var braCount = 0;
             var comaCount = 0;
             var arrCount = 0;
             var genCount = 0;
             var hasChar = false;
-            while (position >= 0)
+            var endPosition = ctx.CurrentMember != null ? sci.LineEndPosition(ctx.CurrentMember.LineFrom) : 0;
+            while (position >= endPosition)
             {
-                if (!sci.PositionIsOnComment(position) && !sci.PositionIsInString(position) || context.CodeComplete.IsStringInterpolationStyle(sci, position))
+                if (!sci.PositionIsOnComment(position) && !sci.PositionIsInString(position) || ctx.CodeComplete.IsStringInterpolationStyle(sci, position))
                 {
                     var c = (char)sci.CharAt(position);
                     if (c <= ' ')

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -3867,7 +3867,8 @@ namespace ASCompletion.Completion
                     else if (c == ',')
                     {
                         expression.coma = DisambiguateComa(sci, position, minPos);
-                        expression.Separator = (expression.coma == ComaExpression.None) ? ";" : ",";
+                        expression.Separator = ",";
+                        expression.SeparatorPosition = position;
                         break;
                     }
                     else if (c == ':')
@@ -4018,18 +4019,14 @@ namespace ASCompletion.Completion
             while (position > minPos)
             {
                 var c = (char)sci.CharAt(position);
-                if (c == ';')
-                {
-                    return ComaExpression.None;
-                }
-                // var declaration
-                else if (c == ':')
+                if (c == ';') return ComaExpression.None;
+                if (c == ':')
                 {
                     position--;
                     string word = GetWordLeft(sci, ref position);
                     word = GetWordLeft(sci, ref position);
                     if (word == features.varKey) return ComaExpression.VarDeclaration;
-                    else continue;
+                    continue;
                 }
                 // Array values
                 else if (c == '[')
@@ -4060,9 +4057,12 @@ namespace ASCompletion.Completion
                                 else if (")}]>".Contains(c)) groupCount++;
                                 position--;
                             }
+
                             word1 = GetWordLeft(sci, ref position);
                         }
-                        if (word1 == features.functionKey) return ComaExpression.FunctionDeclaration; // anonymous function
+
+                        if (word1 == features.functionKey)
+                            return ComaExpression.FunctionDeclaration; // anonymous function
                         var word2 = GetWordLeft(sci, ref position);
                         if (word2 == features.functionKey || word2 == features.setKey || word2 == features.getKey)
                             return ComaExpression.FunctionDeclaration; // function declaration
@@ -4094,8 +4094,10 @@ namespace ASCompletion.Completion
                                     return ComaExpression.VarDeclaration;
                                 }
                             }
+
                             return ComaExpression.AnonymousObjectParam;
                         }
+
                         if (c != ')' && c != '}' && !char.IsLetterOrDigit(c)) return ComaExpression.AnonymousObject;
                         break;
                     }
@@ -4124,8 +4126,10 @@ namespace ASCompletion.Completion
                             if (c == ',' || c == '{') return coma;
                         }
                     }
+
                     return ComaExpression.AnonymousObject;
                 }
+
                 position--;
             }
             return ComaExpression.None;

--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -1912,10 +1912,10 @@ namespace ASCompletion.Completion
         /// <summary>
         /// Complete object member
         /// </summary>
-        /// <param name="Sci">Scintilla control</param>
+        /// <param name="sci">Scintilla control</param>
         /// <param name="autoHide">Don't keep the list open if the word does not match</param>
         /// <returns>Auto-completion has been handled</returns>
-        private static bool HandleDotCompletion(ScintillaControl Sci, bool autoHide)
+        private static bool HandleDotCompletion(ScintillaControl sci, bool autoHide)
         {
             //this method can exit at multiple points, so reset the current class now rather than later
             currentClassHash = null;
@@ -1924,8 +1924,8 @@ namespace ASCompletion.Completion
             if (autoHide && DeclarationSectionOnly()) return false;
 
             // get expression at cursor position
-            var position = Sci.CurrentPos;
-            var expr = GetExpression(Sci, position);
+            var position = sci.CurrentPos;
+            var expr = GetExpression(sci, position);
             if (expr.Value == null) return true;
             var ctx = ASContext.Context;
             var features = ctx.Features;
@@ -1946,14 +1946,13 @@ namespace ASCompletion.Completion
                         return false;
                     // new/extends/implements
                     if (features.HasTypePreKey(word))
-                        return HandleNewCompletion(Sci, expr.Value, autoHide, word);
+                        return HandleNewCompletion(sci, expr.Value, autoHide, word);
                     // import
                     if (features.hasImports && (word == features.importKey || word == features.importKeyAlt))
-                        return HandleImportCompletion(Sci, expr.Value, autoHide);
+                        return HandleImportCompletion(sci, expr.Value, autoHide);
                 }
                 // type
-                else if (features.hasEcmaTyping && expr.Separator == ":"
-                         && HandleColonCompletion(Sci, expr.Value, autoHide))
+                else if (features.hasEcmaTyping && expr.Separator == ":" && HandleColonCompletion(sci, expr.Value, autoHide))
                     return true;
 
                 // no completion
@@ -1964,9 +1963,9 @@ namespace ASCompletion.Completion
 
                 if (expr.coma == ComaExpression.AnonymousObjectParam)
                 {
-                    int cpos = Sci.CurrentPos - 1;
-                    int paramIndex = FindParameterIndex(Sci, ref cpos);
-                    if (calltipPos != cpos) ctx.CodeComplete.ResolveFunction(Sci, cpos, autoHide);
+                    int cpos = sci.CurrentPos - 1;
+                    int paramIndex = FindParameterIndex(sci, ref cpos);
+                    if (calltipPos != cpos) ctx.CodeComplete.ResolveFunction(sci, cpos, autoHide);
                     if (calltipMember == null) return false;
                     argumentType = ResolveParameterType(paramIndex, true);
                     if (argumentType.IsVoid()) return false;
@@ -1974,23 +1973,23 @@ namespace ASCompletion.Completion
 
                 // complete declaration
                 MemberModel cMember = ctx.CurrentMember;
-                int line = Sci.LineFromPosition(position);
+                int line = sci.LineFromPosition(position);
                 if (cMember == null && !ctx.CurrentClass.IsVoid())
                 {
                     if (!string.IsNullOrEmpty(expr.Value))
-                        return HandleDeclarationCompletion(Sci, expr.Value, autoHide);
+                        return HandleDeclarationCompletion(sci, expr.Value, autoHide);
                     if (ctx.CurrentModel.Version >= 2)
-                        return ASGenerator.HandleGeneratorCompletion(Sci, autoHide, features.overrideKey);
+                        return ASGenerator.HandleGeneratorCompletion(sci, autoHide, features.overrideKey);
                 }
                 else if (cMember != null && line == cMember.LineFrom)
                 {
-                    string text = Sci.GetLine(line);
+                    string text = sci.GetLine(line);
                     int p;
                     if ((cMember.Flags & FlagType.Constructor) != 0 && !string.IsNullOrEmpty(features.ConstructorKey))
                         p = text.IndexOfOrdinal(features.ConstructorKey);
                     else p = text.IndexOfOrdinal(cMember.Name);
-                    if (p < 0 || position < Sci.PositionFromLine(line) + p)
-                        return HandleDeclarationCompletion(Sci, expr.Value, autoHide);
+                    if (p < 0 || position < sci.PositionFromLine(line) + p)
+                        return HandleDeclarationCompletion(sci, expr.Value, autoHide);
                 }
             }
             else if (expr.Value.EndsWithOrdinal("..") || Regex.IsMatch(expr.Value, "^[0-9]+\\."))
@@ -1999,10 +1998,10 @@ namespace ASCompletion.Completion
             var tail = (dotIndex >= 0) ? expr.Value.Substring(dotIndex + features.dot.Length) : expr.Value;
             
             // custom completion
-            var items = ctx.ResolveDotContext(Sci, expr, autoHide);
+            var items = ctx.ResolveDotContext(sci, expr, autoHide);
             if (items != null)
             {
-                DotContextResolved(Sci, expr, items, autoHide);
+                DotContextResolved(sci, expr, items, autoHide);
                 return true;
             }
             
@@ -2043,7 +2042,7 @@ namespace ASCompletion.Completion
                 else tmpClass = cClass;
             }
             var mix = new MemberList();
-            ctx.ResolveDotContext(Sci, result, mix);
+            ctx.ResolveDotContext(sci, result, mix);
 
             //stores a reference to our current class. tmpClass gets overwritten later, so we need to store the current class separately
             var classScope = tmpClass;

--- a/External/Plugins/HaXeContext/Completion/CodeComplete.cs
+++ b/External/Plugins/HaXeContext/Completion/CodeComplete.cs
@@ -108,7 +108,11 @@ namespace HaXeContext.Completion
                 if (string.IsNullOrEmpty(wordLeft))
                 {
                     var c = (char) sci.CharAt(pos--);
-                    if (c == '=') return HandleAssignCompletion(sci, pos, autoHide);
+                    if (c == '=')
+                    {
+                        HandleAssignCompletion(sci, pos, autoHide);
+                        return false;
+                    }
                     // for example: case EnumValue | <complete> or case EnumValue, <complete>
                     if (c == '|' || c == ',')
                     {

--- a/External/Plugins/HaXeContext/Completion/CodeComplete.cs
+++ b/External/Plugins/HaXeContext/Completion/CodeComplete.cs
@@ -109,6 +109,18 @@ namespace HaXeContext.Completion
                 {
                     var c = (char) sci.CharAt(pos--);
                     if (c == '=') return HandleAssignCompletion(sci, pos, autoHide);
+                    // for example: case EnumValue | <complete> or case EnumValue, <complete>
+                    if (c == '|' || c == ',')
+                    {
+                        ASResult expr;
+                        while ((expr = GetExpressionType(sci, pos + 1, false, true)) != null && expr.Type != null && !expr.Type.IsVoid())
+                        {
+                            if (expr.Context.WordBefore == "case") return HandleSwitchCaseCompletion(sci, pos, autoHide);
+                            if (expr.Context.Separator is string separator && (separator == "|" || separator == ","))
+                                pos = expr.Context.PositionExpression;
+                            else break;
+                        }
+                    }
                 }
                 return false;
             }

--- a/External/Plugins/HaXeContext/Completion/CodeComplete.cs
+++ b/External/Plugins/HaXeContext/Completion/CodeComplete.cs
@@ -112,12 +112,11 @@ namespace HaXeContext.Completion
                     // for example: case EnumValue | <complete> or case EnumValue, <complete>
                     if (c == '|' || c == ',')
                     {
-                        ASResult expr;
-                        while ((expr = GetExpressionType(sci, pos + 1, false, true)) != null && expr.Type != null && !expr.Type.IsVoid())
+                        while (GetExpressionType(sci, pos + 1, false, true) is ASResult expr && expr.Type != null && !expr.Type.IsVoid())
                         {
                             if (expr.Context.WordBefore == "case") return HandleSwitchCaseCompletion(sci, pos, autoHide);
                             if (expr.Context.Separator is string separator && (separator == "|" || separator == ","))
-                                pos = expr.Context.PositionExpression;
+                                pos = expr.Context.SeparatorPosition - 1;
                             else break;
                         }
                     }

--- a/External/Plugins/HaXeContext/Model/FileParser.cs
+++ b/External/Plugins/HaXeContext/Model/FileParser.cs
@@ -1670,7 +1670,8 @@ namespace HaXeContext.Model
             // when not in a class, parse if/for/while/switch/try...catch blocks
             if (ScriptMode)
             {
-                if (token == "catch" || token == "for" || token == "case")
+                if (token == "case") curModifiers = 0;
+                else if (token == "catch" || token == "for")
                 {
                     curModifiers = 0;
                     foundKeyword = FlagType.Variable;

--- a/Tests/External/Plugins/HaxeContext.Tests/Completion/CodeCompleteTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/Completion/CodeCompleteTests.cs
@@ -250,6 +250,15 @@ namespace HaXeContext.Completion
                 yield return new TestCaseData("BeforeOnChar_issue589_11", ' ', false, false)
                     .SetName("case Node(1 , <complete>) Issue 589. Case 11")
                     .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
+                yield return new TestCaseData("BeforeOnChar_issue589_12", ' ', false, false)
+                    .SetName("case [_, <complete>] Issue 589. Case 12")
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
+                yield return new TestCaseData("BeforeOnChar_issue589_13", ' ', false, true)
+                    .SetName("case EnumValue0 | EnumValue1 | <complete> Issue 589. Case 13")
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
+                yield return new TestCaseData("BeforeOnChar_issue589_14", ' ', false, true)
+                    .SetName("case EnumValue0, EnumValue1, <complete> Issue 589. Case 14")
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
             }
         }
 

--- a/Tests/External/Plugins/HaxeContext.Tests/Completion/CodeCompleteTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/Completion/CodeCompleteTests.cs
@@ -238,6 +238,18 @@ namespace HaXeContext.Completion
                 yield return new TestCaseData("BeforeOnChar_issue589_7", ' ', false, true)
                     .SetName("case EnumValue0, <complete> Issue 589. Case 7")
                     .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
+                yield return new TestCaseData("BeforeOnChar_issue589_8", ' ', false, false)
+                    .SetName("trace(1 | <complete>) Issue 589. Case 8")
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
+                yield return new TestCaseData("BeforeOnChar_issue589_9", ' ', false, false)
+                    .SetName("trace(1 , <complete>) Issue 589. Case 9")
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
+                yield return new TestCaseData("BeforeOnChar_issue589_10", ' ', false, false)
+                    .SetName("case Node(1 | <complete>) Issue 589. Case 10")
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
+                yield return new TestCaseData("BeforeOnChar_issue589_11", ' ', false, false)
+                    .SetName("case Node(1 , <complete>) Issue 589. Case 11")
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
             }
         }
 

--- a/Tests/External/Plugins/HaxeContext.Tests/Completion/CodeCompleteTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/Completion/CodeCompleteTests.cs
@@ -218,19 +218,25 @@ namespace HaXeContext.Completion
             get
             {
                 yield return new TestCaseData("BeforeOnChar_issue589_1", ' ', false, true)
-                    .SetName("case | Issue 589. Case 1")
+                    .SetName("case <complete> Issue 589. Case 1")
                     .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
                 yield return new TestCaseData("BeforeOnChar_issue589_2", ' ', false, true)
-                    .SetName("case | Issue 589. Case 2")
+                    .SetName("case <complete> Issue 589. Case 2")
                     .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
                 yield return new TestCaseData("BeforeOnChar_issue589_3", ' ', false, true)
-                    .SetName("case | Issue 589. Case 3")
+                    .SetName("case <complete> Issue 589. Case 3")
                     .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
                 yield return new TestCaseData("BeforeOnChar_issue589_4", ' ', false, false)
-                    .SetName("case | Issue 589. Case 4")
+                    .SetName("case <complete> Issue 589. Case 4")
                     .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
                 yield return new TestCaseData("BeforeOnChar_issue589_5", ' ', false, false)
-                    .SetName("case | Issue 589. Case 5")
+                    .SetName("case <complete> Issue 589. Case 5")
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
+                yield return new TestCaseData("BeforeOnChar_issue589_6", ' ', false, true)
+                    .SetName("case EnumValue0 | <complete> Issue 589. Case 6")
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
+                yield return new TestCaseData("BeforeOnChar_issue589_7", ' ', false, true)
+                    .SetName("case EnumValue0, <complete> Issue 589. Case 7")
                     .SetDescription("https://github.com/fdorg/flashdevelop/issues/589");
             }
         }

--- a/Tests/External/Plugins/HaxeContext.Tests/HaxeContext.Tests.csproj
+++ b/Tests/External/Plugins/HaxeContext.Tests/HaxeContext.Tests.csproj
@@ -971,6 +971,8 @@
     <EmbeddedResource Include="Test Files\generators\code\AfterGenerateGetterSetter_issue2499_2.hx" />
     <EmbeddedResource Include="Test Files\completion\BeforeOnCharAndReplaceText_issue2499_1.hx" />
     <EmbeddedResource Include="Test Files\completion\AfterOnCharAndReplaceText_issue2499_1.hx" />
+    <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_6.hx" />
+    <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_7.hx" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Tests/External/Plugins/HaxeContext.Tests/HaxeContext.Tests.csproj
+++ b/Tests/External/Plugins/HaxeContext.Tests/HaxeContext.Tests.csproj
@@ -973,6 +973,10 @@
     <EmbeddedResource Include="Test Files\completion\AfterOnCharAndReplaceText_issue2499_1.hx" />
     <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_6.hx" />
     <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_7.hx" />
+    <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_8.hx" />
+    <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_9.hx" />
+    <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_10.hx" />
+    <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_11.hx" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Tests/External/Plugins/HaxeContext.Tests/HaxeContext.Tests.csproj
+++ b/Tests/External/Plugins/HaxeContext.Tests/HaxeContext.Tests.csproj
@@ -977,6 +977,9 @@
     <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_9.hx" />
     <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_10.hx" />
     <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_11.hx" />
+    <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_12.hx" />
+    <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_13.hx" />
+    <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_14.hx" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_10.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_10.hx
@@ -1,0 +1,13 @@
+﻿package;
+class Issue589_10 {
+	function foo(v:EType) {
+		switch v {
+			case Node(1 | $(EntryPoint)):
+			case _:
+		}
+	}
+}
+
+enum EType {
+	Node(v);
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_11.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_11.hx
@@ -1,0 +1,13 @@
+﻿package;
+class Issue589_11 {
+	function foo(v:EType) {
+		switch v {
+			case Node(1, $(EntryPoint)):
+			case _:
+		}
+	}
+}
+
+enum EType {
+	Node(v);
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_12.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_12.hx
@@ -1,0 +1,13 @@
+﻿package;
+class Issue589_12 {
+	function foo() {
+		var myArray = [1, 6];
+		var match = switch(myArray) {
+		  case [2, _]: "0";
+		  case [_, $(EntryPoint)]: "1";
+		  case []: "2";
+		  case [_, _, _]: "3";
+		  case _: "4";
+		}
+	}
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_13.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_13.hx
@@ -1,0 +1,8 @@
+﻿package;
+class Issue589_13 {
+	function foo(v:Null<Bool>) {
+		switch(v) {
+			case true | false | $(EntryPoint):
+		}
+	}
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_14.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_14.hx
@@ -1,0 +1,8 @@
+﻿package;
+class Issue589_14 {
+	function foo(v:Null<Bool>) {
+		switch(v) {
+			case true, false, $(EntryPoint):
+		}
+	}
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_5.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_5.hx
@@ -1,5 +1,5 @@
 ﻿package;
-class Issue589_4 {
+class Issue589_5 {
 	function foo(v:Bool) {
 		switch(v) {
 			case true $(EntryPoint):

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_6.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_6.hx
@@ -1,0 +1,8 @@
+﻿package;
+class Issue589_4 {
+	function foo(v:Bool) {
+		switch(v) {
+			case true | $(EntryPoint):
+		}
+	}
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_6.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_6.hx
@@ -1,5 +1,5 @@
 ﻿package;
-class Issue589_4 {
+class Issue589_6 {
 	function foo(v:Bool) {
 		switch(v) {
 			case true | $(EntryPoint):

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_7.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_7.hx
@@ -1,0 +1,8 @@
+﻿package;
+class Issue589_4 {
+	function foo(v:Bool) {
+		switch(v) {
+			case true, $(EntryPoint):
+		}
+	}
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_7.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_7.hx
@@ -1,5 +1,5 @@
 ﻿package;
-class Issue589_4 {
+class Issue589_7 {
 	function foo(v:Bool) {
 		switch(v) {
 			case true, $(EntryPoint):

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_8.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_8.hx
@@ -1,0 +1,6 @@
+﻿package;
+class Issue589_8 {
+	function foo() {
+		trace(1 | $(EntryPoint))
+	}
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_9.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_9.hx
@@ -1,0 +1,6 @@
+﻿package;
+class Issue589_9 {
+	function foo() {
+		trace(1 , $(EntryPoint))
+	}
+}


### PR DESCRIPTION
![switchcasecompletion_impr](https://user-images.githubusercontent.com/1700940/47834155-5fbc6e80-ddaf-11e8-801f-cc722264b57c.gif)
