### PR TITLE
[Haxe][CodeComplete] Added simple support for `@:privateAccess` e.g. `@:privateAccess member.<complete>`. fixes #2538

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -2122,7 +2122,7 @@ namespace ASCompletion.Completion
             var currentClass = ctx.CurrentClass;
 
             currentClass.ResolveExtends();
-            var access = ctx.TypesAffinity(currentClass, tmpClass);
+            var access = TypesAffinity(expr.Context, currentClass, tmpClass);
 
             // explore members
             tmpClass.ResolveExtends();
@@ -2156,6 +2156,8 @@ namespace ASCompletion.Completion
                 access = ctx.TypesAffinity(currentClass, tmpClass);
             }
         }
+
+        protected virtual Visibility TypesAffinity(ASExpr context, ClassModel inClass, ClassModel withClass) => ASContext.Context.TypesAffinity(inClass, withClass);
 
         private static MemberList GetKeywords()
         {
@@ -2752,15 +2754,15 @@ namespace ASCompletion.Completion
             int n = tokens.Count;
             if (!complete) n--;
             // context
-            IASContext ctx = ASContext.Context;
-            ContextFeatures features = ctx.Features;
-            ASResult step = head;
+            var ctx = ASContext.Context;
+            var features = ctx.Features;
+            var step = head;
             // look for static or dynamic members?
-            FlagType mask = head.IsStatic ? FlagType.Static : FlagType.Dynamic;
+            var mask = head.IsStatic ? FlagType.Static : FlagType.Dynamic;
             // members visibility
-            ClassModel curClass = ctx.CurrentClass;
+            var curClass = ctx.CurrentClass;
             curClass.ResolveExtends();
-            Visibility acc = ctx.TypesAffinity(curClass, step.Type);
+            var acc = ctx.CodeComplete.TypesAffinity(context, curClass, step.Type);
 
             // explore
             var inE4X = false;

--- a/External/Plugins/HaXeContext/Completion/CodeComplete.cs
+++ b/External/Plugins/HaXeContext/Completion/CodeComplete.cs
@@ -1053,6 +1053,16 @@ namespace HaXeContext.Completion
             }
         }
 
