### PR TITLE
Fixing progress bars not appearing

### DIFF
--- a/External/Plugins/CodeRefactor/Controls/ProgressDialog.cs
+++ b/External/Plugins/CodeRefactor/Controls/ProgressDialog.cs
@@ -11,7 +11,7 @@ namespace CodeRefactor.Controls
     {
         private Label labelStatus;
         private Button closeButton;
-        private ProgressBar progressBar;
+        private ProgressBarEx progressBar;
 
         public ProgressDialog()
         {

--- a/FlashDevelop/Dialogs/FRInFilesDialog.cs
+++ b/FlashDevelop/Dialogs/FRInFilesDialog.cs
@@ -30,7 +30,7 @@ namespace FlashDevelop.Dialogs
         private System.Windows.Forms.ColumnHeader fileHeader;
         private System.Windows.Forms.ColumnHeader pathHeader;
         private System.Windows.Forms.ColumnHeader replacedHeader;
-        private System.Windows.Forms.ProgressBar progressBar;
+        private System.Windows.Forms.ProgressBarEx progressBar;
         private System.Windows.Forms.GroupBox optionsGroupBox;
         private System.Windows.Forms.ComboBox folderComboBox;
         private System.Windows.Forms.ComboBox extensionComboBox;


### PR DESCRIPTION
Progress bars in the Find and Replace and the Find All References dialogs were not visible in the recent versions of FlashDevelop. Fixed that by making their declaration type the same as the initialization type, so they behave as a ProgressBarEx.