### PR TITLE
 [Haxe] Added tooltip for enum abstract value. fixes #2804

### DIFF
--- a/External/Plugins/ASCompletion/Completion/ASComplete.cs
+++ b/External/Plugins/ASCompletion/Completion/ASComplete.cs
@@ -4918,53 +4918,60 @@ namespace ASCompletion.Completion
 
         protected static string MemberTooltipText(MemberModel member, ClassModel inClass)
         {
-            // modifiers
-            var ft = member.Flags;
-            var modifiers = "";
-            if ((ft & FlagType.Class) == 0)
-            {
-                if ((ft & FlagType.LocalVar) > 0) modifiers += "(local) ";
-                else if ((ft & FlagType.ParameterVar) > 0) modifiers += "(parameter) ";
-                else if ((ft & FlagType.AutomaticVar) > 0) modifiers += "(auto) ";
-                else
-                {
-                    if ((ft & FlagType.Extern) > 0)
-                        modifiers += "extern ";
-                    if ((ft & FlagType.Native) > 0)
-                        modifiers += "native ";
-                    if ((ft & FlagType.Static) > 0)
-                        modifiers += "static ";
-                    var acc = member.Access;
-                    if ((acc & Visibility.Private) > 0)
-                        modifiers += "private ";
-                    else if ((acc & Visibility.Public) > 0)
-                        modifiers += "public ";
-                    else if ((acc & Visibility.Protected) > 0)
-                        modifiers += "protected ";
-                    else if ((acc & Visibility.Internal) > 0)
-                        modifiers += "internal ";
-                }
-            }
+            var modifiers = ASContext.Context.CodeComplete.GetMemberModifiersTooltipText(member);
             // signature
             var foundIn = "";
             if (inClass != ClassModel.VoidClass)
             {
                 var themeForeColor = PluginBase.MainForm.GetThemeColor("MethodCallTip.InfoColor");
-                var foreColorString = themeForeColor != Color.Empty ? ColorTranslator.ToHtml(themeForeColor) : "#666666:MULTIPLY";
+                var foreColorString =
+                    themeForeColor != Color.Empty ? ColorTranslator.ToHtml(themeForeColor) : "#666666:MULTIPLY";
                 foundIn = "\n[COLOR=" + foreColorString + "]in " + MemberModel.FormatType(inClass.QualifiedName) + "[/COLOR]";
             }
+            return ASContext.Context.CodeComplete.GetMemberSignatureTooltipText(member, modifiers, foundIn);
+        }
+
+        protected virtual string GetMemberSignatureTooltipText(MemberModel member, string modifiers, string foundIn)
+        {
+            var ft = member.Flags;
             if ((ft & (FlagType.Getter | FlagType.Setter)) > 0) return $"{modifiers}property {member}{foundIn}";
             if (ft == FlagType.Function) return $"{modifiers}function {member}{foundIn}";
             if ((ft & FlagType.Namespace) > 0) return $"{modifiers}namespace {member.Name}{foundIn}";
             if ((ft & FlagType.Constant) > 0)
             {
-                if (member.Value == null) return $"{modifiers}const {member}{foundIn}";
+                if (member.Value is null) return $"{modifiers}const {member}{foundIn}";
                 return $"{modifiers}const {member} = {member.Value}{foundIn}";
             }
+
             if ((ft & FlagType.Variable) > 0) return $"{modifiers}var {member}{foundIn}";
             if ((ft & FlagType.Delegate) > 0) return $"{modifiers}delegate {member}{foundIn}";
             return $"{modifiers}{member}{foundIn}";
         }
+
+        protected virtual string GetMemberModifiersTooltipText(MemberModel member)
+        {
+            var result = string.Empty;
+            var flags = member.Flags;
+            if ((flags & FlagType.Class) == 0)
+            {
+                if ((flags & FlagType.LocalVar) > 0) result += "(local) ";
+                else if ((flags & FlagType.ParameterVar) > 0) result += "(parameter) ";
+                else if ((flags & FlagType.AutomaticVar) > 0) result += "(auto) ";
+                else
+                {
+                    if ((flags & FlagType.Extern) > 0) result += "extern ";
+                    if ((flags & FlagType.Native) > 0) result += "native ";
+                    if ((flags & FlagType.Static) > 0) result += "static ";
+                    var access = member.Access;
+                    if ((access & Visibility.Private) > 0) result += "private ";
+                    else if ((access & Visibility.Public) > 0) result += "public ";
+                    else if ((access & Visibility.Protected) > 0) result += "protected ";
+                    else if ((access & Visibility.Internal) > 0) result += "internal ";
+                }
+            }
+            return result;
+        }
+
         #endregion
 
         #region automatic code generation