+        protected override Visibility TypesAffinity(ASExpr context, ClassModel inClass, ClassModel withClass)
+        {
+            var result = base.TypesAffinity(context, inClass, withClass);
+            if (context != null
+                && ASContext.CurSciControl is ScintillaControl sci
+                && context.WordBefore == "privateAccess" && context.WordBeforePosition is int p
+                && sci.CharAt(p - 2) == '@' && sci.CharAt(p - 1) == ':') result |= Visibility.Private;
+            return result;
+        }
+
         public override MemberModel FunctionTypeToMemberModel(string type, FileModel inFile)
         {
             var voidKey = ASContext.Context.Features.voidKey;

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -785,10 +785,10 @@ namespace HaXeContext
         public override Visibility TypesAffinity(ClassModel inClass, ClassModel withClass)
         {
             // same file
-            if (withClass != null && inClass.InFile == withClass.InFile)
+            if (withClass != null && inClass.InFile == withClass.InFile && inClass.BaseType == withClass.BaseType)
                 return Visibility.Public | Visibility.Private;
             // inheritance affinity
-            ClassModel tmp = inClass;
+            var tmp = inClass;
             while (!tmp.IsVoid())
             {
                 if (tmp == withClass)

--- a/Tests/External/Plugins/HaxeContext.Tests/Completion/CodeCompleteTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/Completion/CodeCompleteTests.cs
@@ -966,6 +966,25 @@ namespace HaXeContext.Completion
             }
         }
 
+        static IEnumerable<TestCaseData> OnCharAndReplaceTextIssue2538TestCases
+        {
+            get
+            {
+                yield return new TestCaseData("BeforeOnChar_issue2538_1", '.', false)
+                    .Returns(CodeCompleteTests.ReadAllText("AfterOnCharAndReplaceText_issue2538_1"))
+                    .SetName("new Foo().<complete> Issue 2538. Case 1")
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2538");
+                yield return new TestCaseData("BeforeOnChar_issue2538_2", '.', false)
+                    .Returns(CodeCompleteTests.ReadAllText("AfterOnCharAndReplaceText_issue2538_2"))
+                    .SetName("@:privateAccess new Foo().<complete> Issue 2538. Case 2")
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2538");
+                yield return new TestCaseData("BeforeOnChar_issue2538_3", '.', false)
+                    .Returns(CodeCompleteTests.ReadAllText("AfterOnCharAndReplaceText_issue2538_3"))
+                    .SetName("@:privateAccess new Foo().<complete> Issue 2538. Case 3")
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2538");
+            }
+        }
+
         [
             Test,
             TestCaseSource(nameof(OnCharAndReplaceTextTestCases)),
@@ -983,6 +1002,7 @@ namespace HaXeContext.Completion
             TestCaseSource(nameof(OnCharAndReplaceTextIssue1909TestCases)),
             TestCaseSource(nameof(OnCharAndReplaceTextIssue2526TestCases)),
             TestCaseSource(nameof(OnCharAndReplaceTextIssue2536TestCases)),
+            TestCaseSource(nameof(OnCharAndReplaceTextIssue2538TestCases)),
         ]
         public string OnCharAndReplaceText(string fileName, char addedChar, bool autoHide)
         {

--- a/Tests/External/Plugins/HaxeContext.Tests/HaxeContext.Tests.csproj
+++ b/Tests/External/Plugins/HaxeContext.Tests/HaxeContext.Tests.csproj
@@ -1051,6 +1051,12 @@
     <EmbeddedResource Include="Test Files\completion\AfterOnCharAndReplaceText_issue2536_1.hx" />
     <EmbeddedResource Include="Test Files\completion\BeforeOnCharAndReplaceText_issue2536_2.hx" />
     <EmbeddedResource Include="Test Files\completion\AfterOnCharAndReplaceText_issue2536_2.hx" />
+    <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue2538_1.hx" />
+    <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue2538_2.hx" />
+    <EmbeddedResource Include="Test Files\completion\AfterOnCharAndReplaceText_issue2538_1.hx" />
+    <EmbeddedResource Include="Test Files\completion\AfterOnCharAndReplaceText_issue2538_2.hx" />
+    <EmbeddedResource Include="Test Files\completion\BeforeOnChar_issue2538_3.hx" />
+    <EmbeddedResource Include="Test Files\completion\AfterOnCharAndReplaceText_issue2538_3.hx" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/AfterOnCharAndReplaceText_issue2538_1.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/AfterOnCharAndReplaceText_issue2538_1.hx
@@ -1,0 +1,11 @@
+﻿package;
+class Issue2538_1 {
+    static function main() {
+       var v = new SubClass2538_1();
+	   v.b
+    }
+}
+class SubClass2538_1 {
+    var a;
+	public var b;
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/AfterOnCharAndReplaceText_issue2538_2.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/AfterOnCharAndReplaceText_issue2538_2.hx
@@ -1,0 +1,11 @@
+﻿package;
+class Issue2538_2 {
+    static function main() {
+		var v = new SubClass2538_2();
+		@:privateAccess v.a
+    }
+}
+class SubClass2538_2 {
+    var a;
+	public var b;
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/AfterOnCharAndReplaceText_issue2538_3.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/AfterOnCharAndReplaceText_issue2538_3.hx
@@ -1,0 +1,13 @@
+﻿package;
+class Issue2538_3 {
+    static function main() {
+		var v = new SubClass2538_3_1();
+		@:privateAccess v.a1.a2
+    }
+}
+class SubClass2538_3_1 {
+    var a1:SubClass2538_3_2;
+}
+class SubClass2538_3_2 {
+    var a2;
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue2538_1.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue2538_1.hx
@@ -1,0 +1,11 @@
+﻿package;
+class Issue2538_1 {
+    static function main() {
+       var v = new SubClass2538_1();
+	   v.$(EntryPoint)
+    }
+}
+class SubClass2538_1 {
+    var a;
+	public var b;
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue2538_2.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue2538_2.hx
@@ -1,0 +1,11 @@
+﻿package;
+class Issue2538_2 {
+    static function main() {
+		var v = new SubClass2538_2();
+		@:privateAccess v.$(EntryPoint)
+    }
+}
+class SubClass2538_2 {
+    var a;
+	public var b;
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue2538_3.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/BeforeOnChar_issue2538_3.hx
@@ -1,0 +1,13 @@
+﻿package;
+class Issue2538_3 {
+    static function main() {
+		var v = new SubClass2538_3_1();
+		@:privateAccess v.a1.$(EntryPoint)
+    }
+}
+class SubClass2538_3_1 {
+    var a1:SubClass2538_3_2;
+}
+class SubClass2538_3_2 {
+    var a2;
+}


### PR DESCRIPTION
![codecompletion_privateaccess_2538](https://user-images.githubusercontent.com/1700940/48203008-79ddea00-e377-11e8-9e7e-d797b79a2550.gif)
