### PR TITLE
[Haxe][Context] Avoid duplicate subscriptions in ExternalToolchain

### DIFF
--- a/External/Plugins/HaXeContext/ExternalToolchain.cs
+++ b/External/Plugins/HaXeContext/ExternalToolchain.cs
@@ -176,43 +176,32 @@ namespace HaXeContext
         /// <param name="project"></param>
         public static void Monitor(IProject project)
         {
-            if (!(project is HaxeProject pj))
+            if (project is HaxeProject pj)
             {
-                ProjSwitch();
-                return;
-            }
+                if (updater == null)
+                {
+                    updater = new System.Timers.Timer();
+                    updater.Interval = 200;
+                    updater.SynchronizingObject = (System.Windows.Forms.Form)PluginBase.MainForm;
+                    updater.Elapsed += updater_Elapsed;
+                    updater.AutoReset = false;
+                }
 
-            if (updater == null)
-            {
-                updater = new System.Timers.Timer();
-                updater.Interval = 200;
-                updater.SynchronizingObject = (System.Windows.Forms.Form) PluginBase.MainForm;
-                updater.Elapsed += updater_Elapsed;
-                updater.AutoReset = false;
-            }
-
-            if (hxproj == pj)
-            {
-                // When not calling "Monitor" for the first time
-                // Then the ".Save" will be called later at the same time by the PropertiesDialog updated.
-                skipSaveOnce = true;
+                if (hxproj == pj)
+                {
+                    // Then the ".Save" will be called later at the same time by the PropertiesDialog updated.
+                    skipSaveOnce = true;
+                }
+                else
+                {
+                    hxproj = pj;
+                    hxproj.ProjectUpdating += hxproj_ProjectUpdating;
+                }
+                hxproj_ProjectUpdating(hxproj);
             }
             else
             {
-                ProjSwitch();
-                hxproj = pj;
-                hxproj.ProjectUpdating += hxproj_ProjectUpdating;
-            }
-            hxproj_ProjectUpdating(hxproj);
-        }
-
-        internal static void ProjSwitch()
-        {
-            if (hxproj != null)
-            {
                 StopWatcher();
-                hxproj.ProjectUpdating -= hxproj_ProjectUpdating;
-                hxproj = null;
             }
         }
 

--- a/External/Plugins/HaXeContext/ExternalToolchain.cs
+++ b/External/Plugins/HaXeContext/ExternalToolchain.cs
@@ -181,7 +181,8 @@ namespace HaXeContext
                 return;
             }
 
-            if (updater == null) {
+            if (updater == null)
+            {
                 updater = new System.Timers.Timer();
                 updater.Interval = 200;
                 updater.SynchronizingObject = (System.Windows.Forms.Form) PluginBase.MainForm;

--- a/External/Plugins/HaXeContext/ExternalToolchain.cs
+++ b/External/Plugins/HaXeContext/ExternalToolchain.cs
@@ -178,6 +178,7 @@ namespace HaXeContext
         {
             if (!(project is HaxeProject pj))
             {
+                ProjSwitch();
                 return;
             }
 
@@ -190,18 +191,30 @@ namespace HaXeContext
                 updater.AutoReset = false;
             }
 
-            if (hxproj != null)
+            if (hxproj == pj)
             {
                 // When not calling "Monitor" for the first time
                 // Then the ".Save" will be called later at the same time by the PropertiesDialog updated.
                 skipSaveOnce = true;
             }
-            if (hxproj != pj)
+            else
             {
+                ProjSwitch();
                 hxproj = pj;
                 hxproj.ProjectUpdating += hxproj_ProjectUpdating;
             }
             hxproj_ProjectUpdating(hxproj);
+        }
+
+        internal static void ProjSwitch()
+        {
+            if (hxproj != null)
+            {
+                StopWatcher();
+                hxproj.ProjectUpdating -= hxproj_ProjectUpdating;
+                hxproj = null;
+                skipSaveOnce = false;
+            }
         }
 
         internal static void StopWatcher()

--- a/External/Plugins/HaXeContext/ExternalToolchain.cs
+++ b/External/Plugins/HaXeContext/ExternalToolchain.cs
@@ -213,7 +213,6 @@ namespace HaXeContext
                 StopWatcher();
                 hxproj.ProjectUpdating -= hxproj_ProjectUpdating;
                 hxproj = null;
-                skipSaveOnce = false;
             }
         }
 


### PR DESCRIPTION
It seems that every time you configure through the **PropertiesDialog** in ExternalToolchain, the `hxproj_ProjectUpdating` will be duplicate subscribed.

See the image below, I added `Trace.WriteLine` to reproduce it:
![fd](https://user-images.githubusercontent.com/6825113/54584733-18c7d080-4a53-11e9-82fb-a7b4c700a687.gif)