--- a/External/Plugins/HaXeContext/Completion/CodeComplete.cs
+++ b/External/Plugins/HaXeContext/Completion/CodeComplete.cs
@@ -1221,20 +1221,17 @@ namespace HaXeContext.Completion
 
         protected override string GetToolTipTextEx(ASResult expr)
         {
-            if (expr.Member is null)
+            if (expr.Member is null && expr.Context is { } context)
             {
-                if (expr.Context is { } context)
+                // for example: cast<cursor>(expr, Type);
+                if (context.SubExpressions != null && context.WordBefore == "cast") expr.Member = Context.StubSafeCastFunction;
+                else if (context.Value is { } s)
                 {
-                    // for example: cast<cursor>(expr, Type);
-                    if (context.SubExpressions != null && context.WordBefore == "cast") expr.Member = Context.StubSafeCastFunction;
-                    else if (context.Value is { } s)
-                    {
-                        // for example: cast<cursor> expr;
-                        if (s == "cast") expr.Member = Context.StubUnsafeCastFunction;
-                        // for example: 'c'.code<complete> or "\n".code<complete>
-                        else if ((s.Length == 12 || (s.Length == 13 && s[1] == '\\')) && (s[0] == '\'' || s[0] == '"') && s.EndsWithOrdinal(".#0~.code"))
-                            expr.Member = Context.StubStringCodeProperty;
-                    }
+                    // for example: cast<cursor> expr;
+                    if (s == "cast") expr.Member = Context.StubUnsafeCastFunction;
+                    // for example: 'c'.code<complete> or "\n".code<complete>
+                    else if ((s.Length == 12 || (s.Length == 13 && s[1] == '\\')) && (s[0] == '\'' || s[0] == '"') && s.EndsWithOrdinal(".#0~.code"))
+                        expr.Member = Context.StubStringCodeProperty;
                 }
             }
             return base.GetToolTipTextEx(expr);

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -751,7 +751,7 @@ namespace HaXeContext
                         {
                             var member = @class.Members[index];
                             if (!member.Flags.HasFlag(FlagType.Variable)) continue;
-                            member.Flags = FlagType.Enum | FlagType.Static | FlagType.Variable;
+                            member.Flags = FlagType.Enum | FlagType.Static | (FlagType) HaxeFlagType.Inline | FlagType.Variable;
                             member.Access = Visibility.Public;
                             if (string.IsNullOrEmpty(member.Type)) member.Type = @class.Type;
                             member.InFile = @class.InFile;

--- a/Tests/External/Plugins/HaxeContext.Tests/Completion/Haxe3/CodeCompleteTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/Completion/Haxe3/CodeCompleteTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 using PluginCore;
 using PluginCore.Controls;
 
-namespace HaXeContext.Completion
+namespace HaXeContext.Completion.Haxe3
 {
     class CodeCompleteTests : ASCompleteTests
     {
@@ -470,8 +470,18 @@ namespace HaXeContext.Completion
             get
             {
                 yield return new TestCaseData("GetToolTipText_issue2439_1")
-                    .SetName("var type:Class|Issue2439_1. Issue 2439. Case 1")
+                    .SetName("var type:Class<complete>. Issue2439_1. Issue 2439. Case 1")
                     .Returns("public class ClassIssue2439_1");
+            }
+        }
+
+        static IEnumerable<TestCaseData> GetToolTipTextIssue2804TestCases
+        {
+            get
+            {
+                yield return new TestCaseData("GetToolTipText_issue2804_1")
+                    .SetName("case First<complete>. Issue2804_1. Issue 2804. Case 1")
+                    .Returns("static public inline var First : AInt = 1\n[COLOR=Black]in Issue2804_1[/COLOR]");
             }
         }
 
@@ -479,6 +489,7 @@ namespace HaXeContext.Completion
             Test,
             TestCaseSource(nameof(GetToolTipTextTestCases)),
             TestCaseSource(nameof(GetToolTipTextIssue2439TestCases)),
+            TestCaseSource(nameof(GetToolTipTextIssue2804TestCases)),
         ]
         public string GetToolTipText(string fileName)
         {

--- a/Tests/External/Plugins/HaxeContext.Tests/Completion/Haxe4/CodeCompleteTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/Completion/Haxe4/CodeCompleteTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using ASCompletion.Completion;
+using ASCompletion.Context;
+using NUnit.Framework;
+using PluginCore;
+
+namespace HaXeContext.Completion.Haxe4
+{
+    class CodeCompleteTests : ASCompleteTests
+    {
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+            SetHaxeFeatures(sci);
+            ASContext.Context.Settings.InstalledSDKs = new[] { new InstalledSDK { Path = PluginBase.CurrentProject.CurrentSDK, Version = "4.0.0" } };
+        }
+
+        static IEnumerable<TestCaseData> GetToolTipTextIssue2804TestCases
+        {
+            get
+            {
+                yield return new TestCaseData("GetToolTipText_issue2804_1")
+                    .SetName("case First<complete>. Issue 2804. Case 1")
+                    .Returns("static public inline var First : AInt = 1\n[COLOR=Black]in Issue2804_1[/COLOR]");
+                yield return new TestCaseData("GetToolTipText_issue2804_2")
+                    .SetName("case First<complete>. Issue 2804. Case 2")
+                    .Returns("static public inline var First : AInt = 1\n[COLOR=Black]in Issue2804_2[/COLOR]");
+                yield return new TestCaseData("GetToolTipText_issue2804_3")
+                    .SetName("case Six<complete>. Issue 2804. Case 3")
+                    .Returns("static public inline var Six : AInt = 6\n[COLOR=Black]in Issue2804_3[/COLOR]");
+                yield return new TestCaseData("GetToolTipText_issue2804_4")
+                    .SetName("first<complete>. Issue 2804. Case 4")
+                    .Returns("static public inline var first : Int = 1\n[COLOR=Black]in Issue2804_4[/COLOR]");
+            }
+        }
+
+        [Test, TestCaseSource(nameof(GetToolTipTextIssue2804TestCases))]
+        public string GetToolTipText(string fileName)
+        {
+            SetSrc(sci, Haxe3.CodeCompleteTests.ReadAllText(fileName));
+            var expr = ASComplete.GetExpressionType(sci, sci.CurrentPos, false, true);
+            return ASComplete.GetToolTipText(expr);
+        }
+    }
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/ContextTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/ContextTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using ASCompletion.Completion;
 using ASCompletion.Context;
 using ASCompletion.Model;
+using HaXeContext.Model;
 using HaXeContext.TestUtils;
 using NSubstitute;
 using NUnit.Framework;
@@ -342,7 +343,7 @@ namespace HaXeContext
                 yield return new TestCaseData("GetTopLevelElements_1", new MemberModel("Foo", string.Empty, FlagType.Enum | FlagType.Static | FlagType.Variable, Visibility.Public))
                     .Returns(true)
                     .SetName("Case 1. enum");
-                yield return new TestCaseData("GetTopLevelElements_2", new MemberModel("Foo", string.Empty, FlagType.Enum | FlagType.Static | FlagType.Variable, Visibility.Public))
+                yield return new TestCaseData("GetTopLevelElements_2", new MemberModel("Foo", string.Empty, FlagType.Enum | FlagType.Static | (FlagType) HaxeFlagType.Inline | FlagType.Variable, Visibility.Public))
                     .Returns(true)
                     .SetName("Case 2. @:enum abstract");
                 yield return new TestCaseData("GetTopLevelElements_3", new MemberModel("toString", string.Empty, FlagType.Function, Visibility.Public))
@@ -369,7 +370,7 @@ namespace HaXeContext
                 yield return new TestCaseData("ResolveTopLevelElement_enum")
                     .Returns(new MemberModel("EFoo", "Foo", FlagType.Enum | FlagType.Static | FlagType.Variable, Visibility.Public));
                 yield return new TestCaseData("ResolveTopLevelElement_abstract")
-                    .Returns(new MemberModel("EFoo", "Foo", FlagType.Enum | FlagType.Static | FlagType.Variable, Visibility.Public));
+                    .Returns(new MemberModel("EFoo", "Foo", FlagType.Enum | FlagType.Static | (FlagType) HaxeFlagType.Inline | FlagType.Variable, Visibility.Public));
             }
         }
 

--- a/Tests/External/Plugins/HaxeContext.Tests/HaxeContext.Tests.csproj
+++ b/Tests/External/Plugins/HaxeContext.Tests/HaxeContext.Tests.csproj
@@ -67,7 +67,8 @@
   <ItemGroup>
     <Compile Include="CodeRefactor\Commands\RefactorCommandTests.cs" />
     <Compile Include="CodeRefactor\Provider\HaxeCommandFactoryTests.cs" />
-    <Compile Include="Completion\CodeCompleteTests.cs" />
+    <Compile Include="Completion\Haxe3\CodeCompleteTests.cs" />
+    <Compile Include="Completion\Haxe4\CodeCompleteTests.cs" />
     <Compile Include="Generators\CodeGeneratorTests2.cs" />
     <Compile Include="Generators\CodeGeneratorTests.cs" />
     <Compile Include="ContextTests.cs" />
@@ -1746,6 +1747,10 @@
     <EmbeddedResource Include="Test Files\parser\Issue2801_4.hx" />
     <EmbeddedResource Include="Test Files\generators\code\BeforeContextualGeneratorTests_issue2779_1.hx" />
     <EmbeddedResource Include="Test Files\generators\code\AfterContextualGeneratorTests_issue2779_1.hx" />
+    <EmbeddedResource Include="Test Files\completion\GetToolTipText_issue2804_1.hx" />
+    <EmbeddedResource Include="Test Files\completion\GetToolTipText_issue2804_2.hx" />
+    <EmbeddedResource Include="Test Files\completion\GetToolTipText_issue2804_3.hx" />
+    <EmbeddedResource Include="Test Files\completion\GetToolTipText_issue2804_4.hx" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Tests/External/Plugins/HaxeContext.Tests/Model/Haxe4/FileParserTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/Model/Haxe4/FileParserTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using ASCompletion;
 using ASCompletion.Context;
-using ASCompletion.Model;
 using NUnit.Framework;
 using PluginCore;
 

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/GetToolTipText_issue2804_1.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/GetToolTipText_issue2804_1.hx
@@ -1,0 +1,14 @@
+﻿package;
+class Issue2804_1 {
+	function foo() {
+		var v:AInt;
+		switch(v) {
+			case First$(EntryPoint):
+			case _:
+		}
+	}
+}
+@:enum private abstract AInt(Int) {
+	var Zero = 0;
+	var First = 1;
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/GetToolTipText_issue2804_2.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/GetToolTipText_issue2804_2.hx
@@ -1,0 +1,14 @@
+﻿package;
+class Issue2804_2 {
+	function foo() {
+		var v:AInt;
+		switch(v) {
+			case First$(EntryPoint):
+			case _:
+		}
+	}
+}
+enum abstract AInt(Int) {
+	var Zero;
+	var First;
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/GetToolTipText_issue2804_3.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/GetToolTipText_issue2804_3.hx
@@ -1,0 +1,16 @@
+﻿package;
+class Issue2804_3 {
+	function foo() {
+		var v:AInt;
+		switch(v) {
+			case Six$(EntryPoint):
+			case _:
+		}
+	}
+}
+enum abstract AInt(Int) {
+	var Zero;
+	var First;
+	var Five = 5;
+	var Six;
+}

--- a/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/GetToolTipText_issue2804_4.hx
+++ b/Tests/External/Plugins/HaxeContext.Tests/Test Files/completion/GetToolTipText_issue2804_4.hx
@@ -1,0 +1,7 @@
+﻿package;
+class Issue2804_4 {
+	static public inline var first = 1;
+	function foo() {
+		first$(EntryPoint)
+	}
+}


### PR DESCRIPTION
![2804_Haxe_Tooltip_for_enum_abstract_value](https://user-images.githubusercontent.com/1700940/59783638-3a8e5900-92c9-11e9-9616-53ec6857032b.gif)
