### PR TITLE
[Haxe][CodeComplete][SwitchCaseCompletion] Added code completion after '|' and ',' e.g. 'case EnumValue1 |'

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -3120,8 +3120,12 @@ namespace ASCompletion.Completion
         /// <param name="access">Visibility mask</param>
         public static void FindMember(string token, FileModel inFile, ASResult result, FlagType mask, Visibility access)
         {
-            if (string.IsNullOrEmpty(token))
-                return;
+            ASContext.Context.CodeComplete.FindMemberEx(token, inFile, result, mask, access);
+        }
+
+        protected virtual void FindMemberEx(string token, FileModel inFile, ASResult result, FlagType mask, Visibility access)
+        {
+            if (string.IsNullOrEmpty(token)) return;
 
             // package
             if (result.IsPackage)
@@ -3151,19 +3155,15 @@ namespace ASCompletion.Completion
                         }
                         return;
                     }
-                    else
+                    if (mPack.Name.IndexOf('<') is int p && p > 0)
                     {
-                        int p;
-                        if ((p = mPack.Name.IndexOf('<')) > 0)
+                        if (p > 1 && mPack.Name[p - 1] == '.') p--;
+                        if (mPack.Name.Substring(0, p) == token)
                         {
-                            if (p > 1 && mPack.Name[p - 1] == '.') p--;
-                            if (mPack.Name.Substring(0, p) == token)
-                            {
-                                result.IsPackage = false;
-                                result.Type = ResolveType(fullName + mPack.Name.Substring(p), ASContext.Context.CurrentModel);
-                                result.InFile = result.Type.InFile;
-                                return;
-                            }
+                            result.IsPackage = false;
+                            result.Type = ResolveType(fullName + mPack.Name.Substring(p), ASContext.Context.CurrentModel);
+                            result.InFile = result.Type.InFile;
+                            return;
                         }
                     }
                 }

--- a/External/Plugins/HaXeContext/Completion/CodeComplete.cs
+++ b/External/Plugins/HaXeContext/Completion/CodeComplete.cs
@@ -720,6 +720,23 @@ namespace HaXeContext.Completion
             return base.GetCalltipDef(member);
         }
 
+        protected override void FindMemberEx(string token, FileModel inFile, ASResult result, FlagType mask, Visibility access)
+        {
+            base.FindMemberEx(token, inFile, result, mask, access);
+            if (result.Type != null && !result.Type.IsVoid()) return;
+            var list = ASContext.Context.GetTopLevelElements();
+            if (list == null || list.Count == 0) return;
+            foreach (MemberModel it in list)
+            {
+                if (it.Name != token || !it.Flags.HasFlag(FlagType.Enum)) continue;
+                var type = ResolveType(it.Type, inFile);
+                result.Type = type;
+                result.InClass = type;
+                result.IsStatic = false;
+                return;
+            }
+        }
+
         protected override void FindMemberEx(string token, ClassModel inClass, ASResult result, FlagType mask, Visibility access)
         {
             if (string.IsNullOrEmpty(token)) return;

--- a/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
+++ b/Tests/External/Plugins/ASCompletion.Tests/TestUtils/ContextExtensions.cs
@@ -23,6 +23,8 @@ namespace ASCompletion.TestUtils
             BuildClassPath(context);
             context.CurrentModel = new FileModel {Context = mock, Version = 3};
             SetFeatures(mock, context);
+            mock.When(it => it.ResolveTopLevelElement(Arg.Any<string>(), Arg.Any<ASResult>()))
+                .Do(it => context.ResolveTopLevelElement(it.ArgAt<string>(0), it.ArgAt<ASResult>(1)));
         }
 
         public static void SetHaxeFeatures(this IASContext mock)
@@ -32,6 +34,13 @@ namespace ASCompletion.TestUtils
             BuildClassPath(context);
             context.CurrentModel = new FileModel {Context = mock, Version = 4, haXe = true};
             SetFeatures(mock, context);
+            mock.When(it => it.ResolveTopLevelElement(Arg.Any<string>(), Arg.Any<ASResult>()))
+                .Do(it =>
+                {
+                    context.completionCache.IsDirty = true;
+                    context.GetTopLevelElements();
+                    context.ResolveTopLevelElement(it.ArgAt<string>(0), it.ArgAt<ASResult>(1));
+                });
         }
 
         static void SetFeatures(IASContext mock, IASContext context)
@@ -88,8 +97,6 @@ namespace ASCompletion.TestUtils
             mock.When(it => it.ResolveDotContext(Arg.Any<ScintillaControl>(), Arg.Any<ASResult>(), Arg.Any<MemberList>()))
                 .Do(it => context.ResolveDotContext(it.ArgAt<ScintillaControl>(0), it.ArgAt<ASResult>(1), it.ArgAt<MemberList>(2)));
             mock.ResolvePackage(null, false).ReturnsForAnyArgs(it => context.ResolvePackage(it.ArgAt<string>(0), it.ArgAt<bool>(1)));
