### PR TITLE
support haxe `final` keyword

### DIFF
--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -170,7 +170,7 @@ namespace HaXeContext
             features.importKey = "import";
             features.importKeyAlt = "using";
             features.varKey = "var";
-            //features.finalKey = "final";
+            features.finalKey = "final";
             features.overrideKey = "override";
             features.functionKey = "function";
             features.staticKey = "static";

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -170,6 +170,7 @@ namespace HaXeContext
             features.importKey = "import";
             features.importKeyAlt = "using";
             features.varKey = "var";
+            //features.finalKey = "final";
             features.overrideKey = "override";
             features.functionKey = "function";
             features.staticKey = "static";
@@ -184,11 +185,11 @@ namespace HaXeContext
             features.ConstructorKey = "new";
             features.typesPreKeys = new[] {features.importKey, features.importKeyAlt, features.ConstructorKey, features.ExtendsKey, features.ImplementsKey};
             features.codeKeywords = new[] {
-                "var", "function", "new", "cast", "return", "break",
+                "var", "final", "function", "new", "cast", "return", "break",
                 "continue", "if", "else", "for", "in", "while", "do", "switch", "case", "default", "$type",
                 "null", "untyped", "true", "false", "try", "catch", "throw", "trace", "macro"
             };
-            features.declKeywords = new[] {features.varKey, features.functionKey};
+            features.declKeywords = new[] {features.varKey, features.functionKey, features.finalKey};
             features.accessKeywords = new[] {features.intrinsicKey, features.inlineKey, "dynamic", "macro", features.overrideKey, features.publicKey, features.privateKey, features.staticKey};
             features.typesKeywords = new[] {features.importKey, features.importKeyAlt, "class", "interface", "typedef", "enum", "abstract" };
             features.ArithmeticOperators = new HashSet<char> {'+', '-', '*', '/', '%'};

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -384,7 +384,7 @@ namespace HaXeContext
                 ? new[] {'!'}
                 : Array.Empty<char>();
 
-            if(version >= "4")
+            if (version >= "4")
             {
                 features.finalKey = "final";
 

--- a/External/Plugins/HaXeContext/Context.cs
+++ b/External/Plugins/HaXeContext/Context.cs
@@ -170,7 +170,6 @@ namespace HaXeContext
             features.importKey = "import";
             features.importKeyAlt = "using";
             features.varKey = "var";
-            features.finalKey = "final";
             features.overrideKey = "override";
             features.functionKey = "function";
             features.staticKey = "static";
@@ -185,11 +184,11 @@ namespace HaXeContext
             features.ConstructorKey = "new";
             features.typesPreKeys = new[] {features.importKey, features.importKeyAlt, features.ConstructorKey, features.ExtendsKey, features.ImplementsKey};
             features.codeKeywords = new[] {
-                "var", "final", "function", "new", "cast", "return", "break",
+                "var", "function", "new", "cast", "return", "break",
                 "continue", "if", "else", "for", "in", "while", "do", "switch", "case", "default", "$type",
                 "null", "untyped", "true", "false", "try", "catch", "throw", "trace", "macro"
             };
-            features.declKeywords = new[] {features.varKey, features.functionKey, features.finalKey};
+            features.declKeywords = new[] {features.varKey, features.functionKey};
             features.accessKeywords = new[] {features.intrinsicKey, features.inlineKey, "dynamic", "macro", features.overrideKey, features.publicKey, features.privateKey, features.staticKey};
             features.typesKeywords = new[] {features.importKey, features.importKeyAlt, "class", "interface", "typedef", "enum", "abstract" };
             features.ArithmeticOperators = new HashSet<char> {'+', '-', '*', '/', '%'};
@@ -379,9 +378,34 @@ namespace HaXeContext
 
             LoadMetadata();
 
-            features.SpecialPostfixOperators = GetCurrentSDKVersion() >= "3.3.0"
+            var version = GetCurrentSDKVersion();
+
+            features.SpecialPostfixOperators = version >= "3.3.0"
                 ? new[] {'!'}
                 : Array.Empty<char>();
+
+            if(version >= "4")
+            {
+                features.finalKey = "final";
+
+                if (Array.IndexOf(features.codeKeywords, "final") < 0)
+                {
+                    Array.Resize(ref features.codeKeywords, features.codeKeywords.Length + 1);
+                    features.codeKeywords[features.codeKeywords.Length - 1] = "final";
+                }
+
+                if (Array.IndexOf(features.declKeywords, "final") < 0)
+                {
+                    Array.Resize(ref features.declKeywords, features.declKeywords.Length + 1);
+                    features.declKeywords[features.declKeywords.Length - 1] = "final";
+                }
+            }
+            else
+            {
+                features.finalKey = null;
+                features.codeKeywords = features.codeKeywords.Where(w => w != "final").ToArray();
+                features.declKeywords = features.declKeywords.Where(w => w != "final").ToArray();
+            }
 
             UseGenericsShortNotationChange();
         }

--- a/External/Plugins/HaXeContext/Model/FileParser.cs
+++ b/External/Plugins/HaXeContext/Model/FileParser.cs
@@ -1678,7 +1678,7 @@ namespace HaXeContext.Model
                 if (dotIndex > 0) token = token.Substring(dotIndex + 1);
 
                 // members
-                if (token == "var")
+                if (token == "var" || token == "final")
                 {
                     foundKeyword = FlagType.Variable;
                 }

--- a/FlashDevelop/Bin/Debug/Settings/Languages/Haxe.xml
+++ b/FlashDevelop/Bin/Debug/Settings/Languages/Haxe.xml
@@ -3,7 +3,7 @@
 	<keyword-classes>
 		<keyword-class name="haxe-primary-keywords">
 			abstract break case catch class continue default do else enum extends for in function if implements import
-			interface  new package return switch throw try typedef using var while $type 
+			interface  new package return switch throw try typedef using var final while $type 
 		</keyword-class>
 		<keyword-class name="haxe-secondary-keywords">
 			null true false


### PR DESCRIPTION
Support haxe `final` keyword for variable completion and coloring. 
Resolves #2775 and partially resolves #1925 (does not support `final` as method modifier.)