### PR TITLE
fix "Locate Active Document" in project tree view 

### DIFF
--- a/External/Plugins/ProjectManager/Controls/TreeView/ProjectTreeView.cs
+++ b/External/Plugins/ProjectManager/Controls/TreeView/ProjectTreeView.cs
@@ -32,7 +32,7 @@ namespace ProjectManager.Controls.TreeView
         {
             Instance = this;
             MultiSelect = true;
-            nodeMap = new Dictionary<string, GenericNode>();
+            nodeMap = new Dictionary<string, GenericNode>(StringComparison.OrdinalIgnoreCase);
             ShowNodeToolTips = true;
 
             EventManager.AddEventHandler(this, EventType.ApplyTheme);


### PR DESCRIPTION
Fix "Locate Active Document" in project tree view when paths differ by case (i.e. "c:\\" vs "C:\\")

In my case "Locate Active Document" was not working in hxml project with absolute paths starting with lower case "c:\". 