-            mock.When(it => it.ResolveTopLevelElement(Arg.Any<string>(), Arg.Any<ASResult>()))
-                .Do(it => context.ResolveTopLevelElement(it.ArgAt<string>(0), it.ArgAt<ASResult>(1)));
             mock.TypesAffinity(null, null).ReturnsForAnyArgs(it =>
             {
                 var inClass = it.ArgAt<ClassModel>(0);

--- a/Tests/External/Plugins/HaxeContext.Tests/CodeRefactor/Commands/RefactorCommandTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/CodeRefactor/Commands/RefactorCommandTests.cs
@@ -193,24 +193,13 @@ namespace HaXeContext.CodeRefactor.Commands
         {
             var sourceText = ReadAllText(fileName);
             fileName = GetFullPath(fileName);
-            fileName = Path.GetFileNameWithoutExtension(fileName).Replace('.', Path.DirectorySeparatorChar) +
-                       Path.GetExtension(fileName);
+            fileName = Path.GetFileNameWithoutExtension(fileName).Replace('.', Path.DirectorySeparatorChar)
+                       + Path.GetExtension(fileName);
             fileName = Path.GetFullPath(fileName);
             fileName = fileName.Replace($"\\FlashDevelop\\Bin\\Debug\\{nameof(HaXeContext)}\\Test_Files\\", ProjectPath);
             fileName = fileName.Replace(".hx", "_withoutEntryPoint.hx");
             ASContext.Context.CurrentModel.FileName = fileName;
             PluginBase.MainForm.CurrentDocument.FileName.Returns(fileName);
-            //{TODO slavara: quick hack
-            ASContext.Context.When(it => it.ResolveTopLevelElement(Arg.Any<string>(), Arg.Any<ASResult>()))
-                .Do(it =>
-                {
-                    var ctx = (Context) ASContext.GetLanguageContext("haxe");
-                    ctx.CurrentModel.FileName = fileName;
-                    ctx.GetCodeModel(ctx.CurrentModel, sci.Text);
-                    ctx.completionCache.IsDirty = true;
-                    ctx.ResolveTopLevelElement(it.ArgAt<string>(0), it.ArgAt<ASResult>(1));
-                });
-            //}
             return global::CodeRefactor.Commands.RefactorCommandTests.RenameTests.Rename(sci, sourceText, newName);
         }
     }

--- a/Tests/External/Plugins/HaxeContext.Tests/Completion/CodeCompleteTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/Completion/CodeCompleteTests.cs
@@ -513,6 +513,16 @@ namespace HaXeContext.Completion
             }
         }
 
+        static IEnumerable<TestCaseData> CalltipDefIssue589TestCases
+        {
+            get
+            {
+                yield return new TestCaseData("CalltipDef_issue589_1")
+                    .Returns("EValue (v1:String, v2:Int) : EType")
+                    .SetName("case EType(<complete>. Issue 589. Case 1");
+            }
+        }
+
         [
             Test,
             TestCaseSource(nameof(CalltipDefIssue2356TestCases)),
@@ -521,6 +531,7 @@ namespace HaXeContext.Completion
             TestCaseSource(nameof(CalltipDefIssue2468TestCases)),
             TestCaseSource(nameof(CalltipDefIssue2475TestCases)),
             TestCaseSource(nameof(CalltipDefIssue2489TestCases)),
+            TestCaseSource(nameof(CalltipDefIssue589TestCases)),
         ]
         public string CalltipDef(string fileName)
         {
@@ -761,18 +772,6 @@ namespace HaXeContext.Completion
         public string OnCharAndReplaceText(string fileName, char addedChar, bool autoHide)
         {
             ASContext.Context.ResolveDotContext(null, null, false).ReturnsForAnyArgs(it => null);
-            //{TODO slavara: quick hack
-            ASContext.Context
-                .When(it => it.ResolveTopLevelElement(Arg.Any<string>(), Arg.Any<ASResult>()))
-                .Do(it =>
-                {
-                    var ctx = (Context) ASContext.GetLanguageContext("haxe");
-                    ctx.GetCodeModel(ctx.CurrentModel, sci.Text);
-                    ctx.completionCache.IsDirty = true;
-                    ctx.ResolveTopLevelElement(it.ArgAt<string>(0), it.ArgAt<ASResult>(1));
-                });
-            //}
-            ((Context) ASContext.GetLanguageContext("haxe")).completionCache.IsDirty = true;
             return OnCharAndReplaceText(sci, CodeCompleteTests.ReadAllText(fileName), addedChar, autoHide);
         }
     }

--- a/Tests/External/Plugins/HaxeContext.Tests/HaxeContext.Tests.csproj
+++ b/Tests/External/Plugins/HaxeContext.Tests/HaxeContext.Tests.csproj
@@ -980,6 +980,7 @@
     <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_12.hx" />
     <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_13.hx" />
     <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue589_14.hx" />
+    <EmbeddedResource Include="Test Files\completion\CalltipDef_issue589_1.hx" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_13.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue589_13.hx
@@ -1,8 +1,13 @@
 ﻿package;
 class Issue589_13 {
-	function foo(v:Null<Bool>) {
+	function foo(v:AType) {
 		switch(v) {
-			case true | false | $(EntryPoint):
+			case One, Two, $(EntryPoint)
 		}
 	}
+}
+
+@:enum abstract AType(Int) {
+	var One = 1;
+	var Two = 2;
 }

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/CalltipDef_issue589_1.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/CalltipDef_issue589_1.hx
@@ -1,0 +1,12 @@
+﻿package;
+class CalltipDef_issue589_1 {
+	public function new(e:EType) {
+		switch e {
+			case EValue($(EntryPoint)
+		}
+	}
+}
+
+enum EType {
+	EValue(v1:String, v2:Int);
+}


### PR DESCRIPTION
![switchcasecompletion_impr2](https://user-images.githubusercontent.com/1700940/47837156-060e7100-ddbc-11e8-8bfb-4b1e0dc8be4e.gif)
