### PR TITLE
[ScintillaControl][AS3] Added highlighting for '<' and '>'. fixes #2855

### DIFF
--- a/External/Plugins/AS3Context/Context.cs
+++ b/External/Plugins/AS3Context/Context.cs
@@ -1162,8 +1162,8 @@ namespace AS3Context
         /// </summary>
         protected virtual int BraceMatch(ScintillaControl sci, int position)
         {
+            if (sci.PositionIsOnComment(position, sci.Lexer)) return -1;
             var characters = ScintillaControl.Configuration.GetLanguage(sci.ConfigurationLanguage).characterclass.Characters;
-            var comment = sci.PositionIsOnComment(position, sci.Lexer);
             var sub = 0;
             var c = sci.CharAt(position);
             switch (c)
@@ -1173,18 +1173,17 @@ namespace AS3Context
                     while (position < length)
                     {
                         position++;
+                        if (sci.PositionIsOnComment(position)) continue;
                         var ch = sci.CharAt(position);
                         if (ch == ' ') continue;
-                        if (ch == '<')
-                        {
-                            if (comment == sci.PositionIsOnComment(position, sci.Lexer)) sub++;
-                        }
-                        else if (ch == '>' && comment == sci.PositionIsOnComment(position, sci.Lexer))
+                        if (ch == '<') sub++;
+                        else if (ch == '>')
                         {
                             sub--;
                             if (sub < 0) return position;
                         }
-                        else if (ch != '.' // Vector<Vector.<>>
+                        else if (ch != '.'
+                                 // Vector<Vector.<>>
                                  && !characters.Contains((char) ch))
                         {
                             return -1;
@@ -1195,18 +1194,17 @@ namespace AS3Context
                     while (position >= 0)
                     {
                         position--;
+                        if (sci.PositionIsOnComment(position)) continue;
                         var ch = sci.CharAt(position);
                         if (ch == ' ') continue;
-                        if (ch == '>')
-                        {
-                            if (comment == sci.PositionIsOnComment(position, sci.Lexer)) sub++;
-                        }
-                        else if (ch == '<' && comment == sci.PositionIsOnComment(position, sci.Lexer))
+                        if (ch == '>') sub++;
+                        else if (ch == '<')
                         {
                             sub--;
                             if (sub < 0) return position;
                         }
-                        else if (ch != '.' // Vector<Vector.<>>
+                        else if (ch != '.'
+                                 // Vector<Vector.<>>
                                  && !characters.Contains((char) ch))
                         {
                             return -1;

--- a/External/Plugins/AS3Context/Context.cs
+++ b/External/Plugins/AS3Context/Context.cs
@@ -1160,13 +1160,12 @@ namespace AS3Context
         /// <summary>
         /// Find the position of a matching '<' and '>' or INVALID_POSITION if no match.
         /// </summary>
-        protected virtual int BraceMatch(ScintillaControl sci, int position)
+        protected internal int BraceMatch(ScintillaControl sci, int position)
         {
-            if (sci.PositionIsOnComment(position, sci.Lexer)) return -1;
+            if (sci.PositionIsOnComment(position) || sci.PositionIsInString(position)) return -1;
             var characters = ScintillaControl.Configuration.GetLanguage(sci.ConfigurationLanguage).characterclass.Characters;
             var sub = 0;
-            var c = sci.CharAt(position);
-            switch (c)
+            switch (sci.CharAt(position))
             {
                 case '<':
                     var length = sci.TextLength;
@@ -1174,17 +1173,17 @@ namespace AS3Context
                     {
                         position++;
                         if (sci.PositionIsOnComment(position)) continue;
-                        var ch = sci.CharAt(position);
-                        if (ch == ' ') continue;
-                        if (ch == '<') sub++;
-                        else if (ch == '>')
+                        var c = sci.CharAt(position);
+                        if (c == ' ') continue;
+                        if (c == '<') sub++;
+                        else if (c == '>')
                         {
                             sub--;
                             if (sub < 0) return position;
                         }
-                        else if (ch != '.'
+                        else if (c != '.'
                                  // Vector<Vector.<>>
-                                 && !characters.Contains((char) ch))
+                                 && !characters.Contains((char) c))
                         {
                             return -1;
                         }
@@ -1195,17 +1194,17 @@ namespace AS3Context
                     {
                         position--;
                         if (sci.PositionIsOnComment(position)) continue;
-                        var ch = sci.CharAt(position);
-                        if (ch == ' ') continue;
-                        if (ch == '>') sub++;
-                        else if (ch == '<')
+                        var c = sci.CharAt(position);
+                        if (c == ' ') continue;
+                        if (c == '>') sub++;
+                        else if (c == '<')
                         {
                             sub--;
                             if (sub < 0) return position;
                         }
-                        else if (ch != '.'
+                        else if (c != '.'
                                  // Vector<Vector.<>>
-                                 && !characters.Contains((char) ch))
+                                 && !characters.Contains((char) c))
                         {
                             return -1;
                         }

--- a/External/Plugins/AS3Context/Properties/AssemblyInfo.cs
+++ b/External/Plugins/AS3Context/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using PluginCore;
 
 // Information about this assembly is defined by the following attributes. 
@@ -12,3 +13,5 @@ using PluginCore;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: AssemblyVersion("1.0.0.0")]
+
+[assembly: InternalsVisibleTo("AS3Context.Tests")]

--- a/External/Plugins/ASCompletion/Context/ASContext.cs
+++ b/External/Plugins/ASCompletion/Context/ASContext.cs
@@ -1504,6 +1504,16 @@ namespace ASCompletion.Context
         }
 
         #endregion
+
+        #region Custom behavior of Scintilla
+
+        /// <summary>
+        /// Provides the support for '<' and '>' matching
+        /// </summary>
+        public virtual void OnBraceMatch(ScintillaControl sci)
+        {
+        }
+        #endregion
     }
 
     #region Registered Context class

--- a/External/Plugins/ASCompletion/Context/IASContext.cs
+++ b/External/Plugins/ASCompletion/Context/IASContext.cs
@@ -423,5 +423,13 @@ namespace ASCompletion.Context
 
         #endregion
 
+        #region Custom behavior of Scintilla
+
+        /// <summary>
+        /// Provides the support for '<' and '>' matching
+        /// </summary>
+        void OnBraceMatch(ScintillaControl sci);
+
+        #endregion
     }
 }

--- a/External/Plugins/ASCompletion/PluginMain.cs
+++ b/External/Plugins/ASCompletion/PluginMain.cs
@@ -176,6 +176,7 @@ namespace ASCompletion
                     // caret position in editor
                     case EventType.UIRefresh:
                         if (!doc.IsEditable) return;
+                        ASContext.Context.OnBraceMatch(sci);
                         timerPosition.Enabled = false;
                         timerPosition.Enabled = true;
                         return;

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -2608,6 +2608,8 @@ namespace HaXeContext
                             sub--;
                             if (sub < 0) return position;
                         }
+                        // Map<Int$(EntryPoint), String>
+                        else if (c == ',') continue;
                         else if (c == '-'
                             && position < length
                             // $(EntryPoint)->
@@ -2658,6 +2660,8 @@ namespace HaXeContext
                             sub--;
                             if (sub < 0) return position;
                         }
+                        // Map<Int,$(EntryPoint) String>
+                        else if (c == ',') continue;
                         // $(EntryPoint)->
                         else if (c == '-' && sci.CharAt(position + 1) == '>') {}
                         // Array<Int->{v:Type}$(EntryPoint)>

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -2610,6 +2610,8 @@ namespace HaXeContext
                         }
                         // Map<Int$(EntryPoint), String>
                         else if (c == ',') continue;
+                        // Array<Int->$(EntryPoint)?String>
+                        else if (c == '?') continue;
                         else if (c == '-'
                             && position < length
                             // $(EntryPoint)->
@@ -2662,6 +2664,8 @@ namespace HaXeContext
                         }
                         // Map<Int,$(EntryPoint) String>
                         else if (c == ',') continue;
+                        // Array<Int->$(EntryPoint)?String>
+                        else if (c == '?') continue;
                         // $(EntryPoint)->
                         else if (c == '-' && sci.CharAt(position + 1) == '>') {}
                         // Array<Int->{v:Type}$(EntryPoint)>

--- a/FlashDevelop/MainForm.cs
+++ b/FlashDevelop/MainForm.cs
@@ -1323,7 +1323,7 @@ namespace FlashDevelop
                 BeginInvoke((MethodInvoker)(() => OnScintillaControlUpdateControl(sci)));
                 return;
             }
-            ITabbedDocument document = DocumentManager.FindDocument(sci);
+            var document = DocumentManager.FindDocument(sci);
             if (sci != null && document != null && document.IsEditable)
             {
                 string statusText = " " + TextHelper.GetString("Info.StatusText");
@@ -1338,7 +1338,7 @@ namespace FlashDevelop
             else StatusLabel.Text = " ";
             OnUpdateMainFormDialogTitle();
             ButtonManager.UpdateFlaggedButtons();
-            NotifyEvent ne = new NotifyEvent(EventType.UIRefresh);
+            var ne = new NotifyEvent(EventType.UIRefresh);
             EventManager.DispatchEvent(this, ne);
         }
 

--- a/PluginCore/ScintillaNet/ScintillaControl.cs
+++ b/PluginCore/ScintillaNet/ScintillaControl.cs
@@ -4165,32 +4165,25 @@ namespace ScintillaNet
         /// </summary>
         private void OnBraceMatch(ScintillaControl sci)
         {
-            if (isBraceMatching && sci.SelText.Length == 0)
+            if (!isBraceMatching || sci.SelText.Length != 0) return;
+            var position = CurrentPos - 1;
+            var character = (char)CharAt(position);
+            if (character != '{' && character != '}' && character != '(' && character != ')' && character != '[' && character != ']')
             {
-                int position = CurrentPos - 1;
-                char character = (char)CharAt(position);
-                if (character != '{' && character != '}' && character != '(' && character != ')' && character != '[' && character != ']')
+                position = CurrentPos;
+                character = (char)CharAt(position);
+            }
+            if (character == '{' || character == '}' || character == '(' || character == ')' || character == '[' || character == ']')
+            {
+                if (!PositionIsOnComment(position))
                 {
-                    position = CurrentPos;
-                    character = (char)CharAt(position);
-                }
-                if (character == '{' || character == '}' || character == '(' || character == ')' || character == '[' || character == ']')
-                {
-                    if (!PositionIsOnComment(position))
+                    var bracePosStart = position;
+                    var bracePosEnd = BraceMatch(position);
+                    if (bracePosEnd != -1) BraceHighlight(bracePosStart, bracePosEnd);
+                    if (useHighlightGuides)
                     {
-                        int bracePosStart = position;
-                        int bracePosEnd = BraceMatch(position);
-                        if (bracePosEnd != -1) BraceHighlight(bracePosStart, bracePosEnd);
-                        if (useHighlightGuides)
-                        {
-                            int line = LineFromPosition(position);
-                            HighlightGuide = GetLineIndentation(line);
-                        }
-                    }
-                    else
-                    {
-                        BraceHighlight(-1, -1);
-                        HighlightGuide = 0;
+                        var line = LineFromPosition(position);
+                        HighlightGuide = GetLineIndentation(line);
                     }
                 }
                 else
@@ -4198,6 +4191,11 @@ namespace ScintillaNet
                     BraceHighlight(-1, -1);
                     HighlightGuide = 0;
                 }
+            }
+            else
+            {
+                BraceHighlight(-1, -1);
+                HighlightGuide = 0;
             }
         }
 

--- a/Tests/External/Plugins/AS3Context.Tests/AS3Context.Tests.csproj
+++ b/Tests/External/Plugins/AS3Context.Tests/AS3Context.Tests.csproj
@@ -65,6 +65,16 @@
     <Compile Include="TestUtils\TestFile.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\External\Plugins\AS2Context\AS2Context.csproj">
+      <Project>{74AD0487-CEF9-43FE-9283-BC6F79539ADE}</Project>
+      <Name>AS2Context</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\External\Plugins\AS3Context\AS3Context.csproj">
+      <Project>{0263E5F6-D5B2-4118-B12E-87F9A74DE8AF}</Project>
+      <Name>AS3Context</Name>
+      <Private>False</Private>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\..\External\Plugins\ASCompletion\ASCompletion.csproj">
       <Project>{4EBF2653-9654-4E40-880E-0046B3D6210E}</Project>
       <Name>ASCompletion</Name>
@@ -83,8 +93,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <EmbeddedResource Include="Test Files\parser\IsImported_case1.as" />
     <None Include="packages.config" />
+    <EmbeddedResource Include="Test Files\parser\IsImported_case1.as" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/Tests/External/Plugins/HaxeContext.Tests/ContextTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/ContextTests.cs
@@ -453,5 +453,71 @@ namespace HaXeContext
             actualImports.Sort();
             Assert.AreEqual(expectedImports, actualImports.Items);
         }
+
+        static IEnumerable<TestCaseData> BraceMatchIssue2855
+        {
+            get
+            {
+                yield return new TestCaseData("a >>$(EntryPoint) b. Issue 2855. Case 1")
+                    .Returns(-1)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("a >$(EntryPoint)> b. Issue 2855. Case 2")
+                    .Returns(-1)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("a <<$(EntryPoint) b. Issue 2855. Case 3")
+                    .Returns(-1)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("a <$(EntryPoint)< b. Issue 2855. Case 4")
+                    .Returns(-1)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("new Array<Int$(EntryPoint)>. Issue 2855. Case 5")
+                    .Returns("new Array".Length)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("new Array<Array<Int>$(EntryPoint)>. Issue 2855. Case 6")
+                    .Returns("new Array".Length)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("new Array<Array<Int->Int$(EntryPoint)>>. Issue 2855. Case 7")
+                    .Returns("new Array<Array".Length)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("new Array<Array<{x:Array<Int>}->Int$(EntryPoint)>>. Issue 2855. Case 8")
+                    .Returns("new Array<Array".Length)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("<\"<$(EntryPoint)>\">. Issue 2855. Case 9")
+                    .Returns(-1)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("/*<$(EntryPoint)>*/. Issue 2855. Case 10")
+                    .Returns(-1)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("//<$(EntryPoint)>. Issue 2855. Case 11")
+                    .Returns(-1)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("Array<Int->$(EntryPoint)>. Issue 2855. Case 12")
+                    .Returns("Array".Length)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("Array<((Int->Int)->String)$(EntryPoint)>. Issue 2855. Case 13")
+                    .Returns("Array".Length)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("var v = 1;)$(EntryPoint)>. Issue 2855. Case 14")
+                    .Returns(-1)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("var v = 1;Int->}$(EntryPoint)>. Issue 2855. Case 15")
+                    .Returns(-1)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("<$(EntryPoint){Int-. Issue 2855. Case 16")
+                    .Returns(-1)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("<$(EntryPoint){Int->;. Issue 2855. Case 17")
+                    .Returns(-1)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+            }
+        }
+
+        [Test, TestCaseSource(nameof(BraceMatchIssue2855))]
+        public int BraceMatch(string sourceText)
+        {
+            SetSrc(sci, sourceText);
+            var result = ((Context)ASContext.GetLanguageContext("haxe")).BraceMatch(sci, sci.CurrentPos);
+            return result;
+        }
     }
 }

--- a/Tests/External/Plugins/HaxeContext.Tests/ContextTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/ContextTests.cs
@@ -509,6 +509,12 @@ namespace HaXeContext
                 yield return new TestCaseData("<$(EntryPoint){Int->;. Issue 2855. Case 17")
                     .Returns(-1)
                     .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("new Map<Int, Int$(EntryPoint)>. Issue 2855. Case 18")
+                    .Returns("new Map".Length)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("new Map$(EntryPoint)<Int, Int>. Issue 2855. Case 19")
+                    .Returns("new Map<Int, Int".Length)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
             }
         }
 

--- a/Tests/External/Plugins/HaxeContext.Tests/ContextTests.cs
+++ b/Tests/External/Plugins/HaxeContext.Tests/ContextTests.cs
@@ -515,6 +515,12 @@ namespace HaXeContext
                 yield return new TestCaseData("new Map$(EntryPoint)<Int, Int>. Issue 2855. Case 19")
                     .Returns("new Map<Int, Int".Length)
                     .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("new Array$(EntryPoint)<Int->?String>. Issue 2855. Case 20")
+                    .Returns("new Array<Int->?String".Length)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
+                yield return new TestCaseData("new Array<Int->?String$(EntryPoint)>. Issue 2855. Case 21")
+                    .Returns("new Array".Length)
+                    .SetDescription("https://github.com/fdorg/flashdevelop/issues/2855");
             }
         }
 


### PR DESCRIPTION
- [x] `ActionScript3`
- [x] `Haxe3`
- [x] `Haxe4`
- [x] `Tests`

![2855_Highlight_for_gen_brace](https://user-images.githubusercontent.com/1700940/66197484-29fcc580-e6a3-11e9-9f52-0dd928880e7b.gif)